### PR TITLE
fix: strip duplicate H1 headings caused by Mintlify frontmatter rendering

### DIFF
--- a/docs-vnext/api-sdk/sdk-classic-vs-new.mdx
+++ b/docs-vnext/api-sdk/sdk-classic-vs-new.mdx
@@ -5,8 +5,6 @@ description: "Understand how Microsoft Foundry's SDK ecosystem consolidated from
 
 {/* Explanation page: understanding the SDK consolidation from fragmented packages to unified project client */}
 
-# SDK evolution: from fragmented packages to a unified project client
-
 Microsoft Foundry's SDK ecosystem evolved from a collection of separate packages, each targeting a different endpoint and capability, to a unified project client that provides access to the full platform from a single entry point. This page explains what changed, why, and how to map previous packages to their current equivalents.
 
 ## The problem: too many packages, too many endpoints

--- a/docs-vnext/overview/what-is-foundry.mdx
+++ b/docs-vnext/overview/what-is-foundry.mdx
@@ -2,7 +2,6 @@
 title: "What is Microsoft Foundry?"
 description: "Microsoft Foundry is a trusted platform that empowers developers to drive innovation and shape the future with AI in a safe, secure, and responsible way."
 ---
-# What is Microsoft Foundry?
 **Microsoft Foundry** is a unified Azure platform-as-a-service offering for enterprise AI operations, model builders, and application development. This foundation combines production-grade infrastructure with friendly interfaces, enabling developers to focus on building applications rather than managing infrastructure.
 
 Microsoft Foundry unifies agents, models, and tools under a single management grouping with built-in enterprise-readiness capabilities including tracing, monitoring, evaluations, and customizable enterprise setup configurations. The platform provides streamlined management through unified role-based access control (RBAC), networking, and policies under one Azure resource provider namespace.

--- a/scripts/convert_to_mdx.py
+++ b/scripts/convert_to_mdx.py
@@ -1038,6 +1038,36 @@ def escape_jsx_braces(content: str) -> str:
     return ''.join(parts)
 
 
+def strip_leading_h1(body: str, meta: dict) -> str:
+    """Remove the first H1 heading from the body if it duplicates the frontmatter title.
+
+    Mintlify renders the frontmatter ``title`` as the page H1 and ``description``
+    as a subtitle paragraph.  Microsoft Learn source files also include a body-level
+    ``# Title`` heading, which creates a visible duplicate on Mintlify.  This function
+    strips the first body H1 (and any immediately following paragraph that matches
+    the frontmatter description) so only the frontmatter controls the rendered heading.
+    """
+    if not meta.get("title"):
+        return body
+
+    # Match the first H1 at the start of the body (allowing leading whitespace/newlines)
+    h1_match = re.match(r'^(\s*# .+\n)', body)
+    if not h1_match:
+        return body
+
+    body = body[h1_match.end():]
+
+    # If the next non-empty line is a paragraph that matches the frontmatter description,
+    # strip it too (it would duplicate the Mintlify-rendered subtitle).
+    desc = meta.get("description", "")
+    if desc:
+        desc_match = re.match(r'^(\s*\n)?' + re.escape(desc.strip()) + r'\s*\n', body)
+        if desc_match:
+            body = body[desc_match.end():]
+
+    return body
+
+
 def clean_up(content: str) -> str:
     """Final cleanup pass."""
     # Remove leftover moniker range from front matter comments
@@ -1089,10 +1119,7 @@ def convert_yml_faq(source_path: str) -> str:
         f'title: "{title}"',
         f'description: "{summary.strip()}"' if summary else "",
         "---\n",
-        f"# {title}\n",
     ]
-    if summary:
-        lines.append(summary.strip() + "\n")
 
     for section in data.get("sections", []):
         section_name = section.get("name", "")
@@ -1203,6 +1230,10 @@ def convert_doc(doc: dict) -> str | None:
 
     # Step 20: Final cleanup
     body = clean_up(body)
+
+    # Step 21: Strip leading H1 that duplicates the frontmatter title
+    # Mintlify renders frontmatter title as the page H1, so body H1 creates a duplicate
+    body = strip_leading_h1(body, meta)
 
     # Build final MDX
     front_matter = build_mdx_front_matter(meta)


### PR DESCRIPTION
## Problem

Mintlify renders frontmatter `title` as the page H1 and `description` as a visible subtitle. Microsoft Learn source files also include a body-level `# H1` heading, creating a **duplicate heading on 270 out of 272 pages**.

## Fix

- **`scripts/convert_to_mdx.py`**: Added `strip_leading_h1()` function (Step 21 in pipeline) that removes the first body H1 when a frontmatter title exists, plus any following paragraph that matches the frontmatter description. Also removed explicit H1/summary injection from `convert_yml_faq()`.
- **`what-is-foundry.mdx`**: Removed body `# What is Microsoft Foundry?` heading
- **`sdk-classic-vs-new.mdx`**: Removed body `# SDK evolution...` heading

Run `python scripts/convert_to_mdx.py` to regenerate all converted docs without the duplicates.