### PR TITLE
fix: improve daily-doc-updater and daily-doc-healer workflows

### DIFF
--- a/.github/workflows/daily-doc-healer.md
+++ b/.github/workflows/daily-doc-healer.md
@@ -64,12 +64,12 @@ timeout-minutes: 45
 
 # Daily Documentation Healer
 
-You are a self-healing documentation agent that acts as a companion to the Daily Documentation Updater. Your mission is to detect documentation issues that the updater missed, fix them, and improve the updater's rules so the same gaps don't recur.
+You are a self-healing documentation agent that acts as a companion to the Daily Documentation Updater. Your mission is to detect documentation issues from **multiple sources** — internal issues, community discussions, public docs contributions, and code samples feedback — fix them, and improve the updater's rules so the same gaps don't recur.
 
 ## Your Mission
 
-1. **Detect documentation gaps** by finding recently closed documentation issues (last 7 days) that the updater did not address.
-2. **Cross-reference** those issues against recent code changes to confirm they represent real gaps.
+1. **Scan multiple signal sources** for documentation gaps the updater missed.
+2. **Cross-reference** those signals against docs-vnext content to confirm real gaps.
 3. **Fix confirmed gaps** by proposing documentation updates via a pull request targeting `docs-vnext/`.
 4. **Improve the updater** by identifying root causes and suggesting rule improvements.
 
@@ -80,30 +80,81 @@ You are a self-healing documentation agent that acts as a companion to the Daily
 - **Canonical docs**: `docs/` (do NOT modify)
 - **Updater workflow**: `.github/workflows/daily-doc-updater.md`
 
-## Step 1: Identify Recently Closed Documentation Issues
+## Step 1: Multi-Source Documentation Gap Scan
 
-Search for issues labeled `documentation` closed in the last 7 days:
+Scan four signal sources for documentation issues. Use cache memory to avoid re-processing.
+
+```bash
+cat /tmp/gh-aw/cache-memory/healer-state.txt 2>/dev/null || echo "No cached state — first run"
+```
+
+### 1A: Internal Issues (foundry-docs)
+
+Search for recently closed documentation issues in this repository:
 
 ```
 repo:${{ github.repository }} is:issue is:closed label:documentation closed:>=YYYY-MM-DD
 ```
 
+Also search for open `[community]` issues created by the discussions monitor:
+
+```
+repo:${{ github.repository }} is:issue is:open in:title "[community]"
+```
+
 For each issue found:
-- Record the issue number, title, body, and closing date.
-- Check whether a updater-created PR (label `documentation automation`, title prefix `[docs-vnext]`) was merged that addresses the issue.
-- If such a PR exists, skip this issue.
+- Record the issue number, title, body
+- Check whether an updater-created PR (title prefix `[docs-vnext]`) was merged that addresses it
+- If addressed, skip
 
-If no unaddressed documentation issues exist, call `noop` and stop.
+### 1B: Community Discussions (microsoft-foundry/discussions)
 
-## Step 2: Cross-Reference with Recent Code Changes
+Search for recent discussions in `microsoft-foundry/discussions` with documentation-relevant labels. Use GitHub tools to fetch the last 20 discussions and filter for labels:
 
-For each issue NOT addressed by the updater:
+- `documentation` — explicit docs feedback
+- `python-sdk`, `dotnet-sdk`, `javascript-sdk`, `java-sdk` — SDK issues that may indicate docs errors
+- `bug` — bugs that may stem from unclear documentation
+- `mcp`, `ai-agents`, `observability` — topic areas we document
 
-1. Review commits from the past 7 days using `list_commits` and `get_commit`.
-2. Determine if code changes relate to the issue's subject matter.
-3. Read referenced docs in `docs-vnext/` to verify the gap still exists.
+Skip discussion numbers already in the cache.
 
-Only proceed with confirmed gaps.
+### 1C: Public Docs Issues (MicrosoftDocs/azure-ai-docs)
+
+Search for open issues in the public docs repo that mention Foundry:
+
+```
+repo:MicrosoftDocs/azure-ai-docs is:issue is:open foundry OR ai-foundry OR ai-projects OR "hosted agent"
+```
+
+These are external contributor reports about learn.microsoft.com content — the same content we sync from upstream.
+
+### 1D: Samples Repo Issues (microsoft-foundry/foundry-samples)
+
+Search for issues in the samples repo that mention documentation problems:
+
+```
+repo:microsoft-foundry/foundry-samples is:issue is:open documentation OR docs OR "learn.microsoft.com" OR "documentation gap"
+```
+
+These issues surface real user confusion that often stems from incomplete docs. Examples include missing health endpoint documentation, RBAC permission gaps, and broken tutorial links.
+
+## Step 2: Cross-Reference Against docs-vnext
+
+For each signal found across all sources:
+
+1. Identify the **topic area** (agents, hosted agents, SDK, setup, models, etc.)
+2. Use the `foundry-docs` MCP server: `search_docs("topic")` to find related pages
+3. Read the relevant docs-vnext file to verify the gap exists
+4. Classify the signal:
+
+| Classification | Action |
+|---------------|--------|
+| **Confirmed gap** — docs-vnext is missing this info | Fix it |
+| **Inaccurate docs** — docs-vnext has wrong info | Correct it |
+| **Already documented** — docs-vnext covers this | Skip |
+| **Out of scope** — not a docs-vnext topic | Skip |
+
+Only proceed with confirmed gaps and inaccuracies.
 
 ## Step 3: Read Updater Logic
 
@@ -125,32 +176,51 @@ Follow Mintlify MDX format strictly.
 
 For each confirmed gap:
 
-1. Determine the correct file in `docs-vnext/` to update.
-2. Edit the file using the edit tool.
-3. Follow Mintlify MDX conventions (callouts, code groups, frontmatter).
+1. Determine the correct file in `docs-vnext/` to update
+2. Edit the file using the edit tool
+3. Follow Mintlify MDX conventions (callouts, code groups, frontmatter)
 
 Create a pull request with `create_pull_request`:
 
-**PR Title**: `[docs-vnext] Self-healing documentation fixes from issue analysis - [date]`
+**PR Title**: `[docs-vnext] Self-healing fixes from multi-source analysis - [date]`
+
+Include in the PR description:
+- Which sources surfaced the gaps (internal issues, discussions, public docs, samples)
+- Links to the original issues/discussions
+- Summary of each fix
 
 ## Step 6: Propose Updater Improvements
 
 Create an issue with improvement suggestions if you identified a systemic pattern:
 - What class of documentation gaps the updater is missing
 - Which specific step in the updater failed
+- Which external source surfaced the gap (so we can prioritize monitoring)
 - Concrete changes to prevent recurrence
 
-## Step 7: No-Op Handling
+## Step 7: Update Cache and No-Op Handling
 
-If no gaps found, call `noop`:
+Update cache with processed signal IDs:
+
+```bash
+cat > /tmp/gh-aw/cache-memory/healer-state.txt << EOF
+last_run=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+internal_issues=COMMA_SEPARATED_IDS
+discussions=COMMA_SEPARATED_IDS
+public_docs_issues=COMMA_SEPARATED_IDS
+samples_issues=COMMA_SEPARATED_IDS
+EOF
+```
+
+If no gaps found across all sources, call `noop`:
 
 ```json
-{"noop": {"message": "No documentation gaps found. Analyzed N issues and M recent commits."}}
+{"noop": {"message": "No documentation gaps found. Scanned: N internal issues, M discussions, P public docs issues, Q samples issues."}}
 ```
 
 ## Guidelines
 
 - **Target `docs-vnext/` ONLY** — never modify `docs/`
 - **High certainty required**: Only propose fixes you are confident about
-- **Be minimal**: Fix only confirmed gaps
-- **Exit cleanly**: Always call exactly one safe-output tool
+- **Prioritize by source**: samples repo issues > community `documentation` discussions > public docs issues > internal issues
+- **Be minimal**: Fix only confirmed gaps, don't over-expand scope
+- **Exit cleanly**: Always call exactly one safe-output tool (create-pull-request, create-issue, or noop)

--- a/.github/workflows/daily-doc-updater.lock.yml
+++ b/.github/workflows/daily-doc-updater.lock.yml
@@ -30,7 +30,7 @@
 #     - shared/mood.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"cee01f6a98a91918aea5a23b380378c89c68f9acc20ad20f0e727dcf439ad956","compiler_version":"v0.50.7"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"d4adee1610eed34eb3ebf274c6b1f2d8662b492270d103a0ee81a30307e1f80d","compiler_version":"v0.50.7"}
 
 name: "Daily Documentation Updater"
 "on":

--- a/.github/workflows/daily-doc-updater.md
+++ b/.github/workflows/daily-doc-updater.md
@@ -31,6 +31,7 @@ safe-outputs:
     reviewers: [copilot]
     draft: false
     auto-merge: true
+  noop:
 
 tools:
   cache-memory: true
@@ -77,9 +78,33 @@ Scan the repository for merged pull requests and code changes from the last 24 h
 - **Canonical docs**: `docs/` (synced from upstream, do NOT modify)
 - **Source code**: `foundry_docs_mcp/` (FastMCP server), `scripts/` (pipeline scripts)
 
-## Task Steps
+## Step 1: Read Documentation Guidelines
 
-### 1. Scan Recent Activity (Last 24 Hours)
+**IMPORTANT**: Before making any changes, read the documentation guidelines:
+
+```bash
+cat .github/instructions/documentation.instructions.md
+```
+
+Key rules:
+- Use Mintlify MDX format (`.mdx` files)
+- Use Mintlify callouts (`<Note>`, `<Warning>`, `<Tip>`, `<Info>`)
+- Use `{/* comments */}` not `<!-- comments -->`
+- Use `<br />` not `<br>`
+- Follow Diátaxis framework for document types
+- Use `<CodeGroup>` for multi-language examples
+
+For specific component syntax questions, search the `mintlify-docs` MCP server (e.g., search "callout components", "CodeGroup", "frontmatter").
+
+## Step 2: Search Existing Docs via foundry-docs MCP
+
+Use the `foundry-docs` MCP server to understand existing documentation before making changes:
+
+- `search_docs("topic")` — find related pages to avoid duplication
+- `get_doc("path/to/page")` — read current content before editing
+- `list_sections()` — understand the documentation structure
+
+## Step 3: Scan Recent Activity (Last 24 Hours)
 
 Use GitHub tools to:
 - Search for pull requests merged in the last 24 hours: `repo:${{ github.repository }} is:pr is:merged merged:>=YYYY-MM-DD`
@@ -87,7 +112,7 @@ Use GitHub tools to:
 - Review commits from the last 24 hours using `list_commits`
 - Get detailed commit information using `get_commit` for significant changes
 
-### 2. Analyze Changes
+## Step 4: Analyze Changes for Documentation Impact
 
 For each merged PR and commit, analyze:
 
@@ -97,53 +122,7 @@ For each merged PR and commit, analyze:
 - **Upstream Sync Changes**: New/updated docs from azure-ai-docs-pr sync
 - **Breaking Changes**: Any changes affecting users
 
-### 3. Verify MDX Syntax via Mintlify MCP
-
-**IMPORTANT**: Before making any MDX edits, use the Mintlify reference resources:
-
-**Step 1** — Fetch the Mintlify skill.md for comprehensive writing rules:
-```
-web-fetch: https://mintlify.com/docs/skill.md
-```
-This gives you the complete component decision table, formatting rules, and conventions.
-
-**Step 2** — For specific component questions, search the `mintlify-docs` MCP server:
-- Search "callout components" to confirm `<Note>`, `<Warning>`, `<Tip>` syntax
-- Search "CodeGroup" to confirm multi-language code block syntax
-- Search "frontmatter" to confirm required page metadata fields
-
-**Step 3** — If you need to discover all available Mintlify doc pages:
-```
-web-fetch: https://mintlify.com/docs/llms.txt
-```
-
-Never assume MDX component syntax — always verify via skill.md or MCP search.
-
-### 4. Search Existing Docs via foundry-docs MCP
-
-Use the `foundry-docs` MCP server to understand existing documentation before making changes:
-
-- `search_docs("topic")` — find related pages to avoid duplication
-- `get_doc("path/to/page")` — read current content before editing
-- `list_sections()` — understand the documentation structure
-
-### 5. Review Documentation Instructions
-
-**IMPORTANT**: Before making any changes, read the documentation guidelines:
-
-```bash
-cat .github/instructions/documentation.instructions.md
-```
-
-Key points:
-- Use Mintlify MDX format (`.mdx` files)
-- Use Mintlify callouts (`<Note>`, `<Warning>`, `<Tip>`, `<Info>`)
-- Use `{/* comments */}` not `<!-- comments -->`
-- Use `<br />` not `<br>`
-- Follow Diátaxis framework for document types
-- Use `<CodeGroup>` for multi-language examples
-
-### 4. Identify Documentation Gaps
+## Step 5: Identify Gaps and Update Documentation
 
 Review documentation in `docs-vnext/`:
 
@@ -156,24 +135,31 @@ Check if:
 - Upstream sync brought new content that needs enhancement
 - Existing docs reference outdated APIs or configurations
 
-### 5. Update Documentation
+For each documentation gap, determine the correct file based on topic:
 
-For each documentation gap:
+| Code Change Area | docs-vnext Section |
+|-----------------|-------------------|
+| MCP server changes | `docs-vnext/api-sdk/` |
+| Agent development | `docs-vnext/agents/development/` |
+| Agent tools & integration | `docs-vnext/agents/tools/` |
+| Setup & configuration | `docs-vnext/setup/` |
+| Model capabilities | `docs-vnext/models/capabilities/` |
+| Model fine-tuning | `docs-vnext/models/fine-tuning/` |
+| Observability, evaluation, tracing | `docs-vnext/observability/` |
+| Security & governance | `docs-vnext/security/` |
+| Guardrails & controls | `docs-vnext/guardrails/` |
+| Best practices | `docs-vnext/best-practices/` |
+| Responsible AI | `docs-vnext/responsible-ai/` |
+| Reference (glossary, etc.) | `docs-vnext/reference/` |
+| Overview / What is Foundry | `docs-vnext/overview/` |
 
-1. **Determine the correct file** based on topic:
-   - MCP server changes → `docs-vnext/api-sdk/`
-   - Agent development → `docs-vnext/agents/development/`
-   - Agent tools → `docs-vnext/agents/tools/`
-   - Setup/config → `docs-vnext/setup/`
-   - Model capabilities → `docs-vnext/models/capabilities/`
+Then:
+1. Read the target file with `get_doc()` or `cat`
+2. Edit the file using the edit tool
+3. Follow Mintlify MDX conventions from the documentation instructions
+4. Maintain consistency with existing documentation style
 
-2. **Follow Mintlify MDX conventions** from the documentation instructions
-
-3. **Update the appropriate file(s)** using the edit tool
-
-4. **Maintain consistency** with existing documentation style
-
-### 6. Create Pull Request
+## Step 6: Create Pull Request
 
 If you made documentation changes:
 
@@ -185,10 +171,10 @@ If you made documentation changes:
 
 **PR Title Format**: `[docs-vnext] Update documentation for changes from [date]`
 
-### 7. Handle Edge Cases
+## Step 7: Handle Edge Cases
 
-- **No recent changes**: Exit gracefully without creating a PR
-- **Already documented**: Exit gracefully
+- **No recent changes**: Call `noop` with a message summarizing what was checked
+- **Already documented**: Call `noop` — no PR needed
 - **Unclear features**: Note in PR description for human review
 
 ## Guidelines


### PR DESCRIPTION
## Summary

Two workflow improvements based on the review session.

### daily-doc-updater.md
- Fixed duplicate step numbers (was 1,2,3,4,5,4,5,6,7 → now clean 1-7)
- Reordered: read guidelines and search existing docs **before** analyzing changes
- Removed 20-line web-fetch block for Mintlify skill.md — uses the already-imported MCP server instead
- Added `noop:` safe-output for clean exit when no changes needed
- Expanded docs-vnext section mapping from 5 to 13 directories (added observability, security, fine-tuning, guardrails, best-practices, responsible-ai, reference, overview)

### daily-doc-healer.md
- Expanded from single-source to **4-source** documentation gap scan:
  - 1A: Internal foundry-docs issues (existing)
  - 1B: `microsoft-foundry/discussions` — community discussions labeled documentation/bug/SDK (NEW)
  - 1C: `MicrosoftDocs/azure-ai-docs` — public contributor issues about Foundry docs (NEW)
  - 1D: `microsoft-foundry/foundry-samples` — sample repo issues mentioning doc gaps (NEW, 14 currently open)
- Added per-source cache tracking to avoid re-processing
- Added source prioritization: samples > discussions > public docs > internal

Both compile with `gh aw compile` — 0 errors.