### PR TITLE
docs: expand SDK story from narrow deprecation to full unification narrative

### DIFF
--- a/docs-vnext/api-sdk/sdk-classic-vs-new.mdx
+++ b/docs-vnext/api-sdk/sdk-classic-vs-new.mdx
@@ -1,30 +1,101 @@
 ---
-title: "SDK comparison: Classic vs. New"
-description: "Side-by-side comparison of classic and new SDK patterns in Microsoft Foundry, with code examples for common migration scenarios."
+title: "SDK evolution: from fragmented packages to a unified project client"
+description: "Understand how Microsoft Foundry's SDK ecosystem consolidated from multiple packages and endpoints to a single project client with unified access to agents, models, evaluations, and tools."
 ---
 
-{/* Reference page: neutral, technical comparisons of classic and new SDK patterns */}
+{/* Explanation page: understanding the SDK consolidation from fragmented packages to unified project client */}
 
-# SDK comparison: Classic vs. New
+# SDK evolution: from fragmented packages to a unified project client
 
-Microsoft Foundry's SDK ecosystem evolved alongside the platform's shift from model-centric inference to agent-centric workloads. This page provides side-by-side comparisons of classic and new SDK patterns to help migrate existing code.
+Microsoft Foundry's SDK ecosystem evolved from a collection of separate packages, each targeting a different endpoint and capability, to a unified project client that provides access to the full platform from a single entry point. This page explains what changed, why, and how to map previous packages to their current equivalents.
 
-## SDK mapping
+## The problem: too many packages, too many endpoints
 
-| Classic SDK | New SDK | Purpose | Migration effort |
-|-------------|---------|---------|-----------------|
-| `azure-ai-inference` | `openai` | Model inference (chat completions, embeddings) | Low — package swap, endpoint change |
-| `AzureOpenAI()` client | `OpenAI()` client with `base_url` | Azure OpenAI API access | Low — 3-line change |
-| Monthly `api-version` param | v1 stable routes (`/openai/v1/`) | API version management | Low — remove param |
-| `azure-ai-projects` 1.x | `azure-ai-projects` 2.x | Foundry project capabilities | Medium — API surface changes |
-| `client.agents.create_agent()` | `client.agents.create_version()` | Agent creation | Medium — new definition model |
-| `client.agents.threads.create()` | `openai_client.conversations.create()` | Conversation state | Medium — different client |
-| `client.agents.runs.create()` | `openai_client.responses.create()` | Agent execution | Medium — sync by default |
+The previous SDK landscape required developers to install and configure multiple packages, each with its own endpoint, authentication pattern, and API conventions. A developer building an agent with retrieval-augmented generation, evaluations, and speech might need five or more packages against four or more endpoints.
 
-## Client library: AzureOpenAI → OpenAI
+| Capability | Previous endpoints | Previous SDK packages |
+|-----------|-------------------|----------------------|
+| Model inference | `*.openai.azure.com` | `openai` (with `AzureOpenAI` client), `azure-ai-inference` |
+| Agents | `*.openai.azure.com`, `*.api.azureml.ms/agents` | `openai` (assistants), `azure-ai-projects` 1.x |
+| Knowledge and search | `*.search.windows.net`, `*.api.azureml.ms/assets` | `azure-search-documents`, `azure-ai-ml` |
+| Evaluations | `*.openai.azure.com`, `*.api.azureml.ms/evaluations` | `azure-ai-evaluation`, `azure-ai-projects` 1.x |
+| Generative AI (RAG, prompt flow) | `*.api.azureml.ms` | `azure-ai-generative` |
+| Speech, Vision, Language, Content Safety | `*.cognitiveservices.azure.com`, `*.speech.microsoft.com` | `azure-cognitiveservices-speech`, `azure-ai-contentsafety`, `azure-ai-vision-imageanalysis`, and others |
+
+<Note>
+This fragmentation meant developers often had to configure multiple credentials, manage multiple package versions, and learn different API conventions for each capability.
+</Note>
+
+## The solution: one endpoint, one project client
+
+Foundry converges on:
+
+- **One project endpoint:** `https://{resource}.services.ai.azure.com/api/projects/{project}`
+- **One project client** (`AIProjectClient`) that provides access to agents, models, evaluations, connections, datasets, and indexes
+- **The OpenAI SDK** for model inference through `client.inference.get_azure_openai_client()` or direct use with the `/openai/v1/` endpoint
+
+```bash
+pip install azure-ai-projects azure-identity openai
+```
+
+```python
+from azure.identity import DefaultAzureCredential
+from azure.ai.projects import AIProjectClient
+
+# One client, one endpoint — access to all Foundry capabilities
+client = AIProjectClient(
+    endpoint="https://YOUR_RESOURCE.services.ai.azure.com/api/projects/YOUR_PROJECT",
+    credential=DefaultAzureCredential(),
+)
+
+# Get an OpenAI-compatible client for model inference
+openai_client = client.inference.get_azure_openai_client()
+```
+
+<Tip>
+With the v1 API, `get_azure_openai_client()` returns a standard `OpenAI()` client — no Azure-specific client code required. The same patterns work across providers.
+</Tip>
+
+## SDK mapping: previous packages → current packages
+
+| Previous package | Current package | Capability | Migration effort |
+|-----------------|----------------|------------|-----------------|
+| `azure-ai-inference` | `openai` | Model inference (chat completions, embeddings) | Low — package swap, endpoint change. See [migration guide](/setup/model-inference-to-openai-migration). |
+| `AzureOpenAI()` client | `OpenAI()` client with `base_url` | Azure OpenAI API access | Low — 3-line code change. See [v1 API](/api-sdk/api-version-lifecycle). |
+| Monthly `api-version` param | v1 stable routes (`/openai/v1/`) | API version management | Low — remove parameter |
+| `azure-ai-generative` | `azure-ai-projects` 2.x | RAG, prompt flow, generative scenarios | Medium — package replaced |
+| `azure-ai-projects` 1.x | `azure-ai-projects` 2.x | Project client (agents, evaluations, connections) | Medium — API surface changes |
+| `azure-ai-evaluation` (standalone) | `azure-ai-projects` evaluations API + `azure-ai-evaluation` (local) | Evaluation runs | Low — remote evals via project client; local evals unchanged |
+| `azure-ai-ml` (hub workspaces) | `azure-ai-projects` 2.x | Workspace and project management | Medium — hub→project migration |
+| `azure-search-documents` | `azure-search-documents` (via project connections) | Search index management and queries | Unchanged — discoverable through `client.connections` |
+| `client.agents.create_agent()` | `client.agents.create_version()` | Agent creation | Medium — versioned definition model. See [migration guide](/setup/migrate). |
+| `client.agents.threads.create()` | `openai_client.conversations.create()` | Conversation state | Medium — different client (OpenAI client) |
+| `client.agents.runs.create()` | `openai_client.responses.create()` | Agent execution | Medium — synchronous by default |
+| AI Services SDKs (Speech, Vision, Language, etc.) | Foundry Tools SDKs (unchanged) | Domain-specific AI capabilities | No change — accessible via project connections |
+
+## Endpoint consolidation
+
+| Before | After |
+|--------|-------|
+| `*.openai.azure.com` | `*.openai.azure.com/openai/v1` (v1 API) |
+| `*.api.azureml.ms/agents` | `*.services.ai.azure.com/api/projects/{project}` |
+| `*.api.azureml.ms/evaluations` | `*.services.ai.azure.com/api/projects/{project}` |
+| `*.api.azureml.ms/assets` | `*.services.ai.azure.com/api/projects/{project}` |
+| `*.search.windows.net` | `*.search.windows.net` (separate, discoverable via connections) |
+| `*.cognitiveservices.azure.com` | `*.cognitiveservices.azure.com` (Foundry Tools) |
+
+<Info>
+A Foundry resource exposes three endpoints. The project endpoint at `*.services.ai.azure.com` provides access to most capabilities. The OpenAI v1 endpoint at `*.openai.azure.com/openai/v1` provides direct model access. Foundry Tools at `*.cognitiveservices.azure.com` serve domain-specific services. See [SDKs and Endpoints](/api-sdk/sdk-overview) for details.
+</Info>
+
+## Code comparisons
+
+The following sections show side-by-side code examples for each major API change.
+
+### Client library: AzureOpenAI → OpenAI
 
 <CodeGroup>
-```python Classic
+```python Previous
 from openai import AzureOpenAI
 
 client = AzureOpenAI(
@@ -39,7 +110,7 @@ response = client.chat.completions.create(
 )
 ```
 
-```python New
+```python Current
 from openai import OpenAI
 
 client = OpenAI(
@@ -61,17 +132,17 @@ Key differences:
 - The `api_version` parameter is removed.
 - Both `chat.completions` and `responses` endpoints are available on v1.
 
-## API versioning: monthly params → v1 routes
+### API versioning: monthly params → v1 routes
 
 <CodeGroup>
-```bash Classic
+```bash Previous
 curl -X POST "https://YOUR_RESOURCE.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-10-21" \
   -H "api-key: $AZURE_OPENAI_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"messages": [{"role": "user", "content": "Hello"}]}'
 ```
 
-```bash New
+```bash Current
 curl -X POST "https://YOUR_RESOURCE.openai.azure.com/openai/v1/chat/completions" \
   -H "api-key: $AZURE_OPENAI_API_KEY" \
   -H "Content-Type: application/json" \
@@ -83,10 +154,10 @@ curl -X POST "https://YOUR_RESOURCE.openai.azure.com/openai/v1/chat/completions"
 Preview features use headers (for example, `"aoai-evals":"preview"`) instead of preview API versions. Some features indicate preview status through their API path (for example, `/openai/v1/fine_tuning/alpha/graders/`).
 </Note>
 
-## Agent creation: create_agent → create_version
+### Agent creation: create_agent → create_version
 
 <CodeGroup>
-```python Classic
+```python Previous
 agent = project_client.agents.create_agent(
     model="gpt-4.1",
     name="my-agent",
@@ -95,7 +166,7 @@ agent = project_client.agents.create_agent(
 )
 ```
 
-```python New
+```python Current
 from azure.ai.projects.models import PromptAgentDefinition
 
 agent = project_client.agents.create_version(
@@ -110,16 +181,16 @@ agent = project_client.agents.create_version(
 
 Agent versions have an explicit `kind` (prompt, workflow, hosted) and are versioned by name. The response object includes an `id` in the format `agent-name:version-number`.
 
-## Conversations: threads → conversations
+### Conversations: threads → conversations
 
 <CodeGroup>
-```python Classic
+```python Previous
 thread = project_client.agents.threads.create(
     messages=[{"role": "user", "content": "Hello"}],
 )
 ```
 
-```python New
+```python Current
 openai_client = project_client.get_openai_client()
 
 conversation = openai_client.conversations.create(
@@ -129,13 +200,13 @@ conversation = openai_client.conversations.create(
 </CodeGroup>
 
 <Info>
-In the new API, agent creation uses `AIProjectClient` (project client), while conversations and responses use the OpenAI client obtained via `project_client.get_openai_client()`. This split exists because conversations and responses are built on the Responses API wire format.
+In the current API, agent creation uses `AIProjectClient` (project client), while conversations and responses use the OpenAI client obtained via `project_client.get_openai_client()`. This split exists because conversations and responses are built on the Responses API wire format.
 </Info>
 
-## Execution: runs → responses
+### Execution: runs → responses
 
 <CodeGroup>
-```python Classic
+```python Previous
 run = project_client.agents.runs.create(
     thread_id=thread.id,
     agent_id=agent.id,
@@ -147,7 +218,7 @@ while run.status in ("queued", "in_progress"):
     )
 ```
 
-```python New
+```python Current
 response = openai_client.responses.create(
     input="Draw a graph with slope 4 and y-intercept 9.",
     conversation=conversation.id,
@@ -162,9 +233,10 @@ Responses are synchronous by default — no polling loop is required.
 
 ## Deprecation timeline
 
-| SDK / API | Status | Retirement date | Replacement |
-|-----------|--------|-----------------|-------------|
-| `azure-ai-inference` | Deprecated | May 30, 2026 | `openai` SDK |
+| Package / API | Status | Retirement date | Replacement |
+|--------------|--------|-----------------|-------------|
+| `azure-ai-inference` | Deprecated | May 30, 2026 | `openai` SDK. See [migration guide](/setup/model-inference-to-openai-migration). |
+| `azure-ai-generative` | Superseded | No formal retirement date | `azure-ai-projects` 2.x |
 | Assistants API wire protocol | Deprecated | August 26, 2026 | Responses API |
 | Monthly `api-version` params | Supported (opt-in to v1) | No retirement date | v1 stable routes |
 | `azure-ai-projects` 1.x | Stable | No retirement date | `azure-ai-projects` 2.x (when GA) |
@@ -173,5 +245,6 @@ Responses are synchronous by default — no polling loop is required.
 
 - [Microsoft Foundry SDKs and Endpoints](/api-sdk/sdk-overview)
 - [Azure OpenAI v1 API](/api-sdk/api-version-lifecycle)
+- [Migrate from Azure AI Inference SDK to OpenAI SDK](/setup/model-inference-to-openai-migration)
 - [Migrate to the new Foundry Agent Service](/setup/migrate)
-- [Classic vs. New: terminology and feature comparison](/overview/classic-vs-new)
+- [A developer's guide to Microsoft Foundry](/overview/developer-guide)

--- a/docs-vnext/api-sdk/sdk-overview.mdx
+++ b/docs-vnext/api-sdk/sdk-overview.mdx
@@ -18,6 +18,8 @@ A Foundry resource provides unified access to models, agents, and tools. This ar
 - Use **Foundry Tools SDKs** when working with specific AI services (Vision, Speech, Language, etc.)
 - Use **Agent Framework** when building multi-agent systems in code (local orchestration)
 
+This SDK structure reflects a deliberate consolidation. Previously, building an end-to-end AI application required installing and configuring multiple packages — each with its own endpoint, authentication pattern, and API conventions. The Foundry SDK (`azure-ai-projects`) provides a single entry point that replaces this fragmented approach. For a full mapping of previous packages to their current equivalents, see [SDK evolution: from fragmented packages to a unified project client](/api-sdk/sdk-classic-vs-new).
+
 <Note>
 **Resource types:** A Foundry resource provides all endpoints previously listed. An Azure OpenAI resource provides only the `/openai/v1` endpoint.
 

--- a/docs-vnext/overview/classic-vs-new.mdx
+++ b/docs-vnext/overview/classic-vs-new.mdx
@@ -27,7 +27,14 @@ Microsoft Foundry evolved through several naming and architectural changes. This
 | AI services | Azure AI Services | Foundry Tools | Speech, Vision, Language, Content Safety, Content Understanding. |
 | RBAC roles | Cognitive Services OpenAI User | Azure AI User, Azure AI Project Manager, Azure AI Owner | New roles with control/data plane separation. |
 | Model billing | Model-as-a-Service (MaaS) | Foundry Direct Models | First-party models billed directly via Azure meters. |
-| SDK (Python) | `azure-ai-inference`, `AzureOpenAI` | `azure-ai-projects` 2.x, `openai` | `azure-ai-inference` retiring May 30, 2026. |
+| Model inference SDK | `azure-ai-inference` | `openai` | `azure-ai-inference` retiring May 30, 2026. |
+| Project client | `azure-ai-projects` 1.x | `azure-ai-projects` 2.x | 2.x targets Foundry (new); 1.x targets Foundry (classic). |
+| Generative AI SDK | `azure-ai-generative` | `azure-ai-projects` 2.x | Capabilities merged into project client. |
+| Evaluation SDK | `azure-ai-evaluation` (standalone) | `azure-ai-projects` (remote) + `azure-ai-evaluation` (local) | Remote evaluations via project client; local evaluations unchanged. |
+| Hub workspace SDK | `azure-ai-ml` | `azure-ai-projects` 2.x | For hub-to-project migration scenarios. |
+| Search SDK | `azure-search-documents` | `azure-search-documents` (via project connections) | Separate package, discoverable through project client. |
+| Client library | `AzureOpenAI()` | `OpenAI()` with `base_url` | Standard client, Azure-specific code eliminated. |
+| Endpoints | Multiple (openai, azureml, cognitiveservices, search, speech) | Single project endpoint + OpenAI v1 endpoint | See [SDK evolution](/api-sdk/sdk-classic-vs-new). |
 | Documentation | Foundry (classic) docs | Foundry (new) docs | Version selector in documentation banner. |
 
 ## Feature comparison: Classic vs. New portal

--- a/docs-vnext/overview/developer-guide.mdx
+++ b/docs-vnext/overview/developer-guide.mdx
@@ -37,7 +37,7 @@ Microsoft Foundry represents eight simultaneous transitions across branding, API
 | Agent API | Assistants API (Agents v0.5/v1) | Responses API (Agents v2) |
 | API versioning | Monthly `api-version` params | v1 stable routes (`/openai/v1/`) |
 | Resource model | Hub + Azure OpenAI + Azure AI Services | Foundry resource (single, with projects) |
-| SDKs | `azure-ai-inference`, `AzureOpenAI()` | `azure-ai-projects` 2.x, `OpenAI()` |
+| SDKs & endpoints | Multiple packages (`azure-ai-inference`, `azure-ai-generative`, `azure-ai-ml`, `AzureOpenAI()`) against 5+ endpoints | Unified project client (`azure-ai-projects` 2.x) + `OpenAI()` against one project endpoint. See [SDK evolution](/api-sdk/sdk-classic-vs-new). |
 | Terminology | Threads, Messages, Runs, Assistants | Conversations, Items, Responses, Agent Versions |
 | AI services branding | Azure AI Services | Foundry Tools |
 
@@ -119,6 +119,8 @@ A Foundry resource exposes three endpoints:
 
 Upgrading an existing Azure OpenAI resource changes `kind` from `OpenAI` to `AIServices` while preserving the existing endpoint, keys, deployments, and state. The upgrade is non-breaking and additive — it enables Foundry features without disrupting existing workloads.
 
+The SDK story parallels the resource consolidation. Previously, each Azure AI resource required its own SDK package and endpoint configuration. The Foundry SDK (`azure-ai-projects`) connects to a single project endpoint and provides access to agents, models, evaluations, connections, and datasets — replacing the need to configure multiple packages against multiple endpoints.
+
 ## Which migration path do I need?
 
 The transition involves multiple independent axes. Most developers only need to act on one or two.
@@ -128,7 +130,8 @@ The transition involves multiple independent axes. Most developers only need to 
 | Using Azure OpenAI resources | Upgrade the resource to a Foundry resource | [Upgrade to Foundry](/setup/upgrade-azure-openai) |
 | Using the Assistants API or Agents v1 | Migrate agent code to Agents v2 (Responses API) | [Migrate to Agents v2](/setup/migrate) |
 | Using monthly `api-version` parameters | Switch to v1 API routes | [Move to v1 API](/api-sdk/api-version-lifecycle) |
-| Using `azure-ai-inference` SDK | Switch to the OpenAI SDK | [SDK overview](/api-sdk/sdk-overview) |
+| Using `azure-ai-inference` SDK | Switch to the OpenAI SDK | [Migration guide](/setup/model-inference-to-openai-migration) |
+| Using multiple Azure AI SDK packages | Consolidate to the Foundry SDK + OpenAI SDK | [SDK evolution](/api-sdk/sdk-classic-vs-new) |
 | Using hub-based projects | Continue using Foundry (classic) portal | Migration guides forthcoming |
 
 ## How Foundry differs from Copilot Studio and M365 Copilot


### PR DESCRIPTION
## Summary

Reframes the SDK evolution documentation from a narrow `azure-ai-inference` deprecation notice to the full SDK unification story: fragmented packages and endpoints → single project client and project endpoint.

### Key changes

- **`api-sdk/sdk-classic-vs-new.mdx`** — Rewritten with new title ("SDK evolution: from fragmented packages to a unified project client"). Adds fragmentation problem section, full before-state landscape table (~7 capability areas × multiple endpoints × multiple packages), endpoint consolidation table, project client convergence code, expanded 12-row SDK mapping table, updated deprecation timeline.

- **`api-sdk/sdk-overview.mdx`** — Added paragraph explaining the consolidation context and linking to the SDK evolution page.

- **`overview/developer-guide.mdx`** — Expanded SDKs row in "What changed" table to show full scope (5+ endpoints → 1), added SDK consolidation paragraph to "One resource" section, broadened migration decision tree with two SDK-related rows.

- **`overview/classic-vs-new.mdx`** — Split single "SDK (Python)" row into 8 rows covering the full landscape: model inference, project client, generative AI, evaluation, hub workspaces, search, client library, and endpoints.

### Terminology
Uses "fragmented → unified" framing instead of "Classic vs. New" to avoid collision with Foundry portal terminology (Foundry classic / Foundry new).