### PR TITLE
chore: switch upstream to azure-ai-docs-pr with new foundry/ hierarchy

### DIFF
--- a/.github/workflows/sync-and-convert.yml
+++ b/.github/workflows/sync-and-convert.yml
@@ -116,7 +116,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "docs: sync and convert from upstream
 
-          Automated daily sync from MicrosoftDocs/azure-ai-docs
+          Automated daily sync from MicrosoftDocs/azure-ai-docs-pr
 
           Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
           git push

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,10 +1,10 @@
 # Attribution
 
-This project contains documentation derived from [MicrosoftDocs/azure-ai-docs](https://github.com/MicrosoftDocs/azure-ai-docs), which is licensed under the [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/) license.
+This project contains documentation derived from [MicrosoftDocs/azure-ai-docs-pr](https://github.com/MicrosoftDocs/azure-ai-docs-pr), which is licensed under the [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/) license.
 
 ## Original Source
 
-- **Repository**: https://github.com/MicrosoftDocs/azure-ai-docs
+- **Repository**: https://github.com/MicrosoftDocs/azure-ai-docs-pr
 - **License**: CC BY 4.0
 - **Copyright**: © Microsoft Corporation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A FastMCP server that provides searchable Microsoft Foundry documentation for AI
 
 ## Overview
 
-This project extracts ~250 Microsoft Foundry docs from [MicrosoftDocs/azure-ai-docs](https://github.com/MicrosoftDocs/azure-ai-docs), converts them from Microsoft Learn markdown to Mintlify MDX format, and serves them via a [FastMCP](https://github.com/jlowin/fastmcp) server.
+This project extracts ~250 Microsoft Foundry docs from [MicrosoftDocs/azure-ai-docs-pr](https://github.com/MicrosoftDocs/azure-ai-docs-pr), converts them from Microsoft Learn markdown to Mintlify MDX format, and serves them via a [FastMCP](https://github.com/jlowin/fastmcp) server.
 
 ## Quick Start
 
@@ -130,4 +130,4 @@ Default regression gate:
 
 ## Attribution
 
-Documentation content is derived from Microsoft's azure-ai-docs repository under CC BY 4.0. See [ATTRIBUTION.md](ATTRIBUTION.md).
+Documentation content is derived from Microsoft's azure-ai-docs-pr repository under CC BY 4.0. See [ATTRIBUTION.md](ATTRIBUTION.md).

--- a/docs.json
+++ b/docs.json
@@ -623,6 +623,6 @@
     ]
   },
   "footerSocials": {
-    "github": "https://github.com/MicrosoftDocs/azure-ai-docs"
+    "github": "https://github.com/MicrosoftDocs/azure-ai-docs-pr"
   }
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -523,6 +523,6 @@
     ]
   },
   "footerSocials": {
-    "github": "https://github.com/MicrosoftDocs/azure-ai-docs"
+    "github": "https://github.com/MicrosoftDocs/azure-ai-docs-pr"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "repo": "MicrosoftDocs/azure-ai-docs",
+  "repo": "MicrosoftDocs/azure-ai-docs-pr",
   "root_toc": "articles/ai-foundry/default/toc.yml",
   "stats": {
     "total_docs": 291,

--- a/scripts/build_navigation.py
+++ b/scripts/build_navigation.py
@@ -101,7 +101,7 @@ def main():
             ]
         },
         "footerSocials": {
-            "github": "https://github.com/MicrosoftDocs/azure-ai-docs"
+            "github": "https://github.com/MicrosoftDocs/azure-ai-docs-pr"
         }
     }
 

--- a/scripts/download_docs.py
+++ b/scripts/download_docs.py
@@ -14,7 +14,7 @@ from pathlib import Path, PurePosixPath
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 REPO_OWNER = "MicrosoftDocs"
-REPO_NAME = "azure-ai-docs"
+REPO_NAME = "azure-ai-docs-pr"
 RAW_BASE = f"https://raw.githubusercontent.com/{REPO_OWNER}/{REPO_NAME}/main"
 DOCS_DIR = Path("docs")
 RAW_DIR = Path("raw_docs")  # raw downloaded files before conversion
@@ -30,8 +30,12 @@ def download_file(source_path: str, dest_path: Path) -> bool:
     dest_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
+        cmd = ["curl", "-sL", "-o", str(dest_path), "-w", "%{http_code}", url]
+        gh_token = os.environ.get("GH_TOKEN")
+        if gh_token:
+            cmd[1:1] = ["-H", f"Authorization: token {gh_token}"]
         result = subprocess.run(
-            ["curl", "-sL", "-o", str(dest_path), "-w", "%{http_code}", url],
+            cmd,
             capture_output=True, text=True, timeout=30
         )
         http_code = result.stdout.strip()

--- a/scripts/extract_manifest.py
+++ b/scripts/extract_manifest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Extract manifest from Microsoft Foundry TOC files.
 
-Parses the root toc.yml and all sub-TOC YAML files from MicrosoftDocs/azure-ai-docs,
+Parses the root toc.yml and all sub-TOC YAML files from MicrosoftDocs/azure-ai-docs-pr,
 resolves paths, deduplicates, and outputs manifest.json.
 """
 
@@ -15,8 +15,8 @@ from urllib.parse import urlparse
 import yaml
 
 REPO_OWNER = "MicrosoftDocs"
-REPO_NAME = "azure-ai-docs"
-ROOT_TOC_PATH = "articles/ai-foundry/default/toc.yml"
+REPO_NAME = "azure-ai-docs-pr"
+ROOT_TOC_PATH = "articles/foundry/toc.yml"
 
 # Section name → output directory mapping
 SECTION_SLUG_MAP = {
@@ -169,7 +169,8 @@ def scan_doc_for_images(source_path: str) -> list[str]:
         img_path = match.group(1)
         if img_path.startswith('/azure/'):
             # Absolute MS Learn path — convert to repo-relative articles/ path
-            images.append('articles' + img_path)
+            # /azure/foundry/media/img.png → articles/foundry/media/img.png
+            images.append('articles/' + img_path[len('/azure/'):])
         else:
             resolved = resolve_path(img_path, doc_dir)
             images.append(resolved)
@@ -179,7 +180,7 @@ def scan_doc_for_images(source_path: str) -> list[str]:
         if img_path.startswith('http') or img_path.startswith('~/'):
             continue
         if img_path.startswith('/azure/'):
-            images.append('articles' + img_path)
+            images.append('articles/' + img_path[len('/azure/'):])
         else:
             resolved = resolve_path(img_path, doc_dir)
             images.append(resolved)


### PR DESCRIPTION
## Changes

- Switch source repo from `azure-ai-docs` to `azure-ai-docs-pr` (private, synced 4x/day by MS Learn)
- Update `ROOT_TOC_PATH` from `articles/ai-foundry/default/toc.yml` to `articles/foundry/toc.yml`
- Add `Authorization` header to curl in `download_docs.py` for private repo access
- Fix `/azure/` absolute image path conversion (was producing `articles/azure/...` instead of `articles/...`)
- Update all documentation references (README, ATTRIBUTION, build_navigation, etc.)