### PR TITLE
docs: Classic vs New developer guide, terminology mapping, and SDK comparison

### DIFF
--- a/docs-vnext/api-sdk/sdk-classic-vs-new.mdx
+++ b/docs-vnext/api-sdk/sdk-classic-vs-new.mdx
@@ -1,0 +1,177 @@
+---
+title: "SDK comparison: Classic vs. New"
+description: "Side-by-side comparison of classic and new SDK patterns in Microsoft Foundry, with code examples for common migration scenarios."
+---
+
+{/* Reference page: neutral, technical comparisons of classic and new SDK patterns */}
+
+# SDK comparison: Classic vs. New
+
+Microsoft Foundry's SDK ecosystem evolved alongside the platform's shift from model-centric inference to agent-centric workloads. This page provides side-by-side comparisons of classic and new SDK patterns to help migrate existing code.
+
+## SDK mapping
+
+| Classic SDK | New SDK | Purpose | Migration effort |
+|-------------|---------|---------|-----------------|
+| `azure-ai-inference` | `openai` | Model inference (chat completions, embeddings) | Low — package swap, endpoint change |
+| `AzureOpenAI()` client | `OpenAI()` client with `base_url` | Azure OpenAI API access | Low — 3-line change |
+| Monthly `api-version` param | v1 stable routes (`/openai/v1/`) | API version management | Low — remove param |
+| `azure-ai-projects` 1.x | `azure-ai-projects` 2.x | Foundry project capabilities | Medium — API surface changes |
+| `client.agents.create_agent()` | `client.agents.create_version()` | Agent creation | Medium — new definition model |
+| `client.agents.threads.create()` | `openai_client.conversations.create()` | Conversation state | Medium — different client |
+| `client.agents.runs.create()` | `openai_client.responses.create()` | Agent execution | Medium — sync by default |
+
+## Client library: AzureOpenAI → OpenAI
+
+<CodeGroup>
+```python Classic
+from openai import AzureOpenAI
+
+client = AzureOpenAI(
+    azure_endpoint="https://YOUR_RESOURCE.openai.azure.com",
+    api_key="YOUR_API_KEY",
+    api_version="2024-10-21",
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
+
+```python New
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://YOUR_RESOURCE.openai.azure.com/openai/v1/",
+    api_key="YOUR_API_KEY",
+)
+
+response = client.responses.create(
+    model="gpt-4.1-nano",
+    input="Hello",
+)
+```
+</CodeGroup>
+
+Key differences:
+
+- `OpenAI()` replaces `AzureOpenAI()`.
+- `base_url` replaces `azure_endpoint` (append `/openai/v1/`).
+- The `api_version` parameter is removed.
+- Both `chat.completions` and `responses` endpoints are available on v1.
+
+## API versioning: monthly params → v1 routes
+
+<CodeGroup>
+```bash Classic
+curl -X POST "https://YOUR_RESOURCE.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-10-21" \
+  -H "api-key: $AZURE_OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+```bash New
+curl -X POST "https://YOUR_RESOURCE.openai.azure.com/openai/v1/chat/completions" \
+  -H "api-key: $AZURE_OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "gpt-4.1-nano", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+</CodeGroup>
+
+<Note>
+Preview features use headers (for example, `"aoai-evals":"preview"`) instead of preview API versions. Some features indicate preview status through their API path (for example, `/openai/v1/fine_tuning/alpha/graders/`).
+</Note>
+
+## Agent creation: create_agent → create_version
+
+<CodeGroup>
+```python Classic
+agent = project_client.agents.create_agent(
+    model="gpt-4.1",
+    name="my-agent",
+    instructions="You help with math questions.",
+    tools=[{"type": "code_interpreter"}]
+)
+```
+
+```python New
+from azure.ai.projects.models import PromptAgentDefinition
+
+agent = project_client.agents.create_version(
+    agent_name="my-agent",
+    definition=PromptAgentDefinition(
+        model="gpt-4.1",
+        instructions="You help with math questions.",
+    )
+)
+```
+</CodeGroup>
+
+Agent versions have an explicit `kind` (prompt, workflow, hosted) and are versioned by name. The response object includes an `id` in the format `agent-name:version-number`.
+
+## Conversations: threads → conversations
+
+<CodeGroup>
+```python Classic
+thread = project_client.agents.threads.create(
+    messages=[{"role": "user", "content": "Hello"}],
+)
+```
+
+```python New
+openai_client = project_client.get_openai_client()
+
+conversation = openai_client.conversations.create(
+    items=[{"type": "message", "role": "user", "content": "Hello"}],
+)
+```
+</CodeGroup>
+
+<Info>
+In the new API, agent creation uses `AIProjectClient` (project client), while conversations and responses use the OpenAI client obtained via `project_client.get_openai_client()`. This split exists because conversations and responses are built on the Responses API wire format.
+</Info>
+
+## Execution: runs → responses
+
+<CodeGroup>
+```python Classic
+run = project_client.agents.runs.create(
+    thread_id=thread.id,
+    agent_id=agent.id,
+)
+while run.status in ("queued", "in_progress"):
+    time.sleep(1)
+    run = project_client.agents.runs.get(
+        thread_id=thread.id, run_id=run.id
+    )
+```
+
+```python New
+response = openai_client.responses.create(
+    input="Draw a graph with slope 4 and y-intercept 9.",
+    conversation=conversation.id,
+    extra_body={
+        "agent_reference": {"name": "my-agent", "type": "agent_reference"}
+    }
+)
+```
+</CodeGroup>
+
+Responses are synchronous by default — no polling loop is required.
+
+## Deprecation timeline
+
+| SDK / API | Status | Retirement date | Replacement |
+|-----------|--------|-----------------|-------------|
+| `azure-ai-inference` | Deprecated | May 30, 2026 | `openai` SDK |
+| Assistants API wire protocol | Deprecated | August 26, 2026 | Responses API |
+| Monthly `api-version` params | Supported (opt-in to v1) | No retirement date | v1 stable routes |
+| `azure-ai-projects` 1.x | Stable | No retirement date | `azure-ai-projects` 2.x (when GA) |
+
+## Related content
+
+- [Microsoft Foundry SDKs and Endpoints](/api-sdk/sdk-overview)
+- [Azure OpenAI v1 API](/api-sdk/api-version-lifecycle)
+- [Migrate to the new Foundry Agent Service](/setup/migrate)
+- [Classic vs. New: terminology and feature comparison](/overview/classic-vs-new)

--- a/docs-vnext/docs.json
+++ b/docs-vnext/docs.json
@@ -14,9 +14,11 @@
         "tab": "Documentation",
         "groups": [
           {
-            "group": "What is Microsoft Foundry (new)?",
+            "group": "What is Microsoft Foundry?",
             "pages": [
-              "overview/what-is-foundry"
+              "overview/what-is-foundry",
+              "overview/developer-guide",
+              "overview/classic-vs-new"
             ]
           },
           {
@@ -359,6 +361,7 @@
             "group": "API & SDK",
             "pages": [
               "api-sdk/sdk-overview",
+              "api-sdk/sdk-classic-vs-new",
               "api-sdk/endpoints",
               "api-sdk/sdk-package-resources",
               "api-sdk/rest-api-resources",

--- a/docs-vnext/glossary.mdx
+++ b/docs-vnext/glossary.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Glossary"
-description: "Definitions of key terms used in Microsoft Foundry documentation and the foundry-docs project"
+description: "Definitions of key terms used in Microsoft Foundry documentation"
 ---
 
-A reference for technical terms used throughout Microsoft Foundry documentation, the foundry-docs MCP server, and the supporting toolchain.
+A reference for technical terms used throughout Microsoft Foundry documentation.
 
 ## A
 
@@ -11,13 +11,25 @@ A reference for technical terms used throughout Microsoft Foundry documentation,
 
 An AI-powered entity that can perceive context, reason over goals, and take actions autonomously using tools, models, and instructions. In Microsoft Foundry, agents are built and deployed via the Azure AI Agents Service and may use tools such as Code Interpreter, File Search, and Function Calling.
 
+### Agent Framework
+
+An open-source framework for building multi-agent systems in code. The Agent Framework supports local orchestration with workflow patterns and is cloud-agnostic, connecting to Microsoft Foundry via the project endpoint.
+
+### Agent Version
+
+A versioned, named definition of an agent in Microsoft Foundry. Agent versions have an explicit kind (prompt, workflow, or hosted) and are created using `create_version()`. Replaces the earlier pattern of creating agents with `create_agent()`.
+
 ### AI Red Teaming
 
 An adversarial testing methodology that systematically probes AI systems for safety vulnerabilities, harmful outputs, and security weaknesses. Foundry provides an AI Red Teaming Agent for automated scanning across risk categories.
 
+### Assistants API
+
+The previous wire protocol used by Agents v0.5 and v1 in Foundry Agent Service. Deprecated in favor of the Responses API, with a sunset date of August 26, 2026. See [Migrate to the new agents developer experience](/setup/migrate).
+
 ### Azure AI Foundry
 
-See [Microsoft Foundry](#microsoft-foundry).
+The previous name for Microsoft Foundry, used from November 2024 to November 2025. See [Microsoft Foundry](#microsoft-foundry).
 
 ### Azure AI Projects
 
@@ -37,23 +49,9 @@ The runtime environment in Microsoft Foundry that hosts an agent's tool connecti
 
 An agent tool that executes Python code in a sandboxed environment. Used for data analysis, file processing, and generating outputs such as charts or transformed datasets.
 
-### Content Chunking
+### Conversation
 
-The process of splitting large MDX documents into smaller, semantically coherent segments (chunks) before indexing into a vector store. The `MarkdownChunker` in `foundry_docs_mcp/chunker.py` splits documents by heading structure with configurable overlap to preserve context across chunk boundaries.
-
-## D
-
-### Devvit
-
-Reddit's developer platform for building server-side apps on Reddit. The `devvit-app/` in this repository monitors subreddits for Microsoft Foundry and Azure AI discussions and dispatches signals to GitHub via `repository_dispatch` for documentation impact analysis.
-
-### Diátaxis
-
-A documentation framework that organizes content into four types: tutorials (learning-oriented), how-to guides (goal-oriented), reference (information-oriented), and explanation (understanding-oriented). The docs-vnext documentation follows the Diátaxis framework.
-
-### docs-vnext
-
-The Mintlify MDX documentation directory (`docs-vnext/`) under active development. Served by the `foundry-docs-vnext` MCP server and used as the "D" backend in A/B/C/D evaluation. Distinct from the canonical `docs/` directory synchronized from upstream.
+A durable, server-managed object that stores items (messages, tool calls, tool outputs, reasoning items) across turns. Conversations replace threads in the new agents API. Created via the OpenAI client: `openai_client.conversations.create()`.
 
 ## E
 
@@ -79,6 +77,30 @@ An agent tool that retrieves relevant content from uploaded files using vector s
 
 The process of continuing training on a pre-trained foundation model using a domain-specific dataset, adapting the model's behavior for a target task or style. Foundry supports fine-tuning for select models with JSONL training data.
 
+### Foundry (classic)
+
+The portal experience at ai.azure.com that supports all resource types including Azure OpenAI, hub-based projects, and Foundry projects. Also referred to as "Mainline" internally. See [What is Microsoft Foundry?](/overview/what-is-foundry).
+
+### Foundry (new)
+
+The modernized portal experience at ai.azure.com optimized for multi-agent applications. Displays only Foundry projects. Supports Agents v2, workflows, tool catalog, memory, and Foundry Control Plane. See [What is Microsoft Foundry?](/overview/what-is-foundry).
+
+### Foundry Control Plane
+
+A unified management interface for observing, governing, and controlling AI agents, models, and tools across an enterprise. Provides fleet-level visibility and compliance enforcement.
+
+### Foundry Direct Models
+
+Models sold directly by Azure (including Azure OpenAI, DeepSeek, Meta, xAI, Mistral, and Microsoft models) billed through Azure meters rather than the Azure Marketplace.
+
+### Foundry Resource
+
+The top-level Azure resource (`Microsoft.CognitiveServices/accounts` with `kind: AIServices`) that provides unified access to agents, models, Foundry Tools, evaluations, and projects. Replaces the previous pattern of managing separate Azure OpenAI and Hub resources.
+
+### Foundry Tools
+
+The collection of domain-specific AI services available in Microsoft Foundry, including Azure Speech, Azure Vision, Azure Language, Content Safety, and Content Understanding. Formerly known as Azure AI Services (and before that, Cognitive Services).
+
 ### Function Calling
 
 A capability that allows language models to invoke external functions or APIs defined by the developer. The model emits a structured tool-call response that the application executes, returning results to the model for grounded generation.
@@ -91,21 +113,19 @@ Safety controls and content filters applied to AI model inputs and outputs. In F
 
 ## H
 
-### Hit@K
-
-An information retrieval metric that measures whether at least one expected result appears in the top-K results returned by a search query. Used in the A/B/C/D evaluation harness (`scripts/run_abcd_eval.py`) to compare documentation search backends.
-
-### HNSW (Hierarchical Navigable Small World)
-
-An approximate nearest-neighbor graph algorithm used for efficient vector search. The Azure AI Search index in foundry-docs uses HNSW with cosine similarity to retrieve semantically similar document chunks.
-
 ### Hosted Agent
 
-An agent deployed and managed entirely on Microsoft Foundry infrastructure. Hosted agents have their own identity, tool connections, and lifecycle managed by the Foundry platform, as opposed to agents run locally or in a custom compute environment.
+An agent deployed and managed entirely on Microsoft Foundry infrastructure. Hosted agents have their own identity, tool connections, and lifecycle managed by the Foundry platform, as opposed to agents run locally or in a custom compute environment. Hosted agents run as containerized services with managed scaling, identity, and observability.
 
 ### Hybrid Search
 
 A retrieval strategy that combines keyword search (BM25/full-text) with vector search (embedding similarity) to improve relevance. The `AzureSearchIndex` in `foundry_docs_mcp/indexer.py` uses hybrid search with semantic reranking when Azure AI Search is configured.
+
+## I
+
+### Item
+
+A unit of content in a conversation. Items are a superset of messages and can represent messages, tool calls, tool outputs, reasoning items, and other data. Replaces the message-only model used in threads.
 
 ## M
 
@@ -113,27 +133,15 @@ A retrieval strategy that combines keyword search (BM25/full-text) with vector s
 
 An open protocol for connecting AI models to external tools, data sources, and services. MCP defines a standard interface for tools (callable functions), resources (readable data), and prompts (reusable message templates), allowing AI assistants to interact with the external world in a structured way.
 
-### MCP Gateway (MCPG)
-
-A proxy service that manages the lifecycle of stdio MCP servers via container-based deployment. From MCPG v0.1.6, servers must be declared with `container:` rather than `command:` in workflow configuration. The foundry-docs server runs as `ghcr.io/nicholasdbrady/foundry-docs:latest`.
-
-### MDX
-
-Markdown with JSX components. The documentation format used by Mintlify, allowing standard Markdown content to be mixed with React-style components such as `<Note>`, `<Tip>`, `<CodeGroup>`, and `<Accordion>`. All files in `docs-vnext/` use the `.mdx` extension.
-
 ### Microsoft Foundry
 
-Microsoft's unified AI development platform for building, deploying, and managing AI agents and models. Formerly referred to as Azure AI Foundry or Azure AI Studio, it provides the Azure AI Agents Service, model catalog, fine-tuning, evaluation, observability, and governance capabilities.
-
-### Mintlify
-
-A documentation platform used to author and serve the `docs-vnext/` content. Provides MDX-based page authoring, navigation configuration via `docs.json`, built-in search, and a hosted publishing pipeline.
-
-### MRR (Mean Reciprocal Rank)
-
-An information retrieval metric that measures the average reciprocal rank of the first relevant result across a set of queries. Computed in `scripts/run_abcd_eval.py` to compare documentation search backends. A higher MRR indicates that relevant results appear closer to the top of result lists.
+Microsoft's unified AI development platform for building, deploying, and managing AI agents, models, and tools. Previously known as Azure AI Foundry (2024) and Azure AI Studio (2023). Provides Foundry Agent Service, model catalog, fine-tuning, evaluation, observability, and governance capabilities under a single Foundry resource.
 
 ## P
+
+### Project
+
+A development boundary inside a Foundry resource where teams build, evaluate, and isolate use cases. Projects share the parent resource's security and networking settings but provide independent access control and data isolation.
 
 ### Provisioned Throughput
 
@@ -147,37 +155,27 @@ A pattern that combines document retrieval with language model generation to pro
 
 ### RBAC (Role-Based Access Control)
 
-An authorization model that grants permissions to users and services based on assigned roles rather than individual identities. Microsoft Foundry uses Azure RBAC roles (e.g., Azure AI Developer, Cognitive Services OpenAI User) to control access to resources.
+An authorization model that grants permissions to users and services based on assigned roles rather than individual identities. Microsoft Foundry uses Azure RBAC roles (e.g., Azure AI User, Azure AI Project Manager, Azure AI Owner, Cognitive Services OpenAI User) to control access to resources.
 
-### Redis
+### Response
 
-An in-memory data store used for caching and deduplication. The Devvit Reddit community monitor uses Redis with a 7-day TTL to deduplicate post and comment events before dispatching to GitHub.
+The result of invoking an agent or model through the Responses API. Responses are synchronous by default, returning output items directly without requiring polling. Replaces the async run-and-poll pattern used in the Assistants API.
 
-### `repository_dispatch`
+### Responses API
 
-A GitHub webhook event type that allows external systems to trigger GitHub Actions workflows by sending an HTTP POST to the GitHub API. The Devvit app uses `repository_dispatch` to signal Reddit community activity to the foundry-docs repository.
-
-## S
-
-### SearchIndex
-
-The local TF-IDF-based search index (`foundry_docs_mcp/indexer.py`) built from MDX documentation files at MCP server startup. Used as the default search backend when Azure AI Search is not configured. Supports full-text search with title-weighted scoring.
-
-### Semantic Reranking
-
-Reordering search results using a semantic language model to improve relevance beyond initial keyword or vector ranking. Azure AI Search applies semantic reranking via a `SemanticConfiguration` that prioritizes title, section heading, and content fields.
+The modern API primitive for generating model outputs in Microsoft Foundry. Supports built-in tools (web search, file search, code interpreter, MCP, image generation), stateful context via conversations, and encrypted reasoning for compliance scenarios. Recommended for all new projects.
 
 ## T
 
-### TF-IDF (Term Frequency–Inverse Document Frequency)
+### Thread
 
-A statistical measure used to rank document relevance for a query. TF measures how often a term appears in a document; IDF down-weights terms that appear across many documents. The local `SearchIndex` uses TF-IDF scoring with title boosting (title tokens are weighted 2×).
-
-### Telemetry
-
-Structured logging and metrics emission for observability of MCP server operations. The `foundry_docs_mcp/telemetry.py` module tracks search queries, result counts, backend latency, and search feedback events using OpenTelemetry-compatible instrumentation.
+(Deprecated) A server-side collection of messages used in the Assistants API. Replaced by [Conversation](#conversation) in the Responses API. See [Migrate to the new agents developer experience](/setup/migrate).
 
 ## V
+
+### v1 API
+
+The stable Azure OpenAI API route (`/openai/v1/`) that eliminates monthly `api-version` parameters. Uses the standard `OpenAI()` client instead of the Azure-specific `AzureOpenAI()` client. Supports cross-provider model calls. See [Azure OpenAI v1 API](/api-sdk/api-version-lifecycle).
 
 ### Vector Search
 
@@ -186,3 +184,9 @@ Similarity-based document retrieval using dense embedding vectors. A query is em
 ### Vector Store
 
 A storage system that indexes and retrieves documents using embedding vectors. In Foundry, vector stores are associated with the File Search tool and back agent knowledge bases. The Azure AI Search index in foundry-docs functions as a vector store for documentation chunks.
+
+## W
+
+### Workflow Agent
+
+An agent type in Foundry Agent Service defined as a declarative YAML-based or visual orchestration of multiple agents. Workflow agents coordinate sequential, parallel, or group-chat patterns with optional human-in-the-loop steps.

--- a/docs-vnext/overview/classic-vs-new.mdx
+++ b/docs-vnext/overview/classic-vs-new.mdx
@@ -1,0 +1,71 @@
+---
+title: "Classic vs. New: terminology and feature comparison"
+description: "A reference mapping of terminology, features, and capabilities between Microsoft Foundry (classic) and Microsoft Foundry (new)."
+---
+
+Microsoft Foundry evolved through several naming and architectural changes. This page provides a reference mapping between classic and new terminology, capabilities, and features to help developers navigate the transition.
+
+<Info>
+**Naming history:** Azure AI Studio (Nov 2023) → Azure AI Foundry (Nov 2024) → Microsoft Foundry (Nov 2025). Azure AI Services → Foundry Tools. The Azure resource type remains `Microsoft.CognitiveServices/accounts`. All names in this documentation refer to the same evolving platform.
+</Info>
+
+## Terminology mapping
+
+| Concept | Classic term | New term | Notes |
+|---------|-------------|----------|-------|
+| Conversation state | Threads | Conversations | Conversations store items (messages, tool calls, outputs), not just messages. |
+| Chat messages | Messages | Items | Items are a superset of messages. |
+| Execution | Runs (async, polled) | Responses (sync by default) | No polling loop required. |
+| Agent definition | Assistants / Agents | Agent Versions | Versioned, with explicit kind (prompt, workflow, hosted). |
+| Agent creation | `create_agent()` | `create_version()` | Uses `PromptAgentDefinition`. |
+| API wire protocol | Assistants API | Responses API | Assistants API sunset: August 26, 2026. |
+| API versioning | Monthly `api-version` params | v1 stable routes | No version parameter required. |
+| Client library | `AzureOpenAI()` | `OpenAI()` with `base_url` | Standard client, Azure-specific code eliminated. |
+| Portal (main) | Foundry (classic) | Foundry (new) | Toggle in portal banner switches between them. |
+| Portal settings | Management Center | Operate section | Navigation reorganized. |
+| Resource type | Azure OpenAI + Hub | Foundry Resource | Single `AIServices` kind with child projects. |
+| AI services | Azure AI Services | Foundry Tools | Speech, Vision, Language, Content Safety, Content Understanding. |
+| RBAC roles | Cognitive Services OpenAI User | Azure AI User, Azure AI Project Manager, Azure AI Owner | New roles with control/data plane separation. |
+| Model billing | Model-as-a-Service (MaaS) | Foundry Direct Models | First-party models billed directly via Azure meters. |
+| SDK (Python) | `azure-ai-inference`, `AzureOpenAI` | `azure-ai-projects` 2.x, `openai` | `azure-ai-inference` retiring May 30, 2026. |
+| Documentation | Foundry (classic) docs | Foundry (new) docs | Version selector in documentation banner. |
+
+## Feature comparison: Classic vs. New portal
+
+| Feature | Foundry (classic) | Foundry (new) |
+|---------|-------------------|---------------|
+| Azure OpenAI resources | ✅ | Use Foundry resource (upgrade available) |
+| Hub-based projects | ✅ | Not visible (use classic portal) |
+| Foundry projects | ✅ | ✅ |
+| Agents v2 (Responses API) | ❌ | ✅ |
+| Multi-agent workflows | ❌ | ✅ |
+| Tool catalog (1,400+ tools) | ❌ | ✅ |
+| Agent memory | ❌ | ✅ |
+| Foundry IQ | ❌ | ✅ (preview) |
+| Hosted agents | ❌ | ✅ (preview) |
+| A2A protocol | ❌ | ✅ (preview) |
+| Foundry Control Plane | ❌ | ✅ (preview) |
+| Agent publishing to M365/Teams | ❌ | ✅ |
+| Chat completions | ✅ | ✅ |
+| Responses API | ❌ | ✅ |
+| Fine-tuning | ✅ | ✅ |
+| Evaluations | ✅ | ✅ (enhanced) |
+| Model catalog | ✅ | ✅ (expanded) |
+
+## SDK version mapping
+
+| SDK Version | Portal Version | Status |
+|---|---|---|
+| `azure-ai-projects` 2.x (preview) | Foundry (new) | Preview |
+| `azure-ai-projects` 1.x (GA) | Foundry (classic) | Stable |
+
+<Warning>
+Ensure the SDK version matches your portal experience. Using a 2.x SDK sample with a 1.x setup (or vice versa) causes errors.
+</Warning>
+
+## Related content
+
+- [A developer's guide to Microsoft Foundry](/overview/developer-guide)
+- [SDK comparison: Classic vs. New](/api-sdk/sdk-classic-vs-new)
+- [Migrate to the new Foundry Agent Service](/setup/migrate)
+- [Upgrade from Azure OpenAI to Microsoft Foundry](/setup/upgrade-azure-openai)

--- a/docs-vnext/overview/developer-guide.mdx
+++ b/docs-vnext/overview/developer-guide.mdx
@@ -1,0 +1,154 @@
+---
+title: "A developer's guide to Microsoft Foundry"
+description: "Understand how Microsoft Foundry evolved from a model-centric platform to an agent-centric one, what changed, and how to navigate the transition."
+---
+
+{/* Diátaxis type: Explanation (understanding-oriented) */}
+
+Microsoft Foundry is the result of a rapid industry evolution from model-centric to agent-centric AI. This page explains the forces that drove that evolution, summarizes the eight dimensions of change, and provides a map for navigating the transition.
+
+## How the AI industry changed
+
+The AI industry underwent a phase transition between 2023 and 2025. The pace of model releases accelerated by two orders of magnitude, and the role of models in the software stack shifted fundamentally.
+
+| Era | Release cadence | Paradigm | Platform response |
+|-----|----------------|----------|-------------------|
+| **2023** | Major model release every ~6 months | Model-centric: models are the product. Developers consume inference APIs. | Azure AI Studio launched as a model playground and experimentation environment. |
+| **2024** | Releases every ~2–3 months | Transitional: reasoning and multimodal capabilities emerge (o1-preview, September 2024). Tool-calling and instruction-following improve dramatically. | Azure AI Foundry rebranding — reflecting a shift from "studio" (experimentation) to "foundry" (production). |
+| **2025** | Multiple releases every ~6 days | Agent-centric: models become infrastructure. Agents — compositions of models, tools, memory, and orchestration — are the product. | Microsoft Foundry launched with a unified resource model, Responses API, and v1 API routes. |
+
+Four capabilities converged to make this shift possible:
+
+- **Advanced reasoning** — Models that can plan, decompose tasks, and self-correct (o1, o3, o4-mini) made autonomous agent behavior viable.
+- **Improved tool-calling** — Models became reliable enough at structured function calling to be trusted with real-world tool execution without constant human oversight.
+- **Enhanced instruction following** — System prompt fidelity improved to the point where agents could maintain persona and follow constraints across long conversations.
+- **Multimodal capabilities** — Vision, audio, and image generation collapsed into single model families, enabling agents that perceive and act across modalities.
+
+The platform had to evolve from "serve a model" to "operate an agent factory." Every transition described below follows from this shift.
+
+## What changed
+
+Microsoft Foundry represents eight simultaneous transitions across branding, APIs, portals, SDKs, resource models, and terminology.
+
+| Dimension | Classic | New |
+|-----------|---------|-----|
+| Brand | Azure AI Studio / Azure AI Foundry | Microsoft Foundry |
+| Portal | Mainline → Foundry (classic) | NextGen → Foundry (new) |
+| Agent API | Assistants API (Agents v0.5/v1) | Responses API (Agents v2) |
+| API versioning | Monthly `api-version` params | v1 stable routes (`/openai/v1/`) |
+| Resource model | Hub + Azure OpenAI + Azure AI Services | Foundry resource (single, with projects) |
+| SDKs | `azure-ai-inference`, `AzureOpenAI()` | `azure-ai-projects` 2.x, `OpenAI()` |
+| Terminology | Threads, Messages, Runs, Assistants | Conversations, Items, Responses, Agent Versions |
+| AI services branding | Azure AI Services | Foundry Tools |
+
+For a complete terminology mapping and feature comparison, see [Classic vs. New comparison](/overview/classic-vs-new).
+
+## Why the agent API moved to the Responses API
+
+The Assistants API — the wire protocol underpinning Agents v0.5 and v1 — required managing four tightly-coupled objects (Assistants, Threads, Messages, Runs) with asynchronous polling loops. The Responses API replaces this with a fundamentally different architecture. Seven factors drove the change.
+
+**Simpler mental model.** The Responses API uses a single pattern: send input items, get output items back. There are no polling loops, no run-status checks, and no async orchestration complexity. This reduces the surface area for bugs in agent code.
+
+**Better performance.** The Responses API delivers measurably better model intelligence with reasoning models (o3, o4-mini). Evaluations show a 3% improvement on code-generation benchmarks with the same prompt and setup, because the Responses API preserves reasoning items across tool-calling turns.
+
+**Lower costs.** The Responses API achieves 40–80% improvement in cache utilization compared to previous approaches. Higher cache hit rates translate directly to lower input token costs — cached input tokens for o4-mini are 75% cheaper than uncached ones.
+
+**Native agentic tools.** The Responses API supports a built-in tool loop where the model can call multiple tools — web search, file search, code interpreter, image generation, remote MCP servers, and custom functions — within a single API request. The Assistants API required manual orchestration for multi-tool scenarios.
+
+**Conversations replace threads.** Threads could only store messages. Conversations store items — messages, tool calls, tool outputs, reasoning items, and other data. This richer context enables better debugging, training data extraction, and multi-agent coordination.
+
+**Encrypted reasoning for compliance.** Organizations with Zero Data Retention (ZDR) requirements cannot use stateful APIs. The Responses API supports encrypted reasoning items: the client receives an encrypted blob of reasoning tokens that can be passed back in future requests without the service persisting intermediate state. This capability had no equivalent in the Assistants API and is critical for regulated enterprise scenarios.
+
+**Future-proofing.** All new model support, tool integrations, and API features land exclusively on the Responses API. The Assistants API has received no new features since its deprecation notice. Agents v2, built on the Responses API, is the only path to new capabilities.
+
+<Warning>
+The Assistants API wire protocol is being sunset on August 26, 2026. Applications built on the Assistants API (Agents v0.5 and v1) must migrate to the Responses API (Agents v2) before that date.
+</Warning>
+
+## Why API versions moved to v1 routes
+
+Azure OpenAI historically required a dated `api-version` query parameter on every request. Each month brought a new preview version, each adding features that developers needed — 12 API versions in 12 months. When model releases accelerated to days rather than months, the monthly cadence became a treadmill.
+
+The v1 API eliminates this pattern:
+
+- No `api-version` query parameter. Developers access the latest features without updating version strings.
+- Standard `OpenAI()` client instead of the Azure-specific `AzureOpenAI()` client. The same code runs against multiple providers with only a `base_url` change.
+- Cross-provider model calls. The same `/openai/v1/chat/completions` route works with DeepSeek, Grok, and other Foundry Direct models.
+- Feature-specific preview headers instead of whole-API preview versions. Individual features can be previewed without affecting stable endpoints.
+
+The migration is a three-line code change:
+
+```python
+# Before (classic, monthly api-version)
+from openai import AzureOpenAI
+
+client = AzureOpenAI(
+    azure_endpoint="https://YOUR_RESOURCE.openai.azure.com",
+    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+    api_version="2024-10-21",
+)
+```
+
+```python
+# After (v1, standard OpenAI client)
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://YOUR_RESOURCE.openai.azure.com/openai/v1/",
+    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+)
+```
+
+<Info>
+Classic monthly `api-version` parameters continue to work. The v1 API is opt-in — existing code does not break.
+</Info>
+
+## One resource, one portal
+
+The classic resource model required multiple Azure resource types working together: an Azure OpenAI resource, an Azure AI Services resource, and a hub-based workspace — each with its own RBAC scope, private endpoint, and SDK configuration.
+
+The Foundry resource model consolidates these into a single resource (`Microsoft.CognitiveServices/accounts` with `kind: AIServices`) that contains child projects. Each project is an isolated workspace with its own agents, models, evaluations, and connections, but all projects share a single set of credentials, network configuration, and access control policies.
+
+A Foundry resource exposes three endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `{name}.openai.azure.com` | Azure OpenAI API compatibility (chat completions, responses, embeddings) |
+| `{name}.services.ai.azure.com` | Foundry API (projects, agents, evaluations) |
+| `{name}.cognitiveservices.azure.com` | Foundry Tools (Speech, Vision, Language, Content Safety) |
+
+Upgrading an existing Azure OpenAI resource changes `kind` from `OpenAI` to `AIServices` while preserving the existing endpoint, keys, deployments, and state. The upgrade is non-breaking and additive — it enables Foundry features without disrupting existing workloads.
+
+## Which migration path do I need?
+
+The transition involves multiple independent axes. Most developers only need to act on one or two.
+
+| Current state | Action | Guide |
+|---------------|--------|-------|
+| Using Azure OpenAI resources | Upgrade the resource to a Foundry resource | [Upgrade to Foundry](/setup/upgrade-azure-openai) |
+| Using the Assistants API or Agents v1 | Migrate agent code to Agents v2 (Responses API) | [Migrate to Agents v2](/setup/migrate) |
+| Using monthly `api-version` parameters | Switch to v1 API routes | [Move to v1 API](/api-sdk/api-version-lifecycle) |
+| Using `azure-ai-inference` SDK | Switch to the OpenAI SDK | [SDK overview](/api-sdk/sdk-overview) |
+| Using hub-based projects | Continue using Foundry (classic) portal | Migration guides forthcoming |
+
+## How Foundry differs from Copilot Studio and M365 Copilot
+
+Microsoft Foundry, Copilot Studio, and M365 Copilot serve different personas and development models. The choice depends on who is building, what level of control is required, and where the agent runs.
+
+| Dimension | Microsoft Foundry | Copilot Studio | M365 Copilot |
+|-----------|------------------|----------------|--------------|
+| Target user | Developers, ML engineers | Business users, IT pros | End users |
+| Development model | Code-first (SDKs, CLI, VS Code) | Low-code (visual designer) | No development |
+| Agent complexity | Multi-agent systems, custom models | Departmental chatbots | Built-in assistant |
+| Deployment targets | Azure, containers, any cloud | Teams, Outlook, web | M365 apps |
+
+<Tip>
+For maximum flexibility, build backend logic in Foundry and compose user-facing experiences in Copilot Studio. This hybrid pattern combines full infrastructure control with broad end-user reach.
+</Tip>
+
+## Related content
+
+- [What is Microsoft Foundry?](/overview/what-is-foundry)
+- [Classic vs. New: terminology and feature comparison](/overview/classic-vs-new)
+- [SDK comparison: Classic vs. New](/api-sdk/sdk-classic-vs-new)
+- [Quickstart: Get started with Microsoft Foundry](/get-started/quickstart-create-foundry-resources)

--- a/docs-vnext/overview/what-is-foundry.mdx
+++ b/docs-vnext/overview/what-is-foundry.mdx
@@ -7,22 +7,36 @@ description: "Microsoft Foundry is a trusted platform that empowers developers t
 
 Microsoft Foundry unifies agents, models, and tools under a single management grouping with built-in enterprise-readiness capabilities including tracing, monitoring, evaluations, and customizable enterprise setup configurations. The platform provides streamlined management through unified role-based access control (RBAC), networking, and policies under one Azure resource provider namespace.
 
-<Tip>
-Azure AI Foundry is now Microsoft Foundry. Screenshots appearing throughout this documentation are in the process of being updated.
-</Tip>
+<Info>
+**Naming history:** Azure AI Studio (2023) → Azure AI Foundry (2024) → Microsoft Foundry (2025). All three names refer to the same evolving platform. The AI industry shifted from a model-centric world — where foundational models shipped every six months — to an agent-centric world where models ship every few days and serve as infrastructure for intelligent agents. Foundry evolved to match, unifying agents, models, and tools under a single platform. For the full story, see [A developer's guide to Microsoft Foundry](/overview/developer-guide).
+</Info>
 
 ## Microsoft Foundry portals
 
-There are two different portals for you to use to interact with Microsoft Foundry. A toggle in the portal banner allows you to switch between the two versions.
+Microsoft Foundry provides two portal experiences. Foundry (new) is the default for all Foundry projects.
 
-| Portal  | Banner&nbsp;display  | When to use |
-|---------|----------------|----------|
-| Microsoft Foundry (classic) | <img src="/images/classic-foundry.png" /> | Choose this portal when working with multiple resource types: Azure OpenAI, Foundry resources, hub-based projects, or Foundry projects. |
-| Microsoft Foundry (new) | <img src="/images/new-foundry.png" /> | Choose this portal for a seamless experience that combines simplicity with powerful and secure tools to build, manage and grow multi-agent applications. Only Foundry projects are visible here - use (classic) for all other resource types. |
+| Portal  | When to use |
+|---------|----------|
+| **Microsoft Foundry (new)** | The default experience for building, managing, and scaling multi-agent applications on Foundry projects. Includes Agents v2, workflows, tool catalog, memory, observability, and Foundry Control Plane. |
+| **Microsoft Foundry (classic)** | Use this portal when working with Azure OpenAI resources, hub-based projects, or capabilities not yet available in the new portal. A toggle in the portal banner switches between the two versions. |
 
-<Tip>
-All links to [Microsoft Foundry](https://ai.azure.com/?cid=learnDocs) open whichever version you last used.
-</Tip>
+<Note>
+**Coming from Azure OpenAI?** You can upgrade your Azure OpenAI resource to a Foundry resource while preserving your endpoint, API keys, and existing state. See [Upgrade from Azure OpenAI to Microsoft Foundry](/setup/upgrade-azure-openai).
+</Note>
+
+<Note>
+**Using hub-based projects?** Hub-based projects are accessible in the Foundry (classic) portal. New investments are focused on Foundry projects in the new portal.
+</Note>
+
+## Who is Foundry for?
+
+Microsoft Foundry serves three primary audiences:
+
+- **Application developers** building AI-powered products with agents, models, and tools. Start with the [quickstart](/get-started/quickstart-create-foundry-resources) and [developer guide](/overview/developer-guide).
+- **ML engineers and data scientists** who fine-tune models, run evaluations, and manage model deployments. See [fine-tuning](/models/fine-tuning/fine-tuning) and [evaluation](/observability/observability).
+- **IT administrators and platform engineers** who govern AI resources, enforce policies, and manage access across teams. See [security and governance](/security/architecture) and [Foundry Control Plane](/manage/overview).
+
+For guidance on how Foundry compares to Copilot Studio and M365 Copilot, see the [developer guide](/overview/developer-guide#how-foundry-differs-from-copilot-studio-and-m365-copilot).
 
 ## Microsoft Foundry (new)
 
@@ -81,10 +95,13 @@ Foundry is available in most regions where Foundry Tools are available. For more
 
 ## How to get access
 
-You need an [Azure account](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn).  Then sign in to [Microsoft Foundry](https://ai.azure.com?cid=learnDocs) and turn on the **Try the new Foundry** toggle.
+You need an [Azure account](https://azure.microsoft.com/pricing/purchase-options/azure-account?cid=msft_learn). Sign in to [Microsoft Foundry](https://ai.azure.com?cid=learnDocs) to get started. New users land in the Foundry (new) portal by default.
 
 ## Related content
 
-- [Quickstart: Get started with Microsoft Foundry](/get-started/quickstart-create-foundry-resources)- [Create a project](/setup/create-projects)
+- [Quickstart: Get started with Microsoft Foundry](/get-started/quickstart-create-foundry-resources)
+- [Create a project](/setup/create-projects)
+- [A developer's guide to Microsoft Foundry](/overview/developer-guide)
+- [Classic vs. New: terminology and feature comparison](/overview/classic-vs-new)
 - [Get started with an AI template](/developer-experience/ai-template-get-started)
 - [What's new in Microsoft Foundry documentation?](/operate/whats-new-foundry)

--- a/local/pm-mode/foundry-evolution-research.md
+++ b/local/pm-mode/foundry-evolution-research.md
@@ -1,0 +1,910 @@
+# Untangling Microsoft Foundry: A Framework for Communicating the Classic → New Evolution
+
+## Executive Summary
+
+Microsoft Foundry's messaging challenge stems from **eight simultaneous transitions** happening across branding, APIs, API versioning, portals, SDKs, resource models, terminology, and billing — all driven by a fundamental industry shift from a model-centric to an agent-centric world. These transitions are governed by a **four-phase migration plan** (NextGen GA March 17 → AOAI migration through March 2027 → Hub deprecation → Legacy retirement) that sequences the customer impact across distinct cohorts: FDP users first, AOAI users second, Hub/Foundry Tools users third, and full legacy retirement last[^18]. This report maps each transition dimension, identifies the specific conflation points, proposes a structured communication framework anchored in Dennis Drews' Build 2025 recap, and provides actionable recommendations aligned to each migration phase. Key stakeholder domains: Bala (Foundry API), Dan (Foundry SDKs), Jeff (Agent Service), Marco (horizontal platform). The core recommendation: **treat each transition axis independently in documentation, but present them through a unified "Classic → New" lens** with a single entry point that lets customers self-select into the migration path(s) relevant to them.
+
+---
+
+## Why Everything Changed: The Model-Centric to Agent-Centric Shift
+
+Before diving into the eight axes of transition, it is critical to frame **why** these changes happened. The technical debt and messaging complexity are not accidents — they are the natural consequence of an industry that moved faster than any platform could organically evolve.
+
+### The pace of change
+
+The AI industry underwent a phase transition between 2023 and 2025:
+
+| Era | Cadence | Paradigm | Platform Response |
+|-----|---------|----------|-------------------|
+| **2023** | Major model release every ~6 months (GPT-4, GPT-4 Turbo) | **Model-centric**: Models are the product. Developers consume inference APIs. | Azure AI Studio launched as a model playground and experimentation environment. Monthly `api-version` parameters (e.g., `2024-03-01-preview`) to track each incremental API feature. |
+| **2024 (early)** | Model releases every ~2–3 months (GPT-4o, o1-preview) | **Model-centric → transitional**: Models gain multimodal capabilities. Reasoning emerges with o1-preview (Sept 2024). Tool-calling and instruction-following improve dramatically. | Azure AI Studio rebranded to Azure AI Foundry — reflecting the shift from "studio" (experimentation) to "foundry" (production factory). Monthly API versions proliferate — 12+ preview versions per year, each requiring code and environment variable updates. |
+| **2025** | Multiple model releases every ~6 days (GPT-4.1, o3, o4-mini, GPT-image-1, Codex) | **Agent-centric**: Models become infrastructure. Agents — compositions of models, tools, memory, and orchestration — are the product. | Microsoft Foundry launched: unified resource model, Responses API (replacing Assistants), v1 API routes (replacing monthly versions), Foundry-as-a-service. The platform had to evolve from "serve a model" to "operate an agent factory." |
+
+### What drove the shift
+
+Starting October 2024 and accelerating through 2025, several capabilities converged to make models **infrastructure** rather than **products**:
+
+- **Advanced reasoning** (o1-preview Sept 2024 → o1 Dec 2024 → o3/o4-mini 2025): Models that can plan, decompose tasks, and self-correct made autonomous agent behavior viable.
+- **Improved tool-calling**: Models became reliable enough at structured function calling to be trusted with real-world tool execution — APIs, databases, code interpreters — without constant human oversight.
+- **Enhanced instruction following**: System prompt fidelity improved to the point where agents could maintain persona, follow constraints, and operate within guardrails across long conversations.
+- **Multimodal capabilities**: Vision, audio, and image generation collapsed into single model families, enabling agents that perceive and act across modalities.
+
+This is the context that makes every transition axis below understandable: Microsoft wasn't changing things for the sake of change. The industry moved from a world where "deploy a model, call an API" was the entire workflow, to one where models are one component in a multi-agent system requiring orchestration, state management, governance, and observability. The platform had to evolve to match.
+
+### The API versioning crisis
+
+The monthly API version pattern (`2024-03-01-preview`, `2024-04-01-preview`, ..., `2025-04-01-preview`) was sustainable when models shipped every 6 months. When model releases accelerated to days rather than months, and each release brought new API features, the monthly cadence became a treadmill for developers. The v1 API is the direct answer to this crisis.
+
+---
+
+## The Eight Axes of Transition
+
+The confusion is not a single problem — it is eight overlapping transitions that customers experience simultaneously. Each axis is independent but interacts with the others, creating a combinatorial explosion of possible customer states.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                    MICROSOFT FOUNDRY EVOLUTION                        │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  1. BRANDING         Azure AI Studio → Azure AI Foundry →            │
+│                      Microsoft Foundry                                │
+│                                                                      │
+│  2. PORTAL UX        Mainline (Classic) ←→ NextGen (New)             │
+│                                                                      │
+│  3. AGENT API        Assistants API → Agents v0.5/v1 → Agents v2    │
+│                      (wire protocol: Assistants → Responses)          │
+│                                                                      │
+│  4. API VERSIONING   Monthly api-version params → v1 stable routes   │
+│                      (AzureOpenAI client → OpenAI client)             │
+│                                                                      │
+│  5. RESOURCE MODEL   Hub + Azure OpenAI + AI Services →              │
+│                      Foundry Resource (unified)                       │
+│                                                                      │
+│  6. SDK STACK        AI Inference + AI Generative + AOAI SDK →       │
+│                      AI Projects SDK + OpenAI SDK + Foundry Tools     │
+│                                                                      │
+│  7. TERMINOLOGY      Threads/Messages/Runs →                         │
+│                      Conversations/Items/Responses                    │
+│                                                                      │
+│  8. BILLING          Model-as-a-Service (MaaS) →                     │
+│                      Foundry Direct Models                            │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Axis 1: Branding Evolution
+
+### Timeline
+
+| Date | Brand | Key Event |
+|------|-------|-----------|
+| November 2023 | **Azure AI Studio** | Public preview launch |
+| November 2024 | **Azure AI Foundry** | Rebranding at Ignite 2024; "agent factory" positioning |
+| May 2025 | **Azure AI Foundry** | Build 2025 — new Foundry resource type, Foundry API, Foundry projects announced[^1] |
+| November 2025 | **Microsoft Foundry** | Ignite 2025 — elevated from Azure sub-brand to core Microsoft pillar alongside M365 and Azure[^2] |
+
+### Why This Causes Confusion
+
+- Customers searching for "Azure AI Foundry" find content from three different eras
+- Documentation still uses "Azure AI Foundry" in many places (the `what-is-foundry.mdx` page opens with a tip: "Azure AI Foundry is now Microsoft Foundry. Screenshots appearing throughout this documentation are in the process of being updated.")[^3]
+- The Azure resource type is still `Microsoft.CognitiveServices/accounts` with `kind: 'AIServices'` — there is no "Microsoft.Foundry" resource provider yet[^4]
+- The portal URL remains `ai.azure.com`, not a Microsoft Foundry-branded URL
+
+### Recommendation
+
+Create a "Name History" callout that appears once, early, in the "What is Foundry" page:
+
+> **A note on naming:** Azure AI Studio (2023) → Azure AI Foundry (2024) → Microsoft Foundry (2025). All three names refer to the same evolving platform. The Azure resource type is `Microsoft.CognitiveServices/accounts`. This documentation uses "Microsoft Foundry" or simply "Foundry."
+
+---
+
+## Axis 2: Portal UX — Classic vs. New (NextGen)
+
+### Current State
+
+The docs-vnext `what-is-foundry.mdx` already defines the two portals clearly[^3]:
+
+| Portal | Internal Name | Who Should Use It |
+|--------|--------------|-------------------|
+| **Microsoft Foundry (classic)** | "Mainline" | Working with multiple resource types: Azure OpenAI, Foundry resources, hub-based projects, or Foundry projects |
+| **Microsoft Foundry (new)** | "NextGen" | Seamless experience for multi-agent applications. Only Foundry projects visible. |
+
+A toggle in the portal banner switches between the two.
+
+### Key Differences
+
+| Dimension | Classic (Mainline) | New (NextGen) |
+|-----------|-------------------|---------------|
+| Resource visibility | All resource types (AOAI, Hubs, Foundry) | Foundry projects only |
+| Navigation | Customizable left pane, Management Center | Streamlined, project selector in upper-left |
+| Agent experience | Agents v0.5/v1 (Assistants-based) | Agents v2 (Responses-based) |
+| Multi-agent workflows | Not available | SDK-based orchestration (C#, Python) |
+| Tool catalog | Limited | 1,400+ tools, public/private catalogs |
+| Memory | Not available | GA |
+| Foundry IQ | Not available | Preview |
+| Performance | Standard | Faster load times, dynamic prefetching |
+
+### Conflation Point
+
+The term "Mainline" is an internal code name that has leaked into some customer-facing contexts. Customers don't know what "Mainline" means. The `what-is-foundry.mdx` correctly uses "(classic)" and "(new)" labels[^3], but the internal naming ("Mainline OAI sub-studio" and "NextGen") from the alignment table needs to be systematically replaced.
+
+### Recommendation
+
+- **Label Mainline as "Classic" in all customer-facing content** — NextGen GA is March 13 (announced March 17)[^18]. This is now.
+- The docs-vnext already does this well — ensure Foundry (classic) docs match
+- Create a feature support matrix table comparing Classic vs New portal capabilities (partially exists in the `what-is-foundry.mdx` page but not as a dedicated comparison)
+- **Phase 1 nuance:** Hub projects + AOAI-only resources remain Mainline-only. NextGen shows only Foundry projects. Document the toggle-back flow clearly.
+- **Phase 2 risk to document:** NextGen provides same *functionality* as OAI sub-studio but not same *API surface in UX* (Agents instead of Assistants, Foundry evals instead of OAI evals, AI Search index instead of OAI vector store). The underlying API still supports all legacy patterns — this distinction must be made clear to avoid DSAT.
+
+---
+
+## Axis 3: Agent API Evolution
+
+This is the deepest source of technical confusion. There are effectively **four generations** of agent API in the Foundry ecosystem:
+
+### Lineage
+
+```
+OpenAI Assistants API (beta)
+    │
+    ├── Azure OpenAI Assistants API (Agents v0.5)
+    │       Wire protocol: Assistants API
+    │       Objects: Assistants, Threads, Messages, Runs
+    │       SDK: client.beta.assistants.create()
+    │
+    ├── Azure AI Agent Service (Agents v1)
+    │       Wire protocol: Assistants API (with extensions)
+    │       Objects: Agents, Threads, Messages, Runs
+    │       SDK: project_client.agents.create_agent()
+    │
+    └── Foundry Agent Service (Agents v2)
+            Wire protocol: Responses API
+            Objects: Agent Versions, Conversations, Items, Responses
+            SDK: project_client.agents.create_version()
+                 openai_client.conversations.create()
+                 openai_client.responses.create()
+```
+
+### Critical Context: Why the Wire Protocol Changed
+
+The Assistants API — the wire protocol underpinning Agents v0.5 and v1 — has been **formally deprecated with a sunset date of August 26, 2026**[^5]. This is not a Microsoft decision — the upstream API provider is sunsetting the protocol that Foundry's classic agents were built on. Microsoft's move to the Responses API for Agents v2 is therefore both a feature upgrade and a forced migration.
+
+The upstream provider's own documentation, SDKs, cookbooks, and blog posts articulate seven clear reasons for the migration. These reasons apply directly to Foundry customers and should be incorporated (in Microsoft's voice) into customer-facing messaging:
+
+#### 1. Simpler Mental Model
+
+The Assistants API required managing four tightly-coupled objects: Assistants, Threads, Messages, and Runs. Runs were asynchronous processes requiring polling loops. The Responses API replaces this with a single pattern: **send input items, get output items back**[^15]. No polling, no run status checks, no async orchestration complexity. In the upstream migration guide, this is described as moving to "a simpler and more flexible mental model"[^16].
+
+#### 2. Better Performance with Reasoning Models
+
+The Responses API delivers measurably better model intelligence when using reasoning models (o3, o4-mini, GPT-5). Upstream internal evaluations show a **3% improvement on SWE-bench** with the same prompt and setup, compared to the older Chat Completions API[^15]. This improvement comes from the Responses API's ability to preserve and reuse reasoning items across tool-calling turns — something the Assistants API could not do.
+
+The upstream cookbook on reasoning items explains the mechanism: when a reasoning model makes a tool call, the reasoning tokens from before the tool call are critical context for interpreting the tool's output. The Responses API preserves these automatically via `previous_response_id` or explicit inclusion in subsequent input items[^17].
+
+#### 3. Lower Costs via Cache Utilization
+
+The Responses API achieves **40% to 80% improvement in cache utilization** compared to Chat Completions in internal tests[^15]. Higher cache hit rates mean lower input token costs — for example, cached input tokens for o4-mini are 75% cheaper than uncached ones[^17]. The Assistants API's architecture made efficient caching difficult because state management was opaque and server-side.
+
+#### 4. Native Agentic Tools
+
+The Responses API is **agentic by default** — it supports a built-in tool loop where the model can call multiple tools (web search, file search, code interpreter, image generation, remote MCP servers, and custom functions) **within a single API request**[^15]. The Assistants API required manual orchestration for multi-tool scenarios. The Responses API also supports capabilities that never existed in the Assistants API:
+
+| Capability | Assistants API | Responses API |
+|-----------|---------------|---------------|
+| Web search | ❌ (custom implementation) | ✅ Built-in |
+| File search | ✅ | ✅ |
+| Code interpreter | ✅ | ✅ |
+| Computer use | ❌ | ✅ |
+| Image generation | ❌ | ✅ |
+| MCP (remote servers) | ❌ | ✅ |
+| Deep research | ❌ | ✅ |
+| Reasoning summaries | ❌ | ✅ |
+| Connectors (Google, Dropbox, etc.) | ❌ | ✅ |
+
+#### 5. Conversations Replace Threads
+
+Threads could only store messages. **Conversations** store **items** — messages, tool calls, tool outputs, reasoning items, and other data[^16]. This is a superset: anything you could do with Threads, you can do with Conversations, plus you get richer context that enables better debugging, training data extraction, and multi-agent coordination.
+
+The upstream migration guide provides a direct mapping[^16]:
+
+| Before | Now | Why |
+|--------|-----|-----|
+| Assistants | Prompts | Easier to version, snapshot, diff, and roll back |
+| Threads | Conversations | Streams of items instead of just messages |
+| Runs | Responses | Input items in, output items out; tool call loops explicitly managed |
+| Run steps | Items | Generalized objects — can be messages, tool calls, outputs, and more |
+
+#### 6. Encrypted Reasoning for Compliance
+
+Organizations with Zero Data Retention (ZDR) requirements cannot use stateful APIs. The Responses API supports **encrypted reasoning items**: the client receives an encrypted blob of reasoning tokens that it can pass back in future requests without the provider ever persisting intermediate state[^17]. This capability had no equivalent in the Assistants API and is critical for regulated enterprise scenarios — exactly the scenarios Foundry serves.
+
+#### 7. Future-Proofing
+
+The upstream provider has been explicit: **"The Responses API represents the future direction for building agents"**[^15]. All new model support, tool integrations, and API features land exclusively on the Responses API. The Assistants API received no new features after its deprecation notice in August 2025. For Foundry, this means Agents v2 (built on Responses) is the only path to new capabilities.
+
+### What This Means for Foundry's "Classic → New" Story
+
+The upstream migration is not a Microsoft-specific change — it is an **industry-wide protocol evolution**. Foundry's Agents v2 inherits all seven benefits listed above, plus Foundry-specific additions:
+
+- **Versioned agent definitions** with `PromptAgentDefinition` and `WorkflowAgentDefinition`
+- **Hosted agents** with their own identity and managed lifecycle
+- **Foundry-specific tools** (Foundry IQ, Azure AI Search, SharePoint, Fabric)
+- **Enterprise governance** (RBAC, Azure Policy, content filters, network isolation)
+- **Multi-agent workflows** via the Agent Framework
+
+The key messaging opportunity: **don't frame the migration as "Microsoft changed the API." Frame it as "the industry evolved the protocol, and Foundry adopted it to give you better performance, lower costs, and more capabilities."**
+
+### Key API Changes (from `migrate.mdx`)[^6]
+
+| Before (Classic) | After (New) | Details |
+|---|---|---|
+| Threads | Conversations | Supports streams of items, not just messages |
+| Runs | Responses | Responses send input items, receive output items. Tool call loops explicitly managed |
+| Assistants / Agents | Agents (versioned) | Support for prompt, workflow, and hosted agents with stateful context |
+| `client.agents.create_agent()` | `client.agents.create_version()` | Versioned definitions with explicit `kind`, `model`, `instructions` |
+| `client.agents.threads.create()` | `openai_client.conversations.create()` | Uses OpenAI client, not project client |
+| `client.agents.runs.create()` | `openai_client.responses.create()` | Synchronous by default, no polling loop needed |
+
+### Dual-Client Pattern
+
+A particularly confusing aspect of Agents v2: agent creation uses `AIProjectClient` (Foundry SDK), but conversation/response operations use the **OpenAI client** obtained via `project_client.get_openai_client()`[^6]. This split exists because conversations and responses are built on the OpenAI Responses API wire format, while agent definitions are Foundry-specific resources.
+
+### Recommendation
+
+- **Publish a clear "Agent API Versions" reference page** with the lineage diagram above
+- **Explain the upstream protocol sunset deadline** — customers need to know this is a forced industry migration, not a preference. Frame it as: "the industry evolved the protocol" rather than "Microsoft changed the API"
+- **Incorporate the seven upstream benefits** (simpler model, better performance, lower costs, native tools, conversations, encrypted reasoning, future-proofing) into Foundry's own migration messaging — rewritten in Microsoft's voice without explicitly referencing the upstream provider
+- **Document the dual-client pattern explicitly** — the migration doc does this well already[^6]; elevate it to a concept page
+- **Highlight the capability matrix** showing what's available only in the Responses API (MCP, deep research, image generation, connectors, reasoning summaries) — these are exclusive to "New" and provide concrete value for the migration
+
+---
+
+## Axis 4: API Versioning — Monthly Versions to v1 Stable Routes
+
+This is one of the most impactful developer-facing transitions and one of the clearest wins for the "New" story. It deserves its own axis because it affects **every developer** who calls any Azure OpenAI API, regardless of whether they use agents.
+
+### The Problem: Monthly API Version Treadmill
+
+Azure OpenAI historically required a dated `api-version` query parameter on every request:
+
+```
+POST https://{resource}.openai.azure.com/openai/deployments/{model}/chat/completions?api-version=2024-10-21
+```
+
+Each month brought a new preview version, each adding features that developers needed. The changelog in `api-version-lifecycle.mdx` tells the story[^14]:
+
+| API Version | Key Feature Added |
+|------------|-------------------|
+| `2024-04-01-preview` | Assistants v2, file search, vector stores |
+| `2024-05-01-preview` | Batch API, vector store chunking |
+| `2024-07-01-preview` | Structured outputs |
+| `2024-08-01-preview` | `max_completion_tokens` for o1 models, parallel tool calls |
+| `2024-09-01-preview` | `reasoning_tokens` in usage |
+| `2024-10-01-preview` | Stored completions, `reasoning_effort`, Defender integration |
+| `2024-12-01-preview` | Predicted outputs, audio completions |
+| `2025-01-01-preview` | (continued incremental) |
+| `2025-02-01-preview` | Responses API, computer use |
+| `2025-03-01-preview` | GPT-image-1, reasoning summaries, Evaluation API |
+| `2025-04-01-preview` | Video generation, MCP tool integration, background tasks |
+
+That is **12 API versions in 12 months**, each requiring developers to update a query parameter and test for breaking changes. Moreover, Azure OpenAI required a separate `AzureOpenAI()` client (Python, C#, JS, etc.) distinct from the standard `OpenAI()` client, creating overhead when porting code between OpenAI and Azure OpenAI[^14].
+
+### The Solution: v1 API Routes
+
+Starting August 2025, Azure OpenAI introduced the **v1 API**, which eliminates the monthly version treadmill[^14]:
+
+```
+POST https://{resource}.openai.azure.com/openai/v1/chat/completions
+```
+
+Key changes:
+
+| Dimension | Classic (Monthly Versions) | New (v1 Routes) |
+|-----------|---------------------------|-----------------|
+| **URL pattern** | `/openai/deployments/{model}/chat/completions?api-version=2024-10-21` | `/openai/v1/chat/completions` |
+| **Version management** | Must update `api-version` param monthly to access new features | No version parameter; ongoing access to latest features |
+| **Client library** | `AzureOpenAI()` — Azure-specific client | `OpenAI()` — standard OpenAI client with `base_url` set to Azure[^14] |
+| **Token auth** | Required `AzureOpenAI()` for automatic token refresh | `OpenAI()` client handles token refresh natively |
+| **Cross-provider models** | Azure OpenAI models only | DeepSeek, Grok, and other providers via same `v1` chat completions route[^14] |
+| **Preview features** | Entire API version is "preview" | Feature-specific preview headers (e.g., `"aoai-evals":"preview"`) or path indicators (e.g., `/alpha/`)[^14] |
+
+### Code Comparison
+
+**Classic (monthly version, Azure-specific client):**
+
+```python
+from openai import AzureOpenAI
+
+client = AzureOpenAI(
+    azure_endpoint="https://YOUR-RESOURCE.openai.azure.com",
+    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+    api_version="2024-10-21",  # Must update monthly
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
+
+**New (v1, standard OpenAI client):**
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://YOUR-RESOURCE.openai.azure.com/openai/v1/",
+    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+)
+
+response = client.responses.create(
+    model="gpt-4.1-nano",
+    input="Hello",
+)
+```
+
+Or, with environment variables `OPENAI_BASE_URL` and `OPENAI_API_KEY` set:
+
+```python
+client = OpenAI()  # Zero Azure-specific configuration
+```
+
+### v1 GA API Surface
+
+The v1 API launched with a subset of capabilities, expanding rapidly[^14]:
+
+| API Path | Status |
+|----------|--------|
+| `/openai/v1/chat/completions` | Generally Available |
+| `/openai/v1/responses` | Generally Available |
+| `/openai/v1/embeddings` | Generally Available |
+| `/openai/v1/files` | Generally Available |
+| `/openai/v1/fine_tuning/` | Generally Available |
+| `/openai/v1/models` | Generally Available |
+| `/openai/v1/vector_stores` | Generally Available |
+| `/openai/v1/evals` | Preview (requires header) |
+
+### Why This Matters for the "Classic → New" Story
+
+The v1 API transition is perhaps the **easiest win** for customer messaging because:
+
+1. **It solves a universal pain point**: Every Azure OpenAI developer has been burned by `api-version` management.
+2. **It eliminates Azure-specific client code**: Developers can use the same `OpenAI()` client for both OpenAI and Azure, with only a `base_url` change.
+3. **It enables cross-provider model access**: The same `/openai/v1/chat/completions` route works with DeepSeek, Grok, and other Foundry Direct models.
+4. **It decouples feature access from version management**: Preview features use headers, not version strings.
+
+### Connection to the Agent-Centric Shift
+
+The v1 API is not just a developer convenience — it is architecturally necessary for the agent-centric world. When models shipped every 6 months, monthly API versions were manageable. When the Responses API, MCP tool integration, background tasks, image generation, and encrypted reasoning all land within a 3-month window (Feb–Apr 2025)[^14], forcing developers to hop from `2025-02-01-preview` to `2025-03-01-preview` to `2025-04-01-preview` to access each feature is untenable. The v1 API acknowledges that the pace of innovation has outgrown the monthly versioning model.
+
+### Recommendation
+
+- **Lead with the v1 API as the flagship "Classic → New" developer improvement** — it has the broadest impact and the simplest migration path
+- **Create a prominent "Upgrade to v1" guide** that shows the 3-line code change (already well-documented in `api-version-lifecycle.mdx`[^14])
+- **Document both endpoints**: `https://{resource}.openai.azure.com/openai/v1/` and `https://{resource}.services.ai.azure.com/openai/v1/` (both are valid[^14])
+- **Clarify that monthly API versions still work** — v1 is opt-in, not a forced migration. Classic `api-version` parameters remain supported for existing code.
+
+---
+
+## Axis 5: Resource Model Evolution
+
+### Classic: Multi-Resource Hub Model
+
+```
+┌─────────────────────────────────────────┐
+│              Hub (workspace)            │
+│  ┌──────────┐  ┌──────────────────────┐ │
+│  │Azure     │  │Azure AI Services     │ │
+│  │OpenAI    │  │  ├─ Speech           │ │
+│  │          │  │  ├─ Language          │ │
+│  │          │  │  ├─ Vision            │ │
+│  │          │  │  └─ Content Safety    │ │
+│  └──────────┘  └──────────────────────┘ │
+│  ┌──────────────────────────────────────┐│
+│  │ Azure Machine Learning Workspace     ││
+│  │   └─ Hub-based Projects              ││
+│  └──────────────────────────────────────┘│
+└─────────────────────────────────────────┘
+```
+
+- Multiple Azure resource types to manage
+- Multiple RBAC scopes
+- Multiple SDKs
+- Complex networking (multiple private endpoints)
+
+### New: Foundry-as-a-Service
+
+```
+┌───────────────────────────────────────────┐
+│      Foundry Resource                      │
+│      (Microsoft.CognitiveServices/accounts │
+│       kind: AIServices)                    │
+│                                            │
+│  ┌────────────────────────────────────────┐│
+│  │ Foundry Project (default)              ││
+│  │   ├─ Agents                            ││
+│  │   ├─ Models (AOAI + Direct + Partner)  ││
+│  │   ├─ Foundry Tools (Speech, Vision...) ││
+│  │   ├─ Evaluations                       ││
+│  │   └─ Connections                       ││
+│  └────────────────────────────────────────┘│
+│  ┌────────────────────────────────────────┐│
+│  │ Foundry Project (team-2)               ││
+│  │   └─ (isolated workspace)              ││
+│  └────────────────────────────────────────┘│
+│                                            │
+│  Endpoints:                                │
+│   .openai.azure.com                        │
+│   .services.ai.azure.com                   │
+│   .cognitiveservices.azure.com              │
+└───────────────────────────────────────────┘
+```
+
+### The Upgrade Path
+
+The `upgrade-azure-openai.mdx` document describes the AOAI → Foundry upgrade as changing `kind` from `'OpenAI'` to `'AIServices'` while preserving endpoint, keys, and state[^4]. This is a **non-breaking upgrade** that adds capabilities.
+
+### Three FQDNs
+
+A Foundry resource exposes three FQDNs[^4]:
+- `{name}.openai.azure.com` — Azure OpenAI API compatibility
+- `{name}.services.ai.azure.com` — Foundry API (projects, agents, evaluations)
+- `{name}.cognitiveservices.azure.com` — Cognitive Services / Foundry Tools
+
+This triple-endpoint model is itself a source of confusion. Customers need to know which endpoint to use for which SDK.
+
+### Recommendation
+
+- **Create a "Resource Types Explained" page** that shows the before/after diagram
+- **Explicitly document the three endpoints** and which SDK/scenario uses each (the `sdk-overview.mdx` does this with a table[^7] — ensure it's prominent and cross-linked)
+- **Hub deprecation is Phase 3** — target is April 30, 2026, contingent on Foundry Hosting (MaaP) GA[^18]. Hub users will be routed to ML Studio from NextGen for MaaP deployments and Prompt Flow. The hub-to-Foundry migration guide does not yet exist and is a critical Phase 3 deliverable.
+- **Agents v0.5 on Hub** needs a deprecation owner — this is called out as an unresolved blocker in the migration plan[^18]
+- **Foundry Tools naming:** Confirmed lineage is Cognitive Services → Azure AI Services → Foundry Tools. "Foundry Tools" refers to the domain-specific AI services (Speech, Vision, Language, Content Understanding, Content Safety), **not** the Foundry resource type. The `multi-service-resource.mdx` phrasing is misleading.
+
+---
+
+## Axis 6: SDK Evolution
+
+### Classic SDK Stack
+
+| SDK | Purpose | Status |
+|-----|---------|--------|
+| `azure-ai-inference` | Chat completions, embeddings (model inference) | **Deprecated**, retiring May 30, 2026[^8] |
+| `azure-ai-generative` | RAG, prompt flow, evaluations | Superseded |
+| `azure-ai-evaluation` | Model/agent evaluations | Continues in `azure-ai-projects` |
+| `openai` (Azure OpenAI SDK) | OpenAI API compatibility | Continues |
+
+### New SDK Stack
+
+| SDK | Purpose | Endpoint | Status |
+|-----|---------|----------|--------|
+| `azure-ai-projects` (2.x preview) | Agents, evaluations, Foundry-specific features | `.services.ai.azure.com/api/projects/{project}` | Preview[^7] |
+| `azure-ai-projects` (1.x GA) | Classic experience | Same | Stable[^7] |
+| `openai` | Chat completions, responses, conversations | `.openai.azure.com/openai/v1` | Stable[^7] |
+| Foundry Tools SDKs | Speech, Vision, Language, Content Safety | Tool-specific | Stable |
+| Agent Framework | Multi-agent orchestration (cloud-agnostic) | Via project endpoint | Preview |
+
+### The Azure AI Inference Question
+
+From your open questions: **"Is Azure AI Inference deprecated now that GitHub Models is no longer using it?"**
+
+**Yes.** The `azure-ai-inference` beta SDK is deprecated with a retirement date of **May 30, 2026**[^8]. Microsoft recommends migrating to the OpenAI SDK (`openai` package), which provides the same chat completions and embeddings capabilities through the `/openai/v1` endpoint. GitHub Models now uses the OpenAI SDK directly. The migration is minimal — mostly changing import statements and endpoint URLs.
+
+### SDK Version ↔ Portal Version Mapping
+
+This is a critical detail from `sdk-overview.mdx`[^7]:
+
+| SDK Version | Portal Version | Status |
+|---|---|---|
+| `azure-ai-projects` 2.x (preview) | Foundry (new) | Preview |
+| `azure-ai-projects` 1.x (GA) | Foundry (classic) | Stable |
+
+Customers using the wrong SDK version for their portal experience will encounter confusing errors. This mapping must be prominent.
+
+### Recommendation
+
+- **Create a "SDK Migration Matrix"** showing old SDK → new SDK for each use case
+- **Answer the Azure AI Inference question explicitly** in a deprecation notice or FAQ
+- **Emphasize the SDK ↔ Portal version mapping** in quickstart and getting-started content
+
+---
+
+## Axis 7: Terminology Changes
+
+### Comprehensive Terminology Table
+
+This is the table you started — here it is completed and verified against the codebase:
+
+| Concept | Classic Term | New Term | Notes |
+|---------|-------------|----------|-------|
+| **Conversation state** | Threads | Conversations | Conversations store items (messages, tool calls, outputs), not just messages[^6] |
+| **Chat messages** | Messages | Items | Items are a superset of messages[^6] |
+| **Execution** | Runs (async, polled) | Responses (sync by default) | No polling loop needed[^6] |
+| **Agent definition** | Assistants / Agents | Agent Versions | Versioned, with explicit `kind` (prompt, workflow, hosted)[^6] |
+| **Portal settings** | Management Center | Admin Console | Portal navigation rename |
+| **AI services** | Azure AI Services | Foundry Tools | Speech, Vision, Language, Content Safety, Content Understanding |
+| **Agent creation** | `create_agent()` | `create_version()` | Uses `PromptAgentDefinition`[^6] |
+| **API wire protocol** | Assistants API | Responses API | OpenAI-driven change; Assistants sunset Aug 2026[^5] |
+| **API versioning** | Monthly `api-version` params (e.g., `2024-10-21`) | v1 stable routes (`/openai/v1/...`), no version param | Platform pace-of-innovation change[^14] |
+| **Client library** | `AzureOpenAI()` — Azure-specific | `OpenAI()` — standard, with `base_url` for Azure | Eliminates Azure-specific code[^14] |
+| **Resource type** | Azure OpenAI + Hub | Foundry Resource | Single `AIServices` kind[^4] |
+| **RBAC roles** | Cognitive Services OpenAI User | Azure AI User, Azure AI Project Manager, Azure AI Owner | New Foundry-specific roles with control/data plane separation[^9] |
+| **Policies** | Azure AI Services policies | Foundry policies | Same `Microsoft.CognitiveServices` provider; policies being renamed[^10] |
+| **Model billing** | Model-as-a-Service (MaaS) | Foundry Direct Models | First-party models billed directly via Azure meters[^11] |
+| **Portal (main)** | Mainline / OAI sub-studio | Classic | Internal "Mainline" name not customer-facing |
+| **Portal (new)** | — | NextGen → Foundry (new) | Internal "NextGen" name not customer-facing |
+
+### Recommendation
+
+- **Publish this table as a standalone reference page** (e.g., "Terminology: Classic vs. New")
+- **Link it from migration guides, FAQs, and the glossary**
+- **Include both old and new terms in the glossary** (`glossary.mdx` currently defines "Conversation" implicitly but not the mapping from "Thread")[^12]
+
+---
+
+## Axis 8: Model Billing Evolution
+
+| Aspect | Classic (MaaS) | New (Foundry Direct) |
+|--------|---------------|---------------------|
+| **Who hosts** | Microsoft-managed GPU pools | Dedicated VMs or Microsoft-managed |
+| **Billing unit** | Tokens (input/output) | VM core hours or tokens depending on deployment type |
+| **Billing path** | Azure Marketplace for partners | Azure meters (first-party) |
+| **Model scope** | Azure OpenAI models only | Azure OpenAI + DeepSeek + Meta + xAI + Mistral + Microsoft + Black Forest Labs[^4] |
+| **Provisioned throughput** | PTUs per model | Fungible PTUs across Foundry Direct Models |
+
+### Recommendation
+
+- This is the least well-documented transition axis. Create a "Model Billing Explained" page
+- Clarify that pay-per-token still exists for standard deployments; "Foundry Direct" is about billing path, not pricing model
+
+---
+
+## Differentiating from Copilot Studio and M365 Copilot
+
+This is a critical messaging need. Here is a decision framework:
+
+| Dimension | Microsoft Foundry | Copilot Studio | M365 Copilot |
+|-----------|------------------|----------------|--------------|
+| **Target user** | Developers, ML engineers | Business users, IT pros, pro-makers | End users |
+| **Development model** | Code-first (SDKs, CLI, VS Code) | Low-code (visual designer, connectors) | No development |
+| **Agent complexity** | Multi-agent systems, custom models, fine-tuning | Departmental chatbots, workflows | Built-in AI assistant |
+| **Infrastructure** | Full Azure control (VNETs, compute, BYO resources) | Fully managed SaaS | Embedded in M365 |
+| **Integrations** | Deep Azure + multi-cloud + custom code | M365 + Power Platform connectors | M365 Graph only |
+| **Deployment targets** | Azure, containers, any cloud | Teams, Outlook, web | M365 apps |
+| **Pricing model** | Consumption (tokens, compute hours) | Capacity-based (messages/month) | Per-user license |
+
+### The Hybrid Pattern
+
+The most powerful messaging for enterprises: **build backend logic in Foundry, compose user-facing experiences in Copilot Studio**. This is the bridge between the two platforms and should be documented as a first-class pattern[^13].
+
+### Recommendation
+
+- **Create a "Foundry vs. Copilot Studio vs. M365 Copilot" comparison page** (this is in your open items)
+- **Lead with the persona** ("Who are you?") rather than the technology
+- **Document the hybrid pattern** as a recommended architecture
+
+---
+
+## Proposed Documentation Structure for the Evolution
+
+Based on the analysis, here is a recommended documentation structure for addressing the Classic → New transition:
+
+### 1. Landing Page: "What is Foundry" (exists, needs refinement)
+
+- Who is it for (developer personas)
+- Discovery → Build → Operate lifecycle
+- Link to Classic docs for customers not yet migrated
+
+### 2. Understanding the Evolution (new section)
+
+```
+setup/
+├── evolution/
+│   ├── classic-vs-new-overview.mdx          # Single entry point
+│   ├── terminology-mapping.mdx              # The big terminology table
+│   ├── feature-comparison.mdx               # Feature support matrix
+│   ├── agent-api-versions.mdx               # Assistants → Agents v2 lineage
+│   └── sdk-migration-matrix.mdx             # Which SDK replaces what
+```
+
+### 3. Migration Guides (consolidate once NextGen GA)
+
+```
+setup/
+├── migrate/
+│   ├── overview.mdx                         # "Which migration path do I need?"
+│   ├── aoai-to-foundry.mdx                  # Azure OpenAI → Foundry resource (exists as upgrade-azure-openai.mdx)
+│   ├── hub-to-foundry.mdx                   # Hub-based projects → Foundry projects
+│   ├── agents-v1-to-v2.mdx                  # Agents v1 → v2 (exists as migrate.mdx)
+│   ├── api-version-to-v1.mdx               # Monthly api-versions → v1 routes (exists as api-version-lifecycle.mdx)
+│   └── sdk-migration.mdx                    # azure-ai-inference → openai SDK
+```
+
+### 4. Blog Posts Needed
+
+| Blog | Purpose | Owner |
+|------|---------|-------|
+| "V1/V2 Terminology Table" | Customer-facing terminology mapping with examples | (Dennis) |
+| "Why Foundry, not Copilot Studio?" | Persona-based decision guide | (Nick) |
+| "The OpenAI Responses API: What It Means for Foundry Developers" | Explain the Assistants → Responses migration in context | (Dennis/Dan) |
+| "From Hub to Foundry: A Migration Story" | Customer-facing narrative of what changed and why | (Nick) |
+
+---
+
+## Complete "Classic vs. New" Alignment Table (Refined)
+
+This is the refined version of the table from your initial draft, with corrections and additions based on research:
+
+| Dimension | Classic | New | Migration Effort |
+|-----------|---------|-----|-----------------|
+| **Agent service** | Agents v0.5 (Assistants API on AOAI), Agents v1 (Assistants API on Agent Service) | Agents v2 (Responses API on Agent Service) | Medium — code changes required[^6] |
+| **Inference shape** | Chat Completions API | Responses API (Chat Completions still available) | Low — additive, not breaking |
+| **API versioning** | Monthly `api-version` params (`2024-03-01-preview` through `2025-04-01-preview`) | v1 stable routes (`/openai/v1/`); preview features via headers | Low — 3-line code change; opt-in[^14] |
+| **Client library** | `AzureOpenAI()` client (Azure-specific) | `OpenAI()` client with `base_url` (standard) | Low — drop-in replacement[^14] |
+| **UX experience** | Mainline portal → label as "(classic)" | NextGen portal → label as "(new)" | N/A — toggle switch |
+| **Threads** | Threads (message-only) | Conversations (items: messages, tool calls, outputs) | Medium — structural change[^6] |
+| **Messages** | Messages (in threads) | Items (in conversations) | Low — superset |
+| **Execution** | Runs (async polling) | Responses (sync by default) | Medium — pattern change[^6] |
+| **Portal settings** | Management Center | Admin Console | N/A — UI rename |
+| **AI services branding** | Azure AI Services | Foundry Tools | N/A — name change |
+| **Resource model** | Hub + AOAI + AI Services (multiple resources) | Foundry Resource (single, with child projects) | Low — upgrade path exists[^4] |
+| **Agent API** | Assistants API (OpenAI wire protocol) | Agents API (Responses wire protocol) | High — wire protocol change |
+| **RBAC roles** | Cognitive Services OpenAI User, Cognitive Services User | Azure AI User, Azure AI Project Manager, Azure AI Owner | Medium — review assignments[^9] |
+| **Model billing** | MaaS (Marketplace for partners, per-token for AOAI) | Foundry Direct Models (Azure meters, fungible PTUs) | Low — billing path change |
+| **Documentation** | Domain-specific (Speech, Language, Vision separate) | Foundry-centric with branches to domain-specific | N/A — docs restructure |
+| **SDK (Python)** | `azure-ai-inference`, `azure-ai-generative`, `azure-openai` | `azure-ai-projects` (2.x), `openai`, Foundry Tools SDKs | Medium — package swap |
+| **Azure Policies** | `Azure AI Services` namespace | `Foundry` namespace (rename in progress) | Low — policy rename[^10] |
+
+---
+
+## Open Questions — Answers
+
+### "Is Azure AI Inference deprecated now that GitHub Models is no longer using it?"
+
+**Yes.** The `azure-ai-inference` SDK (Python, .NET, JS) is deprecated with a retirement date of **May 30, 2026**[^8]. The recommended migration target is the `openai` SDK package, which provides the same inference capabilities (chat completions, embeddings) through the `/openai/v1` endpoint on Foundry resources. The migration is straightforward — mostly changing import statements and endpoint configuration. GitHub Models now uses the OpenAI SDK directly.
+
+---
+
+## Recommended Action Items (Aligned to Migration Phases)
+
+### Phase 1 — Before March 17 (NextGen GA Announcement)
+
+1. **Ensure docs-vnext is production-ready** — all pages in the NextGen TOC are live and reviewed
+2. **Publish the terminology mapping table** as a standalone reference page
+3. **Rename all "Mainline" references to "Classic"** in customer-facing content
+4. **Answer the Azure AI Inference deprecation question** in a deprecation notice
+5. **Create the feature comparison matrix** (Classic vs. New portal capabilities)
+6. **Document the toggle-back flow** — users need to know they can return to Classic
+
+### Phase 1 → Phase 2 Transition (March–April 2026)
+
+7. **Label the Classic portal as "Classic"** consistently in UI, docs, and blog posts
+8. **Publish the V1/V2 terminology blog post** (owner: Dennis)
+9. **Publish the "Why Foundry, not Copilot Studio?" comparison** (owner: Nick)
+10. **Document the default-project API key behavior** — critical for AOAI upgrade users
+11. **Document the assistants playground redirect** — users upgrading from AOAI need to know where to find assistants in Mainline
+
+### Phase 2 (AOAI → FDP Migration, March 2026 – March 2027)
+
+12. **Consolidate migration guides** under a single section with a "Which migration do I need?" entry point
+13. **Create the "What is changing and why" customer-facing narrative article** (owner: Nick)
+14. **Align Azure Portal display names** with Classic/New terminology
+15. **Update landing page** to lead with the Discovery → Build → Operate lifecycle
+16. **Publish the "From AOAI to Foundry" blog post** — explaining the auto-upgrade process, rollback options, and what changes
+
+### Phase 3 (Hub Deprecation, TBD ~April 2026+)
+
+17. **Create hub-to-Foundry migration guide** (does not yet exist)
+18. **Publish Agents v0.5 deprecation notice** — needs an owner
+19. **Document the ML Studio routing** for MaaP and Prompt Flow customers
+20. **Publish Foundry Tools studio retirement comms** (Language Studio, Speech Studio, etc.)
+
+### Phase 4 (Legacy Retirement, TBD)
+
+21. **Archive/remove classic docs** (owner: Amir/Sheri per migration plan)
+22. **Redirect ai.azure.com to NextGen** (owner: Shané/Sean per migration plan)
+23. **Remove Azure Portal AOAI view** (owner: Varsha per migration plan)
+
+---
+
+## The Four-Phase Migration Plan
+
+The all-up migration plan — authored by Amir Zur, Dennis Eikelenboom, and Shané Winner — provides the authoritative roadmap for how everything in this report comes together operationally[^18]. The plan resolves the core ambiguity: this is not one migration but **four sequential phases**, each with distinct customer cohorts, entry/exit criteria, and KPIs.
+
+### Phase Overview
+
+```
+Phase 1                Phase 2                Phase 3               Phase 4
+─────────────          ─────────────          ─────────────         ─────────────
+NextGen GA             AOAI → FDP             Hub Deprecation       Retire Legacy
+for FDP users          + NextGen              + Foundry Tools       Experiences
+                                              → FDP + NextGen
+Mar 13 → Mar 17       Mar '26 → Mar '27      TBD (Apr '26+)        TBD
+─────────────          ─────────────          ─────────────         ─────────────
+  Low impact            Moderate-High          Moderate              High
+  (toggle back)         (resource change)      (destination change)  (hard cutoff)
+```
+
+### Phase 1: NextGen GA for FDP Customers (March 13–17, 2026)
+
+**Goal:** Make NextGen the trusted default for FDP (Foundry Data Platform) customers with GA quality.
+
+| Milestone | Description | Target | KPI |
+|-----------|-------------|--------|-----|
+| M0 (Done) | Users can opt-in to NextGen via toggle | Live | 12% of Mainline users using NextGen |
+| M1 | NextGen GA — FDP users default to NextGen, can toggle back | **March 13** (announced March 17) | 30% of Mainline users using NextGen |
+| M2 | Full Mainline parity for FDP; toggle removed after KPIs met | Post-GA | Error rates < 1%, retention targets met |
+
+**Key M1 blockers being resolved:**
+- API key support for project-scoped resources (short-term: API-key access for default project only)
+- UX continuity for vector stores, files, and assistants created in Mainline
+- Agents V2 GA
+- OAI v1 endpoint discoverability from NextGen UX
+
+**Critical nuance:** Hub projects and AOAI-only resources remain **Mainline-only** in Phase 1. NextGen shows only Foundry projects.
+
+### Phase 2: AOAI → FDP + NextGen (March 2026 – March 2027)
+
+**Goal:** Move the largest legacy cohort (Azure OpenAI customers) onto the Foundry resource type and NextGen portal.
+
+| Milestone | Description | Target |
+|-----------|-------------|--------|
+| M3 | Any AOAI user can opt-in to upgrade to Foundry + land in NextGen | Post-Phase 1 |
+| M4 | Auto-upgrade all AOAI customers; rollback available; opt-out via Policy | TBD (gating metrics must be met) |
+
+**Auto-upgrade gating metrics (draft):**
+- Parity + no experience cliffs
+- Rollback rate < 0.6%
+- 30-day retention post-upgrade on par with AOAI baseline
+- 15%+ MoM token growth
+- Non-OAI model/feature attach
+- ICM and support case volume stable
+
+**Critical risk:** DSAT because NextGen alternatives for OAI sub-studio provide same functionality but not same API surface in the UX (e.g., Agents instead of OAI Assistants, Foundry evals over OAI evals, AI Search index over OAI vector store). The API still supports all legacy patterns.
+
+### Phase 3: Hub Deprecation + Foundry Tools Migration (TBD, ~April 2026+)
+
+**Goal:** Consolidate the Hub fork by transitioning Foundry Tools / managed compute customers.
+
+| Milestone | Description | Target |
+|-----------|-------------|--------|
+| M5 | Deprecate Hub once Foundry Hosting (MaaP) lands | Target: April 30 (depends on Foundry Hosting GA) |
+| M6 | NextGen becomes default for Language, Translator, Content Understanding, Speech | Target: April 30 (pending AI Services alignment) |
+
+**Critical dependencies:**
+- Foundry Hosting (MaaP) GA timeline has slipped (Feb → Apr → Build)
+- Agents v0.5 in preview on Hub has never been retired; needs owner for deprecation
+- Language team is *increasing* Hub dependency for Language Studio retirement — conflicts with Hub phase-out
+- ML Studio continuation strategy needs clarity (are MaaP and Prompt Flow customers routed to ML Studio or NextGen?)
+
+### Phase 4: Retire Legacy Experiences (TBD)
+
+**Goal:** Remove Mainline, legacy studios, and legacy resource types entirely.
+
+**Workstreams:**
+1. **Retire Mainline** — remove toggle, remove Classic docs, redirect ai.azure.com to NextGen, remove Azure Portal AOAI view
+2. **Retire 1keyv1 (kind=CognitiveServices)** — depends on Azure AI Search dependency resolution (Target: September 2027)
+3. **Retire Azure Speech resource type** — auto-upgrade all Speech customers to FDP
+4. **Retire Azure Language resource type** — auto-upgrade all Language customers to FDP
+
+**Open questions:**
+- Target date for shutting down Mainline experience
+- Cross-org retirement date for all legacy resource types and studios
+- Strategy for Azure ML workspace continuation and Foundry Horizon
+
+### What the Migration Plan Means for Documentation
+
+The four-phase plan directly informs what documentation needs to exist and when:
+
+| Phase | Docs Action |
+|-------|-------------|
+| **Phase 1 (Now)** | NextGen GA docs (docs-vnext) must be production-ready by March 13. "What is Foundry" page updated. Toggle-back guidance documented. |
+| **Phase 2** | AOAI → Foundry upgrade guide (exists as `upgrade-azure-openai.mdx`). Must address: default project API key behavior, assistants playground redirect to Mainline, OAI vector store → AI Search transition. |
+| **Phase 3** | Hub → ML Studio routing docs. Agents v0.5 deprecation notice. Foundry Tools studio retirement comms. **Hub-to-Foundry migration guide** (does not yet exist). |
+| **Phase 4** | Classic docs archived. Redirect documentation. Migration completion verification guides. |
+
+---
+
+## Key Stakeholder Domains
+
+| Person | Domain | What They Uniquely Know |
+|--------|--------|------------------------|
+| **Bala** | Foundry API | API design decisions, project endpoint routing, Foundry API architecture, API key auth scoping, data plane architect decisions |
+| **Dan** | Foundry SDKs | SDK 1.x→2.x migration specifics, language parity (Python/C#/JS/Java), Agent Framework orchestration, SDK deprecation timelines |
+| **Jeff** | Foundry Agent Service | Agent v1→v2 backend evolution, Agents v0.5 retirement plan, hosted agent architecture, A2A protocol integration, agent identity model |
+| **Marco** | Horizontal platform | Cross-cutting concerns: how all the pieces fit together, Foundry Hosting (MaaP) strategy, ML Studio continuation, Foundry Horizon plans, resource type consolidation strategy |
+
+---
+
+## Naming Lineage Confirmed
+
+Per your clarification, the naming lineage for "Foundry Tools" is:
+
+> **Cognitive Services** (original) → **Azure AI Services** (rebranding) → **Foundry Tools** (current)
+
+These were announced at successive Build/Ignite events. This confirms that "Foundry Tools" is the current name for the collection of domain-specific AI services (Speech, Vision, Language, Content Understanding, Content Safety), **not** the Foundry resource type itself. The `multi-service-resource.mdx` phrasing ("renaming of former 'Foundry Tools'") is misleading and should be clarified.
+
+## Documentation Architecture Confirmed
+
+The dual-docs model is intentional:
+
+| Docs Version | Maps To | Content Scope |
+|-------------|---------|---------------|
+| `foundry-classic` | Hubs, Agents v1, Mainline portal | Legacy resource types, Assistants API, hub-based projects |
+| `foundry` (docs-vnext) | Projects, Agents v2, NextGen portal | Foundry resource type, Responses API, Foundry projects |
+
+Per Phase 4, Classic docs will eventually be **removed** (not just archived) — this is listed as a Phase 4 deliverable: "Remove classic docs (Amir/Sheri)."
+
+---
+
+## Confidence Assessment
+
+### High Confidence
+- Branding timeline (Azure AI Studio → Azure AI Foundry → Microsoft Foundry) — confirmed across multiple sources
+- Agent API evolution and wire protocol changes — confirmed in `migrate.mdx`[^6] and Dennis's blog[^1]
+- **v1 API evolution from monthly `api-version` parameters** — confirmed in `api-version-lifecycle.mdx`[^14] with complete changelog, code examples, and GA surface
+- **`AzureOpenAI()` → `OpenAI()` client migration** — confirmed with code examples across 6 languages in `api-version-lifecycle.mdx`[^14]
+- SDK evolution and deprecation of `azure-ai-inference` — confirmed by Microsoft Learn docs[^8]
+- OpenAI Assistants API sunset (August 26, 2026) — confirmed by OpenAI[^5]
+- Resource model changes — confirmed in `upgrade-azure-openai.mdx`[^4] and `sdk-overview.mdx`[^7]
+- Portal duality (Classic/New) — confirmed in `what-is-foundry.mdx`[^3]
+- **Industry shift from model-centric to agent-centric** — confirmed by model release cadence data, reasoning model timeline (o1-preview Sept 2024, o1 Dec 2024, o3/o4-mini 2025), and Foundry's architectural response
+- **NextGen GA date: March 13 (announced March 17)** — confirmed from internal migration plan[^18]
+- **Four-phase migration plan with milestones** — confirmed from internal migration plan[^18]
+- **Naming lineage: Cognitive Services → Azure AI Services → Foundry Tools** — confirmed by user input citing Build/Ignite announcements
+- **Stakeholder domains: Bala (API), Dan (SDKs), Jeff (Agent Service), Marco (horizontal platform)** — confirmed by user input
+- **Dual-docs model (foundry-classic / foundry) is intentional** — confirmed by user input and Phase 4 plan to remove classic docs
+
+### Medium Confidence
+- "Foundry Direct Models" billing details — the distinction between MaaS and Foundry Direct is documented but the exact billing changes are still evolving
+- Azure Policy namespace rename from "Azure AI Services" to "Foundry" — referenced in your alignment table but the `policy-reference.mdx` page is currently minimal[^10]
+- Hub deprecation timeline — Phase 3 targets April 30 but depends on Foundry Hosting GA, which has slipped multiple times[^18]
+- AOAI auto-upgrade timeline — Phase 2 milestone 4 has gating metrics but no firm date[^18]
+
+### Lower Confidence
+- Phase 4 timelines — "TBD" across all workstreams; depends on Phase 2-3 completion
+- 1keyv1 (kind=CognitiveServices) retirement — target September 2027, but depends on Azure AI Search dependency resolution[^18]
+- ML Studio continuation strategy and Foundry Horizon — listed as "help needed" in the migration plan
+- "Admin Console" as replacement for "Management Center" — still not confirmed in docs; may be "Operate" section in NextGen
+
+---
+
+## Footnotes
+
+[^1]: Dennis Drews, "Build Recap: New Azure AI Foundry Resource, Developer APIs, and Tools," Microsoft Tech Community, May 2025. https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/build-recap-new-azure-ai-foundry-resource-developer-apis-and-tools/4427241
+
+[^2]: Perplexity research citing Microsoft Ignite 2025 announcements and market coverage confirming November 2025 rebranding from Azure AI Foundry to Microsoft Foundry.
+
+[^3]: `docs-vnext/overview/what-is-foundry.mdx` — Lines 1-89 in the foundry-docs repository.
+
+[^4]: `docs-vnext/setup/upgrade-azure-openai.mdx` — Lines 1-338 in the foundry-docs repository. Documents the AOAI → Foundry upgrade path, resource type (`AIServices`), and three FQDNs.
+
+[^5]: OpenAI Community announcement: "Assistants API Beta Deprecation — August 26, 2026 Sunset." https://community.openai.com/t/assistants-api-beta-deprecation-august-26-2026-sunset/1354666
+
+[^6]: `docs-vnext/setup/migrate.mdx` — Lines 1-505 in the foundry-docs repository. Documents Threads→Conversations, Runs→Responses, and the dual-client pattern.
+
+[^7]: `docs-vnext/api-sdk/sdk-overview.mdx` — Lines 1-80 in the foundry-docs repository. Defines the SDK table (Foundry SDK, OpenAI SDK, Foundry Tools SDKs, Agent Framework) and the 2.x vs 1.x version mapping.
+
+[^8]: Microsoft Learn, "Endpoints for Azure AI Foundry Models" — deprecation notice for azure-ai-inference SDK with May 30, 2026 retirement date. https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints
+
+[^9]: `docs-vnext/security/rbac-foundry.mdx` — Lines 1-60 in the foundry-docs repository. Documents new built-in roles (Azure AI User, Azure AI Project Manager, Azure AI Owner).
+
+[^10]: `docs-vnext/security/policy-reference.mdx` — Lines 1-21 in the foundry-docs repository. Currently minimal; Azure Policy definitions are being renamed from "Azure AI Services" to "Foundry Tools."
+
+[^11]: Microsoft Learn, "Models sold directly by Azure" — Foundry Direct Models documentation. https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure
+
+[^12]: `docs-vnext/glossary.mdx` — Lines 1-189 in the foundry-docs repository. Defines current terms but does not include migration mappings from deprecated terms.
+
+[^13]: Microsoft Tech Community, "Microsoft Copilot Studio vs. Microsoft Foundry: Building AI Agents and Apps." https://techcommunity.microsoft.com/blog/microsoft-security-blog/microsoft-copilot-studio-vs-microsoft-foundry-building-ai-agents-and-apps/4483160
+
+[^14]: `docs-vnext/api-sdk/api-version-lifecycle.mdx` — Lines 1-605 in the foundry-docs repository. Documents the v1 API evolution from monthly `api-version` parameters, the complete API version changelog, v1 GA API surface, preview header mechanism, and code examples showing `AzureOpenAI()` → `OpenAI()` migration across Python, C#, JavaScript, Go, Java, and REST.
+
+[^15]: Upstream API provider, "Migrate to the Responses API" guide (`/api/docs/guides/migrate-to-responses/`). Documents: Responses API as "recommended for all new projects"; 3% SWE-bench improvement; 40–80% cache utilization improvement; agentic loop with built-in tools; Chat Completions vs Responses capability matrix; Assistants API deprecation (Aug 26, 2025) with sunset Aug 26, 2026. Quote: "The Responses API represents the future direction for building agents."
+
+[^16]: Upstream API provider, "Assistants Migration Guide" (`/api/docs/assistants/migration/`). Documents: Assistants→Prompts, Threads→Conversations, Runs→Responses, Run Steps→Items mapping; practical migration steps; side-by-side code examples for user chat apps, function-calling apps, and thread backfill; Conversations API as replacement for Threads.
+
+[^17]: Upstream API provider, "Better performance from reasoning models using the Responses API" cookbook (`/cookbook/examples/responses_api/reasoning_items/`). Documents: reasoning item preservation across tool-calling turns; 3% SWE-bench improvement from including reasoning items; cache utilization improvement (40% to 80%); encrypted reasoning items for ZDR/compliance organizations; reasoning summaries feature. [openai/openai-cookbook](https://github.com/openai/openai-cookbook) `examples/responses_api/reasoning_items.ipynb`.
+
+[^18]: Internal document, "Foundry All-Up Migration Plan" (Amir Zur, Dennis Eikelenboom, Shané Winner). Documents the four-phase migration plan: Phase 1 (NextGen GA for FDP, March 13), Phase 2 (AOAI → FDP + NextGen, March '26–March '27), Phase 3 (Hub deprecation + Foundry Tools migration, TBD ~April '26), Phase 4 (Retire legacy experiences, TBD). Includes milestone definitions, gating metrics, blockers, risks, and owner assignments.

--- a/local/pm-mode/gap-analysis.md
+++ b/local/pm-mode/gap-analysis.md
@@ -1,0 +1,272 @@
+# Gap Analysis: Where the Research Needs Your Input
+
+## Executive Summary
+
+After auditing all eight axes of the current research report against the docs-vnext codebase, the original alignment table from your team, publicly available sources, and the limits of what I can fetch/discover, I identified **five axes with significant gaps** where your insider context would materially improve the report, plus **three potential missing axes** that the current framework doesn't cover at all. The gaps fall into two categories: (1) information that exists internally but isn't public/documented, and (2) evolving decisions that only the team can speak to.
+
+---
+
+## Axes with Gaps (Where Your Input Would Help)
+
+### Gap 1: Axis 2 (Portal UX) — NextGen GA Timeline & Feature Parity Plan
+
+**What the report says:** The Classic/New portal distinction is well-documented. The report recommends labeling Classic "the moment NextGen goes GA."
+
+**What I cannot determine:**
+
+- **When is NextGen GA?** No public commitment found. The report flags this as "Lower Confidence." This is the single most important timeline for the entire documentation plan — every action item hinges on it.
+- **What's the feature parity plan?** The docs-vnext `what-is-foundry.mdx` says "Only Foundry projects are visible here — use (classic) for all other resource types."[^1] But the report doesn't capture:
+  - Will Classic eventually be deprecated entirely, or will it persist indefinitely as the "power user" portal?
+  - What's the disposition of **hub-based projects** — deprecated? Frozen? Migration-required?
+  - Dennis's blog says "hub-based project type remains accessible"[^2] but new investments are "Foundry project" only — is there a sunset date for hubs?
+- **Azure Portal display alignment** — your alignment table calls out "Azure Portal display should align with classic vs new" and "Azure Portal landing page should align." What specifically needs to change in the Azure Portal (as opposed to ai.azure.com)?
+
+**What you could provide:**
+- NextGen GA timeline (even approximate: Q1 2026? Q2?)
+- Hub-based projects disposition plan
+- Azure Portal changes that are planned/in-flight
+
+**Confidence: LOW** — I'm guessing at timelines and can't determine internal roadmap decisions.
+
+---
+
+### Gap 2: Axis 5 (Resource Model) — The Hub → Foundry Project Migration Path
+
+**What the report says:** AOAI → Foundry upgrade is well-documented (`upgrade-azure-openai.mdx`). The resource model diagram is accurate.
+
+**What I cannot determine:**
+
+- **Hub → Foundry project migration** is listed in your "once NextGen GA" migration section but **no migration guide exists yet** in docs-vnext. The current `migrate.mdx` covers Agents v1→v2 only.[^3] There's no `hub-to-foundry.mdx`.
+- **What happens to existing hub resources?** The `architecture.mdx` page documents the new Foundry resource types but doesn't address:
+  - Do hubs continue to work indefinitely?
+  - Is there an automated migration tool planned?
+  - What data/state carries over vs. must be recreated?
+  - What about Azure Machine Learning workspaces that were connected to hubs?
+- **The `multi-service-resource.mdx` page** mentions Foundry resource is "the next version and renaming of former 'Foundry Tools'"[^4] — this is itself confusing. Is "Foundry Tools" the new name for Azure AI Services, or for the Foundry resource? The terminology is inconsistent.
+
+**What you could provide:**
+- Hub deprecation/sunset timeline and plan
+- Whether a hub→Foundry migration tool is planned
+- Clarification of "Foundry Tools" vs "Foundry resource" naming (these seem to be used inconsistently)
+
+**Confidence: MEDIUM** — The AOAI → Foundry upgrade path is clear; the hub → Foundry path is completely absent.
+
+---
+
+### Gap 3: Axis 7 (Terminology) — "Management Center" → "Admin Console" & Foundry Tools Naming
+
+**What the report says:** The terminology table lists "Management Center → Admin Console" as a portal navigation rename.
+
+**What I cannot determine:**
+
+- **Is "Admin Console" the actual name?** I searched docs-vnext for "Admin Console" and found zero hits. The Classic portal uses "Management Center" in navigation. The New portal doesn't appear to use either term — it uses "Operate" as the section name[^5]. Your alignment table says "Admin Console" but this might be an internal/planned name that hasn't landed yet.
+- **"Foundry Tools" confusion:** The term "Foundry Tools" appears in docs-vnext with at least three different meanings:
+  1. The collection of domain-specific AI services (Speech, Vision, Language, Content Safety, Content Understanding) — as in "Foundry Tools SDKs"[^6]
+  2. The Azure resource type itself — as in `multi-service-resource.mdx` saying Foundry resource is "renaming of former 'Foundry Tools'"[^4]
+  3. The policy namespace — as in "Azure Policy built-in definitions for Foundry Tools"[^7]
+  
+  This triple-use of "Foundry Tools" is a conflation point the report doesn't call out.
+
+**What you could provide:**
+- Confirm the correct replacement for "Management Center" — is it "Admin Console" or "Operate" or something else?
+- Clarify whether "Foundry Tools" refers to (a) AI services collection, (b) resource type, or (c) both — and whether this naming collision is intentional
+- Any other terminology changes in the New portal not captured in the table (e.g., "Playground" → ?)
+
+**Confidence: LOW** on "Admin Console"; **HIGH** on the "Foundry Tools" naming confusion being a real problem.
+
+---
+
+### Gap 4: Axis 8 (Billing) — This Axis Is Thin
+
+**What the report says:** A brief table comparing MaaS vs Foundry Direct. The report already acknowledges this is "the least well-documented transition axis."
+
+**What I cannot determine:**
+
+- **Foundry Direct Models billing specifics:** The docs reference "models sold directly by Azure"[^8] and mention fungible PTUs, but the actual billing model differences are vague. Questions I can't answer:
+  - Does Foundry Direct change the pricing for customers already using Azure OpenAI standard deployments?
+  - How does billing work for non-OpenAI models (DeepSeek, Grok, Meta) — are these billed through Azure meters or still through Marketplace?
+  - What's the actual customer impact of the billing path change? Is it just "the invoice looks different" or are there pricing implications?
+- **Agent Service billing:** The FAQ says you're charged for model inference + Code Interpreter sessions + File Search vector storage[^9]. But the "new" experience adds:
+  - Hosted agents (preview) — how are these billed? The `hosted-agents.mdx` says "See Limits, pricing, and availability (preview)" but the section is sparse.
+  - Memory (GA in new) — is this free or billable?
+  - Multi-agent workflows — is there per-agent or per-workflow pricing?
+  - Foundry IQ — preview pricing model?
+
+**What you could provide:**
+- Clarification on Foundry Direct Models billing vs. classic MaaS
+- Hosted agent pricing model
+- Any net-new billing meters in the "New" experience
+- Whether the billing change is transparent to existing customers or requires action
+
+**Confidence: LOW** — Billing is the weakest axis by far.
+
+---
+
+### Gap 5: Axis 3 (Agent API) — The "Bala" and "Dan" Inputs
+
+**What the report says:** Comprehensive coverage of the Assistants→Responses wire protocol change, the dual-client pattern, and upstream migration rationale.
+
+**What I cannot determine:**
+
+Your original alignment table specifically calls out:
+- **"Bala - Align Agent v1/v2"** — What specific alignment is needed from Bala? Is this about the backend service evolution, the v1→v2 mapping for specific features, or something else?
+- **"Bala's inputs" in next steps** — What context does Bala have that's not in the docs?
+- **"Dan's inputs" in next steps** — Same question.
+- **"Jeff" and "Marco" in next steps** — What are their areas of input?
+
+Additionally, the **Agent Framework** (for multi-agent orchestration in code) is mentioned briefly in the SDK table but doesn't have its own axis or section. This is a major new capability (workflows, A2A protocol, hosted agents) that exists only in the "New" experience:
+
+| New-Only Agent Capability | Status |
+|--------------------------|--------|
+| Multi-agent workflows (UI-based) | GA[^10] |
+| Agent Framework (code-based orchestration) | Preview |
+| Hosted agents (containerized) | Preview[^11] |
+| Agent-to-Agent (A2A) protocol | Preview[^12] |
+| Agent publishing to M365/Teams | GA[^13] |
+| Agent identity (Entra Agent ID) | GA |
+| Foundry Control Plane (fleet management) | Preview[^14] |
+
+These "New-only" agent capabilities are a major selling point for migration and currently get no dedicated coverage in the report.
+
+**What you could provide:**
+- Bala's, Dan's, Jeff's, and Marco's specific input areas
+- Whether the Agent Framework / multi-agent story deserves its own axis or section in the evolution narrative
+- The "Agent Factory" / "Discovery → Build → Operate" lifecycle framing — is this the official customer-facing framework?
+
+**Confidence: MEDIUM** on the agent capabilities inventory; **LOW** on what Bala/Dan/Jeff/Marco need to contribute.
+
+---
+
+## Potentially Missing Axes
+
+### Missing Axis A: Observability & Evaluation Evolution
+
+The report mentions observability in passing but doesn't capture it as a transition axis. The "New" experience introduces significant observability changes:
+
+| Dimension | Classic | New |
+|-----------|---------|-----|
+| Tracing | SDK-based tracing with Application Insights | Built-in trace capture + Application Insights |
+| Evaluations | `azure-ai-evaluation` SDK | Built-in evaluators in Foundry API + SDK |
+| Agent metrics | Limited | Dedicated agent monitoring dashboard[^15] |
+| Continuous evaluation | Not available | Python SDK-based continuous eval[^16] |
+| AI Red Teaming | Not available | AI Red Teaming Agent[^17] |
+| Foundry Control Plane | Not available | Fleet-wide observability[^14] |
+
+**Should this be Axis 9?** Only if the observability changes are substantial enough to cause customer confusion or require migration. If evaluations code from 1.x SDK works differently in 2.x, that's a migration axis.
+
+**What you could provide:** Is the evaluation SDK migration significant enough to warrant its own axis? Are there breaking changes in how tracing/eval works between classic and new?
+
+---
+
+### Missing Axis B: Multi-Agent & Orchestration Architecture
+
+The "New" Foundry introduces an entirely new layer that didn't exist in Classic:
+
+- **Workflow Agent** (UI-based, low-code)[^10]
+- **Hosted Agents** (containerized, code-first)[^11]
+- **Agent Framework** (open-source, cloud-agnostic)
+- **A2A Protocol** support[^12]
+- **MCP Protocol** support (remote servers)
+- **Agent Publishing** to M365/Teams/BizChat[^13]
+- **Foundry Control Plane** for fleet management[^14]
+
+This isn't a "Classic → New" migration — it's an entirely new capability layer. But customers migrating from Classic need to understand that these capabilities exist and are only available in the New experience.
+
+**What you could provide:** Should this be a dedicated axis? Or is it better covered as part of the "Why Migrate?" value proposition rather than a transition axis?
+
+---
+
+### Missing Axis C: Documentation Architecture Itself
+
+Your original table includes "Docs" as a dimension:
+
+> **Classic:** "Classic use of AI Services tools – Domain specific docs for speech service, language service etc."
+> **New:** "Forward-looking scenarios where Foundry Tools enrich Agentic capabilities for Agent Factory scenarios demonstrated in NextGen. Branches out to classic docs for domain-specific API."
+
+The docs-vnext structure is itself an axis of change. The `whats-new-foundry.mdx` page says: "This month marks a significant update to our documentation structure. With the introduction of the new Microsoft Foundry portal, we now maintain two corresponding versions of the documentation"[^18].
+
+This dual-version documentation model is a source of confusion:
+- Which docs should a customer read?
+- How do the two versions relate?
+- What's the versioning strategy going forward?
+
+**What you could provide:** Is the dual-docs model permanent? Will classic docs eventually be archived? How should customers navigate between the two?
+
+---
+
+## Summary: Priority Input Requests
+
+| Priority | Gap | What You Know That I Don't |
+|----------|-----|---------------------------|
+| 🔴 **Critical** | NextGen GA timeline | Even approximate timing drives all action items |
+| 🔴 **Critical** | Hub deprecation/sunset plan | Determines whether a migration guide is needed |
+| 🟡 **High** | Billing axis substance | Foundry Direct Models, hosted agent pricing, new billing meters |
+| 🟡 **High** | "Foundry Tools" naming clarification | Three conflicting usages need resolution |
+| 🟡 **High** | "Management Center" → ? replacement | Confirm actual new term |
+| 🟡 **High** | Bala/Dan/Jeff/Marco input areas | What context do they uniquely hold? |
+| 🟢 **Medium** | Agent Framework as its own axis | New-only capabilities inventory for the "Why Migrate?" story |
+| 🟢 **Medium** | Observability evolution | Breaking changes in eval/tracing between classic and new? |
+| 🟢 **Medium** | Dual-docs strategy | Permanent or transitional? Navigation guidance? |
+| ⚪ **Nice to Have** | Azure Portal specific changes needed | What display names need to change in portal.azure.com? |
+
+---
+
+## Confidence Assessment
+
+### What the Report Handles Well (No Input Needed)
+- ✅ Branding evolution timeline — complete and verified
+- ✅ Agent API lineage (Assistants → Agents v2) — deeply covered with upstream rationale
+- ✅ API versioning (monthly → v1) — fully documented with code examples
+- ✅ SDK evolution — deprecation timelines and migration paths confirmed
+- ✅ Wire protocol change rationale — seven upstream reasons incorporated
+- ✅ Copilot Studio differentiation — decision framework is solid
+- ✅ Terminology mapping — comprehensive table verified against codebase
+
+### What Needs Your Insider Knowledge (Input Requested)
+- ❌ NextGen GA timing
+- ❌ Hub sunset plan
+- ❌ Billing specifics
+- ❌ "Foundry Tools" naming resolution
+- ❌ "Admin Console" vs "Operate" naming
+- ❌ Bala/Dan/Jeff/Marco contribution areas
+- ❌ Whether Agent Framework / Observability deserve their own axes
+
+---
+
+## Footnotes
+
+[^1]: `docs-vnext/overview/what-is-foundry.mdx` — Line 21. "Only Foundry projects are visible here — use (classic) for all other resource types."
+
+[^2]: Dennis Drews, Build 2025 recap blog. "hub-based project type remains accessible in Azure AI Foundry portal for GenAI capabilities that are not yet supported by the new resource type."
+
+[^3]: `docs-vnext/setup/migrate.mdx` — covers Agents v1→v2 migration only. No hub→Foundry project migration guide exists in docs-vnext.
+
+[^4]: `docs-vnext/setup/multi-service-resource.mdx` — Line 14. "Foundry resource is the next version and renaming of former 'Foundry Tools'."
+
+[^5]: `docs-vnext/manage/overview.mdx` — Line 6. "Microsoft Foundry Control Plane is a unified management interface..." under the "Operate" section of the new portal.
+
+[^6]: `docs-vnext/api-sdk/sdk-overview.mdx` — Line 12-13. "Foundry Tools SDKs" listed as SDK category for Speech, Vision, Language, Content Safety.
+
+[^7]: `docs-vnext/security/policy-reference.mdx` — Line 5. "Azure Policy built-in policy definitions for Foundry Tools."
+
+[^8]: Microsoft Learn, "Models sold directly by Azure." https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure
+
+[^9]: `docs-vnext/agents/development/faq.mdx` — Lines 92-100. Agent Service billing: model inference cost + Code Interpreter per session + File Search vector storage.
+
+[^10]: `docs-vnext/agents/development/workflow.mdx` — Lines 1-39. Workflow-based agent orchestration with visual builder, sequential/group-chat/human-in-the-loop patterns.
+
+[^11]: `docs-vnext/agents/development/hosted-agents.mdx` — Lines 1-38. Containerized agent deployment with managed hosting, scaling, and observability.
+
+[^12]: `docs-vnext/agents/tools/agent-to-agent.mdx` — Lines 1-40. A2A protocol support for cross-agent communication in Foundry Agent Service (preview).
+
+[^13]: `docs-vnext/agents/development/publish-copilot.mdx` — Lines 1-40. Publishing agents to Microsoft 365 Copilot and Teams.
+
+[^14]: `docs-vnext/manage/overview.mdx` — Lines 1-50. Foundry Control Plane for fleet management, observability, compliance, and security.
+
+[^15]: `docs-vnext/agents/development/how-to-monitor-agents-dashboard.mdx` — referenced in `what-is-foundry.mdx` as "Real-Time Observability."
+
+[^16]: `docs-vnext/agents/development/how-to-monitor-agents-dashboard.mdx` — referenced for continuous evaluation via Python SDK.
+
+[^17]: `docs-vnext/observability/ai-red-teaming-agent.mdx` — AI Red Teaming Agent for automated scanning.
+
+[^18]: `docs-vnext/operate/whats-new-foundry.mdx` — Lines 7-9. "This month marks a significant update to our documentation structure."

--- a/local/pm-mode/implementation-plan.md
+++ b/local/pm-mode/implementation-plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Foundry Classic → New Documentation Suite
+
+## Problem Statement
+
+Microsoft Foundry's transition from Classic to New creates confusion across eight simultaneous axes (branding, portals, agent API, API versioning, resource model, SDKs, terminology, billing). With NextGen GA launching March 17, 2026, there is no single authoritative documentation resource that helps developers understand what changed, why, and what to do about it. The existing docs cover individual topics but lack the connective tissue — a "Developer Guide to Foundry" narrative, an updated glossary with migration mappings, SDK comparison tables, and a revised overview page that frames the platform through the Discovery → Build → Operate lifecycle.
+
+## Approach
+
+Create a suite of 6 documentation deliverables (5 MDX pages + 1 glossary update) in `docs-vnext/` that work together as a coherent "understand the evolution" layer. Each page is standalone but cross-linked. All follow Mintlify MDX format and Diátaxis conventions.
+
+## Deliverables
+
+### 1. Rewrite `overview/what-is-foundry.mdx` — The Landing Page
+- **File:** `docs-vnext/overview/what-is-foundry.mdx` (edit existing)
+- **Diátaxis type:** Explanation
+- **What changes:**
+  - Add "Who is Foundry for?" section with developer personas (app developers, ML engineers, IT admins)
+  - Add "How Foundry evolved" section with the 3-line naming timeline (Azure AI Studio → Azure AI Foundry → Microsoft Foundry) and a brief explanation of the model-centric → agent-centric industry shift
+  - Restructure body around Discovery → Build → Operate lifecycle instead of feature bullet list
+  - Update the portals table to reflect NextGen as default (post-March 17 GA)
+  - Remove "How to get access" toggle language (NextGen is now default)
+  - Add "Coming from Azure OpenAI?" callout with link to upgrade guide
+  - Add "Coming from Hubs?" callout with link to classic docs
+  - Fix broken related-content link (line 88 has missing line break)
+
+### 2. New page: `overview/developer-guide.mdx` — The Developer Guide to Foundry
+- **File:** `docs-vnext/overview/developer-guide.mdx` (create new)
+- **Diátaxis type:** Explanation
+- **Purpose:** Single narrative explaining why the platform changed. This is the "customer-facing article on what is happening from classic → new" from the original requirements.
+- **Outline:**
+  1. **The industry shifted** — model-centric (2023) → agent-centric (2025), pace of model releases, reasoning/tool-calling/multimodal convergence
+  2. **What changed and why** — eight axes summarized in a single table (the "Classic vs. New" alignment table from research, simplified for customers)
+  3. **The Responses API** — why the wire protocol moved from Assistants to Responses (simpler model, better performance, lower costs, native tools, encrypted reasoning, future-proofing — rewritten in Microsoft voice without naming upstream provider)
+  4. **The v1 API** — why monthly api-versions were replaced with stable `/openai/v1/` routes
+  5. **One resource, one portal** — Foundry resource replaces Hub + AOAI + AI Services; NextGen replaces Mainline
+  6. **Which migration do I need?** — decision tree linking to specific migration guides
+  7. **Foundry vs. Copilot Studio vs. M365 Copilot** — persona-based decision framework
+- **Nav location:** Add to "What is Microsoft Foundry (new)?" group in `docs.json`
+
+### 3. New page: `overview/classic-vs-new.mdx` — Terminology & Feature Comparison
+- **File:** `docs-vnext/overview/classic-vs-new.mdx` (create new)
+- **Diátaxis type:** Reference
+- **Purpose:** The terminology mapping table + feature comparison matrix. Two tables in one page.
+- **Content:**
+  - **Terminology mapping table** — Classic Term → New Term → Notes (the full 17-row table from research)
+  - **Feature comparison matrix** — Classic portal vs. New portal capabilities (what's available where)
+  - **Naming lineage callout** — Cognitive Services → Azure AI Services → Foundry Tools; Azure AI Studio → Azure AI Foundry → Microsoft Foundry
+- **Nav location:** Add to "What is Microsoft Foundry (new)?" group in `docs.json`
+
+### 4. New page: `api-sdk/sdk-classic-vs-new.mdx` — SDK Migration Comparison
+- **File:** `docs-vnext/api-sdk/sdk-classic-vs-new.mdx` (create new)
+- **Diátaxis type:** Reference
+- **Purpose:** Side-by-side comparison of classic vs. new SDK patterns with code examples.
+- **Content:**
+  - **SDK mapping table** — Classic SDK → New SDK → Status → Migration effort
+  - **Client library comparison** — `AzureOpenAI()` vs `OpenAI()` with side-by-side code (Python, C#, JS)
+  - **API versioning comparison** — monthly `api-version` vs v1 routes with before/after curl examples
+  - **Agent SDK comparison** — `create_agent()` vs `create_version()` with before/after Python code
+  - **Conversation SDK comparison** — threads vs conversations with before/after Python code
+  - **Deprecation notices** — `azure-ai-inference` (retiring May 30, 2026), Assistants API (sunset Aug 26, 2026)
+  - Link to existing `api-version-lifecycle.mdx` for full v1 API details
+  - Link to existing `migrate.mdx` for full agent migration guide
+- **Nav location:** Add to "API & SDK" group in `docs.json`
+
+### 5. Update `glossary.mdx` — Add Migration Mappings & Missing Terms
+- **File:** `docs-vnext/glossary.mdx` (edit existing)
+- **What changes:**
+  - Add missing terms: Conversation, Foundry Tools, Foundry Resource, Foundry Project, Items, Responses API, v1 API, Classic (portal), New (portal), Agents v2, Workflow Agent, Hosted Agent, Foundry Control Plane, Foundry Direct Models, Agent Framework
+  - Add "See also" cross-references for deprecated terms: Thread → see Conversation, Run → see Response, Assistant → see Agent, Azure AI Services → see Foundry Tools, Azure AI Studio → see Microsoft Foundry, Hub → see Foundry Resource
+  - Remove foundry-docs MCP server-specific terms that don't belong in customer-facing glossary (Devvit, Redis, repository_dispatch, Content Chunking, Hit@K, HNSW, MRR, TF-IDF, SearchIndex, Semantic Reranking, MCP Gateway, FastMCP, MDX, Mintlify, Telemetry, docs-vnext, Diátaxis, Embeddings as implementation detail, Hybrid Search as implementation detail)
+
+### 6. Update `docs.json` navigation — Wire New Pages Into Nav
+- **File:** `docs-vnext/docs.json` (edit existing)
+- **What changes:**
+  - Add `overview/developer-guide` and `overview/classic-vs-new` to the "What is Microsoft Foundry (new)?" group
+  - Add `api-sdk/sdk-classic-vs-new` to the "API & SDK" group
+  - Consider renaming top nav group from "What is Microsoft Foundry (new)?" to "What is Microsoft Foundry?" (drop the "(new)" since NextGen is now GA default)
+
+## Notes
+
+- All new pages follow Mintlify MDX format per `.github/instructions/documentation.instructions.md`
+- All new pages use Diátaxis framework (explanation for narrative, reference for tables)
+- Code samples are minimal, focused, copy-paste ready with ALL_CAPS placeholders
+- No promotional language; neutral technical tone
+- Content is drawn from the research report at `~/.copilot/session-state/.../research/i-m-having-a-problem-with-explaining-the-technical.md`
+- The developer guide blog post mentioned in research is separate from these docs pages and not part of this implementation


### PR DESCRIPTION
## Summary

Add documentation suite addressing the eight-axis Classic → New Foundry transition for the March 17 NextGen GA launch.

### New pages
- **`overview/developer-guide.mdx`** — Narrative explaining the model→agent industry shift, 8-axis alignment table, Responses API rationale, v1 API rationale, migration decision tree, Foundry vs Copilot Studio comparison
- **`overview/classic-vs-new.mdx`** — 17-row terminology mapping table + feature comparison matrix (Classic vs New portal) + SDK version mapping
- **`api-sdk/sdk-classic-vs-new.mdx`** — Side-by-side code comparisons: `AzureOpenAI()`→`OpenAI()`, api-version→v1, `create_agent()`→`create_version()`, threads→conversations, runs→responses, deprecation timeline

### Updated pages
- **`overview/what-is-foundry.mdx`** — Added naming history, developer personas, "Coming from AOAI/Hub?" callouts, post-GA portal table, fixed broken link
- **`glossary.mdx`** — Added 17 customer-facing terms, removed 16 MCP-server-internal terms, updated 4 entries with migration cross-references
- **`docs.json`** — Wired new pages into navigation, renamed group from "What is Microsoft Foundry (new)?" to "What is Microsoft Foundry?"

### Research artifacts
Research report (63KB, 910 lines), gap analysis, and implementation plan archived in `local/pm-mode/`.