### PR TITLE
[docs-vnext] Full 5-language SDK samples + response examples for all 267 API endpoints

### DIFF
--- a/docs-vnext/openapi/openai-v1-preview.json
+++ b/docs-vnext/openapi/openai-v1-preview.json
@@ -235,12 +235,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/audio/speech\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"tts-1\", \"voice\": \"alloy\", \"input\": \"Hello!\"}' \\\n  --output output.mp3"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/audio/speech\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"tts-1\", \"voice\": \"alloy\", \"input\": \"Hello!\"}' \\\n  --output output.mp3"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/audio/speech\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"tts-1\", \"voice\": \"alloy\", \"input\": \"Hello!\"}' \\\n  --output output.mp3"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/audio/speech\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"tts-1\", \"voice\": \"alloy\", \"input\": \"Hello!\"}' \\\n  --output output.mp3"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar audioClient = client.OpenAI.GetAudioClient(\"tts-1\");\nvar result = await audioClient.GenerateSpeechAsync(\n    \"Hello, how are you today?\", GeneratedSpeechVoice.Alloy);\n\nawait File.WriteAllBytesAsync(\n    \"output.mp3\", result.Value.ToArray());"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar audioClient = client.OpenAI.GetAudioClient(\"tts-1\");\nvar result = await audioClient.GenerateSpeechAsync(\n    \"Hello, how are you today?\", GeneratedSpeechVoice.Alloy);\n\nawait File.WriteAllBytesAsync(\n    \"output.mp3\", result.Value.ToArray());"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.audio.speech.create({\n    model: \"tts-1\",\n    voice: \"alloy\",\n    input: \"Hello, how are you today?\",\n});\nconst buffer = Buffer.from(await response.arrayBuffer());\nfs.writeFileSync(\"output.mp3\", buffer);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.audio.speech.create({\n    model: \"tts-1\",\n    voice: \"alloy\",\n    input: \"Hello, how are you today?\",\n});\nconst buffer = Buffer.from(await response.arrayBuffer());\nfs.writeFileSync(\"output.mp3\", buffer);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.audio().speech().create(\n    \"tts-1\", \"alloy\",\n    \"Hello, how are you today?\");\n\nFiles.write(Path.of(\"output.mp3\"), response);"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.audio().speech().create(\n    \"tts-1\", \"alloy\",\n    \"Hello, how are you today?\");\n\nFiles.write(Path.of(\"output.mp3\"), response);"
           }
         ]
       }
@@ -277,6 +307,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AzureAudioTranscriptionResponse"
+                },
+                "example": {
+                  "text": "Hello, this is a transcription of the audio file."
                 }
               },
               "text/plain": {
@@ -426,12 +459,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/audio/transcriptions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F model=\"whisper-1\" \\\n  -F file=\"@audio.mp3\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/audio/transcriptions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F model=\"whisper-1\" \\\n  -F file=\"@audio.mp3\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/audio/transcriptions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F model=\"whisper-1\" \\\n  -F file=\"@audio.mp3\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/audio/transcriptions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F model=\"whisper-1\" \\\n  -F file=\"@audio.mp3\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar audioClient = client.OpenAI.GetAudioClient(\"whisper-1\");\nvar result = await audioClient.TranscribeAudioAsync(\n    \"audio.mp3\");\n\nConsole.WriteLine(result.Value.Text);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar audioClient = client.OpenAI.GetAudioClient(\"whisper-1\");\nvar result = await audioClient.TranscribeAudioAsync(\n    \"audio.mp3\");\n\nConsole.WriteLine(result.Value.Text);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst transcription = await openai.audio.transcriptions.create({\n    model: \"whisper-1\",\n    file: fs.createReadStream(\"audio.mp3\"),\n});\nconsole.log(transcription.text);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst transcription = await openai.audio.transcriptions.create({\n    model: \"whisper-1\",\n    file: fs.createReadStream(\"audio.mp3\"),\n});\nconsole.log(transcription.text);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar transcription = openai.audio().transcriptions()\n    .create(\"whisper-1\", Path.of(\"audio.mp3\"));\n\nSystem.out.println(transcription.getText());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar transcription = openai.audio().transcriptions()\n    .create(\"whisper-1\", Path.of(\"audio.mp3\"));\n\nSystem.out.println(transcription.getText());"
           }
         ]
       }
@@ -468,6 +531,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AzureAudioTranslationResponse"
+                },
+                "example": {
+                  "text": "Hello, this is the English translation of the audio."
                 }
               },
               "text/plain": {
@@ -594,12 +660,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/audio/translations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F model=\"whisper-1\" \\\n  -F file=\"@audio.mp3\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/audio/translations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F model=\"whisper-1\" \\\n  -F file=\"@audio.mp3\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/audio/translations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F model=\"whisper-1\" \\\n  -F file=\"@audio.mp3\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/audio/translations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F model=\"whisper-1\" \\\n  -F file=\"@audio.mp3\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar audioClient = client.OpenAI.GetAudioClient(\"whisper-1\");\nvar result = await audioClient.TranslateAudioAsync(\n    \"audio.mp3\");\n\nConsole.WriteLine(result.Value.Text);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar audioClient = client.OpenAI.GetAudioClient(\"whisper-1\");\nvar result = await audioClient.TranslateAudioAsync(\n    \"audio.mp3\");\n\nConsole.WriteLine(result.Value.Text);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst translation = await openai.audio.translations.create({\n    model: \"whisper-1\",\n    file: fs.createReadStream(\"audio.mp3\"),\n});\nconsole.log(translation.text);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst translation = await openai.audio.translations.create({\n    model: \"whisper-1\",\n    file: fs.createReadStream(\"audio.mp3\"),\n});\nconsole.log(translation.text);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar translation = openai.audio().translations()\n    .create(\"whisper-1\", Path.of(\"audio.mp3\"));\n\nSystem.out.println(translation.getText());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar translation = openai.audio().translations()\n    .create(\"whisper-1\", Path.of(\"audio.mp3\"));\n\nSystem.out.println(translation.getText());"
           }
         ]
       }
@@ -833,6 +929,15 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "batch_abc123def456",
+                  "object": "batch",
+                  "endpoint": "/v1/chat/completions",
+                  "input_file_id": "file-abc123def456",
+                  "completion_window": "24h",
+                  "status": "validating",
+                  "created_at": 1741312436
                 }
               }
             }
@@ -961,22 +1066,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nbatch = openai.batches.create(\n    input_file_id=\"file-abc123\",\n    endpoint=\"/v1/chat/completions\",\n    completion_window=\"24h\",\n)\nprint(batch.id, batch.status)\n# Output: batch_abc123 validating"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nbatch = openai.batches.create(\n    input_file_id=\"file-abc123\",\n    endpoint=\"/v1/chat/completions\",\n    completion_window=\"24h\",\n)\nprint(batch.id, batch.status)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nbatch = openai.batches.create(\n    input_file_id=\"file-abc123\",\n    endpoint=\"/v1/chat/completions\",\n    completion_window=\"24h\",\n)\nprint(batch.id, batch.status)\n# Output: batch_abc123 validating"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nbatch = openai.batches.create(\n    input_file_id=\"file-abc123\",\n    endpoint=\"/v1/chat/completions\",\n    completion_window=\"24h\",\n)\nprint(batch.id, batch.status)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input_file_id\": \"file-abc123\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input_file_id\": \"file-abc123\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input_file_id\": \"file-abc123\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input_file_id\": \"file-abc123\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}'"
           },
           {
             "lang": "csharp",
@@ -997,6 +1102,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.batches.create({\n    input_file_id: \"file-abc123\",\n    endpoint: \"/v1/chat/completions\",\n    completion_window: \"24h\",\n});\nconsole.log(batch.id, batch.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.batches().create(\n    \"file-abc123\", \"/v1/chat/completions\", \"24h\");\n\nSystem.out.println(batch.getId() + \" \" + batch.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.batches().create(\n    \"file-abc123\", \"/v1/chat/completions\", \"24h\");\n\nSystem.out.println(batch.getId() + \" \" + batch.getStatus());"
           }
         ]
       },
@@ -1084,6 +1199,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListBatchesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "batch_abc123def456",
+                      "object": "batch",
+                      "endpoint": "/v1/chat/completions",
+                      "input_file_id": "file-abc123def456",
+                      "completion_window": "24h",
+                      "status": "completed",
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "batch_abc123def456",
+                  "last_id": "batch_abc123def456"
                 }
               }
             }
@@ -1160,12 +1292,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar batchClient = client.OpenAI.GetBatchClient();\nvar batches = batchClient.GetBatches();\n\nforeach (var b in batches)\n    Console.WriteLine($\"{b.Id} {b.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar batchClient = client.OpenAI.GetBatchClient();\nvar batches = batchClient.GetBatches();\n\nforeach (var b in batches)\n    Console.WriteLine($\"{b.Id} {b.Status}\");"
           },
           {
             "lang": "javascript",
@@ -1176,6 +1318,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batches = await openai.batches.list();\nfor await (const b of batches) {\n    console.log(b.id, b.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batches = openai.batches().list();\n\nfor (var b : batches) {\n    System.out.println(b.getId() + \" \" + b.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batches = openai.batches().list();\n\nfor (var b : batches) {\n    System.out.println(b.getId() + \" \" + b.getStatus());\n}"
           }
         ]
       }
@@ -1402,6 +1554,22 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "batch_abc123def456",
+                  "object": "batch",
+                  "endpoint": "/v1/chat/completions",
+                  "input_file_id": "file-abc123def456",
+                  "completion_window": "24h",
+                  "status": "completed",
+                  "created_at": 1741312436,
+                  "completed_at": 1741315036,
+                  "output_file_id": "file-xyz789ghi012",
+                  "request_counts": {
+                    "total": 100,
+                    "completed": 95,
+                    "failed": 5
+                  }
                 }
               }
             }
@@ -1478,12 +1646,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/batches/batch_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/batches/batch_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/batches/batch_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/batches/batch_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar batchClient = client.OpenAI.GetBatchClient();\nvar batch = await batchClient.GetBatchAsync(\"batch_abc123\");\n\nConsole.WriteLine($\"{batch.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar batchClient = client.OpenAI.GetBatchClient();\nvar batch = await batchClient.GetBatchAsync(\"batch_abc123\");\n\nConsole.WriteLine($\"{batch.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.batches.retrieve(\"batch_abc123\");\nconsole.log(batch.status, batch.request_counts);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.batches.retrieve(\"batch_abc123\");\nconsole.log(batch.status, batch.request_counts);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.batches().retrieve(\"batch_abc123\");\n\nSystem.out.println(batch.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.batches().retrieve(\"batch_abc123\");\n\nSystem.out.println(batch.getStatus());"
           }
         ]
       }
@@ -1710,6 +1908,15 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "batch_abc123def456",
+                  "object": "batch",
+                  "endpoint": "/v1/chat/completions",
+                  "input_file_id": "file-abc123def456",
+                  "completion_window": "24h",
+                  "status": "cancelling",
+                  "created_at": 1741312436
                 }
               }
             }
@@ -1786,12 +1993,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/batches/batch_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/batches/batch_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/batches/batch_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/batches/batch_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar batchClient = client.OpenAI.GetBatchClient();\nawait batchClient.CancelBatchAsync(\"batch_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar batchClient = client.OpenAI.GetBatchClient();\nawait batchClient.CancelBatchAsync(\"batch_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.batches.cancel(\"batch_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.batches.cancel(\"batch_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.batches().cancel(\"batch_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.batches().cancel(\"batch_abc123\");"
           }
         ]
       }
@@ -1961,6 +2198,27 @@
                       }
                     }
                   ]
+                },
+                "example": {
+                  "id": "chatcmpl-abc123def456",
+                  "object": "chat.completion",
+                  "created": 1741312436,
+                  "model": "gpt-4o-2024-11-20",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": "Hello! How can I help you today?"
+                      },
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 9,
+                    "completion_tokens": 9,
+                    "total_tokens": 18
+                  }
                 }
               }
             }
@@ -2349,22 +2607,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.chat.completions.create(\n    model=\"gpt-4o\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n# Output: \"Hello! How can I help you today?\""
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.chat.completions.create(\n    model=\"gpt-4o\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.chat.completions.create(\n    model=\"gpt-4o\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n# Output: \"Hello! How can I help you today?\""
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.chat.completions.create(\n    model=\"gpt-4o\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/chat/completions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/chat/completions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/chat/completions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/chat/completions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]}'"
           },
           {
             "lang": "csharp",
@@ -2385,6 +2643,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.chat.completions.create({\n    model: \"gpt-4o\",\n    messages: [{ role: \"user\", content: \"Hello!\" }],\n});\nconsole.log(response.choices[0].message.content);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.chat().completions().create(\n    \"gpt-4o\",\n    List.of(Map.of(\"role\", \"user\", \"content\", \"Hello!\")));\n\nSystem.out.println(\n    response.getChoices().get(0).getMessage().getContent());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.chat().completions().create(\n    \"gpt-4o\",\n    List.of(Map.of(\"role\", \"user\", \"content\", \"Hello!\")));\n\nSystem.out.println(\n    response.getChoices().get(0).getMessage().getContent());"
           }
         ]
       }
@@ -2470,6 +2738,24 @@
                         "$ref": "#/components/schemas/AzureContentFilterResultForPrompt"
                       }
                     }
+                  }
+                },
+                "example": {
+                  "id": "cmpl-abc123def456",
+                  "object": "text_completion",
+                  "created": 1741312436,
+                  "model": "gpt-3.5-turbo-instruct",
+                  "choices": [
+                    {
+                      "text": " world! This is a test.",
+                      "index": 0,
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 7,
+                    "total_tokens": 12
                   }
                 }
               }
@@ -2769,12 +3055,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/completions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"prompt\": \"Say hello\", \"max_tokens\": 100}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/completions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"prompt\": \"Say hello\", \"max_tokens\": 100}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/completions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"prompt\": \"Say hello\", \"max_tokens\": 100}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/completions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"prompt\": \"Say hello\", \"max_tokens\": 100}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar chatClient = client.OpenAI\n    .GetProjectChatClientForModel(\"gpt-4o\");\n\nvar response = await chatClient.CompleteChatAsync(\n    new ChatMessage[] {\n        new UserChatMessage(\"Say hello\"),\n    });\n\nConsole.WriteLine(response.Value.Content[0].Text);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar chatClient = client.OpenAI\n    .GetProjectChatClientForModel(\"gpt-4o\");\n\nvar response = await chatClient.CompleteChatAsync(\n    new ChatMessage[] {\n        new UserChatMessage(\"Say hello\"),\n    });\n\nConsole.WriteLine(response.Value.Content[0].Text);"
           },
           {
             "lang": "javascript",
@@ -2785,6 +3081,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.completions.create({\n    model: \"gpt-4o\",\n    prompt: \"Say hello\",\n    max_tokens: 100,\n});\nconsole.log(response.choices[0].text);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.completions().create(\n    \"gpt-4o\", \"Say hello\", 100);\n\nSystem.out.println(response.getChoices().get(0).getText());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.completions().create(\n    \"gpt-4o\", \"Say hello\", 100);\n\nSystem.out.println(response.getChoices().get(0).getText());"
           }
         ]
       }
@@ -2866,6 +3172,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerListResource"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "container_abc123def456",
+                      "object": "container",
+                      "name": "my-training-data",
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "container_abc123def456",
+                  "last_id": "container_abc123def456"
                 }
               }
             }
@@ -2942,12 +3262,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar containers = containerClient.GetContainers();\n\nforeach (var c in containers)\n    Console.WriteLine($\"{c.Id} {c.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar containers = containerClient.GetContainers();\n\nforeach (var c in containers)\n    Console.WriteLine($\"{c.Id} {c.Name}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst containers = await openai.containers.list();\nfor await (const c of containers) {\n    console.log(c.id, c.name);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst containers = await openai.containers.list();\nfor await (const c of containers) {\n    console.log(c.id, c.name);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar containers = openai.containers().list();\n\nfor (var c : containers) {\n    System.out.println(c.getId() + \" \" + c.getName());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar containers = openai.containers().list();\n\nfor (var c : containers) {\n    System.out.println(c.getId() + \" \" + c.getName());\n}"
           }
         ]
       },
@@ -2981,6 +3331,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerResource"
+                },
+                "example": {
+                  "id": "container_abc123def456",
+                  "object": "container",
+                  "name": "my-training-data",
+                  "created_at": 1741312436,
+                  "expires_after": null
                 }
               }
             }
@@ -3067,12 +3424,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-container\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-container\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-container\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-container\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar container = await containerClient\n    .CreateContainerAsync(\"my-container\");\n\nConsole.WriteLine(container.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar container = await containerClient\n    .CreateContainerAsync(\"my-container\");\n\nConsole.WriteLine(container.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst container = await openai.containers.create({\n    name: \"my-container\",\n});\nconsole.log(container.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst container = await openai.containers.create({\n    name: \"my-container\",\n});\nconsole.log(container.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar container = openai.containers()\n    .create(\"my-container\");\n\nSystem.out.println(container.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar container = openai.containers()\n    .create(\"my-container\");\n\nSystem.out.println(container.getId());"
           }
         ]
       }
@@ -3117,6 +3504,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerResource"
+                },
+                "example": {
+                  "id": "container_abc123def456",
+                  "object": "container",
+                  "name": "my-training-data",
+                  "created_at": 1741312436,
+                  "expires_after": null
                 }
               }
             }
@@ -3193,12 +3587,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar container = await containerClient\n    .GetContainerAsync(\"container_abc123\");\n\nConsole.WriteLine(container.Value.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar container = await containerClient\n    .GetContainerAsync(\"container_abc123\");\n\nConsole.WriteLine(container.Value.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst container = await openai.containers.retrieve(\"container_abc123\");\nconsole.log(container.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst container = await openai.containers.retrieve(\"container_abc123\");\nconsole.log(container.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar container = openai.containers()\n    .retrieve(\"container_abc123\");\n\nSystem.out.println(container.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar container = openai.containers()\n    .retrieve(\"container_abc123\");\n\nSystem.out.println(container.getName());"
           }
         ]
       },
@@ -3234,6 +3658,15 @@
                 "description": "A request ID used for troubleshooting purposes.",
                 "schema": {
                   "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "container_abc123",
+                  "object": "container.deleted",
+                  "deleted": true
                 }
               }
             }
@@ -3310,12 +3743,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nawait containerClient.DeleteContainerAsync(\"container_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nawait containerClient.DeleteContainerAsync(\"container_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.containers.delete(\"container_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.containers.delete(\"container_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.containers().delete(\"container_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.containers().delete(\"container_abc123\");"
           }
         ]
       }
@@ -3406,6 +3869,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerFileListResource"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "container_file_abc123",
+                      "object": "container.file",
+                      "container_id": "container_abc123def456",
+                      "path": "/data/training.jsonl",
+                      "created_at": 1741312436,
+                      "bytes": 2048
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "container_file_abc123",
+                  "last_id": "container_file_abc123"
                 }
               }
             }
@@ -3482,12 +3961,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar files = containerClient\n    .GetContainerFiles(\"container_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Path}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar files = containerClient\n    .GetContainerFiles(\"container_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Path}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.containers.files.list(\"container_abc123\");\nfor await (const f of files) {\n    console.log(f.id, f.path);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.containers.files.list(\"container_abc123\");\nfor await (const f of files) {\n    console.log(f.id, f.path);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.containers().files()\n    .list(\"container_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getPath());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.containers().files()\n    .list(\"container_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getPath());\n}"
           }
         ]
       },
@@ -3530,6 +4039,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerFileResource"
+                },
+                "example": {
+                  "id": "container_file_abc123",
+                  "object": "container.file",
+                  "container_id": "container_abc123def456",
+                  "path": "/data/training.jsonl",
+                  "created_at": 1741312436,
+                  "bytes": 2048,
+                  "source": "user"
                 }
               }
             }
@@ -3616,12 +4134,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F file=\"@data.txt\" \\\n  -F file_path=\"data.txt\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F file=\"@data.txt\" \\\n  -F file_path=\"data.txt\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F file=\"@data.txt\" \\\n  -F file_path=\"data.txt\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F file=\"@data.txt\" \\\n  -F file_path=\"data.txt\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar file = await containerClient.CreateContainerFileAsync(\n    \"container_abc123\",\n    File.OpenRead(\"data.txt\"), \"data.txt\");\n\nConsole.WriteLine(file.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar file = await containerClient.CreateContainerFileAsync(\n    \"container_abc123\",\n    File.OpenRead(\"data.txt\"), \"data.txt\");\n\nConsole.WriteLine(file.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.containers.files.create(\"container_abc123\", {\n    file: fs.createReadStream(\"data.txt\"),\n    file_path: \"data.txt\",\n});\nconsole.log(file.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.containers.files.create(\"container_abc123\", {\n    file: fs.createReadStream(\"data.txt\"),\n    file_path: \"data.txt\",\n});\nconsole.log(file.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.containers().files()\n    .create(\"container_abc123\",\n        Path.of(\"data.txt\"), \"data.txt\");\n\nSystem.out.println(file.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.containers().files()\n    .create(\"container_abc123\",\n        Path.of(\"data.txt\"), \"data.txt\");\n\nSystem.out.println(file.getId());"
           }
         ]
       }
@@ -3675,6 +4223,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerFileResource"
+                },
+                "example": {
+                  "id": "container_file_abc123",
+                  "object": "container.file",
+                  "container_id": "container_abc123def456",
+                  "path": "/data/training.jsonl",
+                  "created_at": 1741312436,
+                  "bytes": 2048,
+                  "source": "user"
                 }
               }
             }
@@ -3751,12 +4308,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar file = await containerClient.GetContainerFileAsync(\n    \"container_abc123\", \"file_abc123\");\n\nConsole.WriteLine(file.Value.Path);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar file = await containerClient.GetContainerFileAsync(\n    \"container_abc123\", \"file_abc123\");\n\nConsole.WriteLine(file.Value.Path);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.containers.files.retrieve(\n    \"container_abc123\", \"file_abc123\"\n);\nconsole.log(file.path);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.containers.files.retrieve(\n    \"container_abc123\", \"file_abc123\"\n);\nconsole.log(file.path);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.containers().files()\n    .retrieve(\"container_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getPath());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.containers().files()\n    .retrieve(\"container_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getPath());"
           }
         ]
       },
@@ -3801,6 +4388,15 @@
                 "description": "A request ID used for troubleshooting purposes.",
                 "schema": {
                   "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "file_abc123",
+                  "object": "container.file.deleted",
+                  "deleted": true
                 }
               }
             }
@@ -3877,12 +4473,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nawait containerClient.DeleteContainerFileAsync(\n    \"container_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nawait containerClient.DeleteContainerFileAsync(\n    \"container_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.containers.files.delete(\n    \"container_abc123\", \"file_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.containers.files.delete(\n    \"container_abc123\", \"file_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.containers().files()\n    .delete(\"container_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.containers().files()\n    .delete(\"container_abc123\", \"file_abc123\");"
           }
         ]
       }
@@ -4012,12 +4638,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar content = await containerClient\n    .GetContainerFileContentAsync(\n        \"container_abc123\", \"file_abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar content = await containerClient\n    .GetContainerFileContentAsync(\n        \"container_abc123\", \"file_abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.containers.files.content(\n    \"container_abc123\", \"file_abc123\"\n);\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.containers.files.content(\n    \"container_abc123\", \"file_abc123\"\n);\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.containers().files()\n    .content(\"container_abc123\", \"file_abc123\");\n\nSystem.out.println(new String(content));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.containers().files()\n    .content(\"container_abc123\", \"file_abc123\");\n\nSystem.out.println(new String(content));"
           }
         ]
       }
@@ -4053,6 +4709,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationResource"
+                },
+                "example": {
+                  "id": "conv_abc123def456",
+                  "object": "conversation",
+                  "created_at": 1741312436,
+                  "metadata": {}
                 }
               }
             }
@@ -4129,22 +4791,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nconversation = openai.conversations.create(\n    items=[{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}],\n)\nprint(conversation.id)\n# Output: conv_abc123def456"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nconversation = openai.conversations.create(\n    items=[{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}],\n)\nprint(conversation.id)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nconversation = openai.conversations.create(\n    items=[{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}],\n)\nprint(conversation.id)\n# Output: conv_abc123def456"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nconversation = openai.conversations.create(\n    items=[{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}],\n)\nprint(conversation.id)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/conversations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/conversations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}]}'"
           },
           {
             "lang": "csharp",
@@ -4165,6 +4827,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst conversation = await openai.conversations.create({\n    items: [{ type: \"message\", role: \"user\", content: \"Hello\" }],\n});\nconsole.log(conversation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations().create(\n    List.of(Map.of(\"type\", \"message\", \"role\", \"user\",\n        \"content\", \"Hello\")));\n\nSystem.out.println(conversation.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations().create(\n    List.of(Map.of(\"type\", \"message\", \"role\", \"user\",\n        \"content\", \"Hello\")));\n\nSystem.out.println(conversation.getId());"
           }
         ]
       }
@@ -4209,6 +4881,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationResource"
+                },
+                "example": {
+                  "id": "conv_abc123def456",
+                  "object": "conversation",
+                  "created_at": 1741312436,
+                  "metadata": {}
                 }
               }
             }
@@ -4285,12 +4963,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar conversation = client.OpenAI.Conversations\n    .GetConversation(\"conv_abc123\");\n\nConsole.WriteLine(conversation.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar conversation = client.OpenAI.Conversations\n    .GetConversation(\"conv_abc123\");\n\nConsole.WriteLine(conversation.Id);"
           },
           {
             "lang": "javascript",
@@ -4301,6 +4989,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst conversation = await openai.conversations.retrieve(\"conv_abc123\");\nconsole.log(conversation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations()\n    .retrieve(\"conv_abc123\");\n\nSystem.out.println(conversation.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations()\n    .retrieve(\"conv_abc123\");\n\nSystem.out.println(conversation.getId());"
           }
         ]
       },
@@ -4343,6 +5041,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationResource"
+                },
+                "example": {
+                  "id": "conv_abc123def456",
+                  "object": "conversation",
+                  "created_at": 1741312436,
+                  "metadata": {
+                    "topic": "customer-support"
+                  }
                 }
               }
             }
@@ -4429,12 +5135,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"geography\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"geography\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"geography\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"geography\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar conversation = client.OpenAI.Conversations\n    .UpdateConversation(\"conv_abc123\",\n        new { metadata = new { topic = \"geography\" } });\n\nConsole.WriteLine(conversation.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar conversation = client.OpenAI.Conversations\n    .UpdateConversation(\"conv_abc123\",\n        new { metadata = new { topic = \"geography\" } });\n\nConsole.WriteLine(conversation.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst conversation = await openai.conversations.update(\"conv_abc123\", {\n    metadata: { topic: \"geography\" },\n});\nconsole.log(conversation.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst conversation = await openai.conversations.update(\"conv_abc123\", {\n    metadata: { topic: \"geography\" },\n});\nconsole.log(conversation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations()\n    .update(\"conv_abc123\",\n        Map.of(\"metadata\", Map.of(\"topic\", \"geography\")));\n\nSystem.out.println(conversation.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations()\n    .update(\"conv_abc123\",\n        Map.of(\"metadata\", Map.of(\"topic\", \"geography\")));\n\nSystem.out.println(conversation.getId());"
           }
         ]
       },
@@ -4477,6 +5213,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeletedConversationResource"
+                },
+                "example": {
+                  "id": "conv_abc123def456",
+                  "object": "conversation",
+                  "deleted": true
                 }
               }
             }
@@ -4553,12 +5294,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.OpenAI.Conversations\n    .DeleteConversation(\"conv_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.OpenAI.Conversations\n    .DeleteConversation(\"conv_abc123\");"
           },
           {
             "lang": "javascript",
@@ -4569,6 +5320,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.conversations.delete(\"conv_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().delete(\"conv_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().delete(\"conv_abc123\");"
           }
         ]
       }
@@ -4662,6 +5423,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationItemList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "convitem_abc123",
+                      "object": "conversation.item",
+                      "conversation_id": "conv_abc123def456",
+                      "role": "user",
+                      "type": "message",
+                      "content": [
+                        {
+                          "type": "input_text",
+                          "text": "Hello!"
+                        }
+                      ],
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "convitem_abc123",
+                  "last_id": "convitem_abc123"
                 }
               }
             }
@@ -4738,12 +5521,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar items = client.OpenAI.Conversations\n    .GetConversationItems(\"conv_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine($\"{item.Type} {item.Id}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar items = client.OpenAI.Conversations\n    .GetConversationItems(\"conv_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine($\"{item.Type} {item.Id}\");"
           },
           {
             "lang": "javascript",
@@ -4754,6 +5547,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.conversations.items.list(\"conv_abc123\");\nfor await (const item of items) {\n    console.log(item.type, item.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.conversations().items()\n    .list(\"conv_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getType() + \" \" + item.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.conversations().items()\n    .list(\"conv_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getType() + \" \" + item.getId());\n}"
           }
         ]
       },
@@ -4809,6 +5612,25 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationItemList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "convitem_abc123",
+                      "object": "conversation.item",
+                      "conversation_id": "conv_abc123def456",
+                      "role": "user",
+                      "type": "message",
+                      "content": [
+                        {
+                          "type": "input_text",
+                          "text": "Hello!"
+                        }
+                      ],
+                      "created_at": 1741312436
+                    }
+                  ]
                 }
               }
             }
@@ -4895,12 +5717,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Follow-up\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Follow-up\"}]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Follow-up\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Follow-up\"}]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.OpenAI.Conversations\n    .CreateConversationItems(\"conv_abc123\",\n        new { items = new[] {\n            new { type = \"message\", role = \"user\", content = \"Follow-up\" }\n        }});"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.OpenAI.Conversations\n    .CreateConversationItems(\"conv_abc123\",\n        new { items = new[] {\n            new { type = \"message\", role = \"user\", content = \"Follow-up\" }\n        }});"
           },
           {
             "lang": "javascript",
@@ -4911,6 +5743,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.conversations.items.create(\"conv_abc123\", {\n    items: [{ type: \"message\", role: \"user\", content: \"Follow-up\" }],\n});"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().items().create(\"conv_abc123\",\n    List.of(Map.of(\"type\", \"message\", \"role\", \"user\",\n        \"content\", \"Follow-up\")));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().items().create(\"conv_abc123\",\n    List.of(Map.of(\"type\", \"message\", \"role\", \"user\",\n        \"content\", \"Follow-up\")));"
           }
         ]
       }
@@ -4977,6 +5819,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationItem"
+                },
+                "example": {
+                  "id": "convitem_abc123",
+                  "object": "conversation.item",
+                  "conversation_id": "conv_abc123def456",
+                  "role": "user",
+                  "type": "message",
+                  "content": [
+                    {
+                      "type": "input_text",
+                      "text": "Hello!"
+                    }
+                  ],
+                  "created_at": 1741312436
                 }
               }
             }
@@ -5053,12 +5909,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar item = client.OpenAI.Conversations\n    .GetConversationItem(\"conv_abc123\", \"item_abc123\");\n\nConsole.WriteLine(item.Type);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar item = client.OpenAI.Conversations\n    .GetConversationItem(\"conv_abc123\", \"item_abc123\");\n\nConsole.WriteLine(item.Type);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst item = await openai.conversations.items.retrieve(\n    \"conv_abc123\", \"item_abc123\"\n);\nconsole.log(item.type);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst item = await openai.conversations.items.retrieve(\n    \"conv_abc123\", \"item_abc123\"\n);\nconsole.log(item.type);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar item = openai.conversations().items()\n    .retrieve(\"conv_abc123\", \"item_abc123\");\n\nSystem.out.println(item.getType());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar item = openai.conversations().items()\n    .retrieve(\"conv_abc123\", \"item_abc123\");\n\nSystem.out.println(item.getType());"
           }
         ]
       },
@@ -5110,6 +5996,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationResource"
+                },
+                "example": {
+                  "id": "convitem_abc123",
+                  "object": "conversation.item",
+                  "deleted": true
                 }
               }
             }
@@ -5186,12 +6077,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.OpenAI.Conversations\n    .DeleteConversationItem(\"conv_abc123\", \"item_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.OpenAI.Conversations\n    .DeleteConversationItem(\"conv_abc123\", \"item_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.conversations.items.delete(\n    \"conv_abc123\", \"item_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.conversations.items.delete(\n    \"conv_abc123\", \"item_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().items()\n    .delete(\"conv_abc123\", \"item_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().items()\n    .delete(\"conv_abc123\", \"item_abc123\");"
           }
         ]
       }
@@ -5228,6 +6149,27 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.CreateEmbeddingResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "object": "embedding",
+                      "embedding": [
+                        -0.0128,
+                        -0.0074,
+                        -0.0176,
+                        -0.0283,
+                        -0.0187
+                      ],
+                      "index": 0
+                    }
+                  ],
+                  "model": "text-embedding-3-large",
+                  "usage": {
+                    "prompt_tokens": 5,
+                    "total_tokens": 5
+                  }
                 }
               }
             }
@@ -5304,22 +6246,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.embeddings.create(\n    model=\"text-embedding-3-large\",\n    input=\"Sample text to embed\",\n)\nprint(response.data[0].embedding[:5])\n# Output: [-0.0128, -0.0074, -0.0176, -0.0283, -0.0187]"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.embeddings.create(\n    model=\"text-embedding-3-large\",\n    input=\"Sample text to embed\",\n)\nprint(response.data[0].embedding[:5])\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.embeddings.create(\n    model=\"text-embedding-3-large\",\n    input=\"Sample text to embed\",\n)\nprint(response.data[0].embedding[:5])\n# Output: [-0.0128, -0.0074, -0.0176, -0.0283, -0.0187]"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.embeddings.create(\n    model=\"text-embedding-3-large\",\n    input=\"Sample text to embed\",\n)\nprint(response.data[0].embedding[:5])\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/embeddings\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"text-embedding-3-large\", \"input\": \"Sample text\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/embeddings\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"text-embedding-3-large\", \"input\": \"Sample text\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/embeddings\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"text-embedding-3-large\", \"input\": \"Sample text\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/embeddings\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"text-embedding-3-large\", \"input\": \"Sample text\"}'"
           },
           {
             "lang": "csharp",
@@ -5340,6 +6282,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.embeddings.create({\n    model: \"text-embedding-3-large\",\n    input: \"Sample text to embed\",\n});\nconsole.log(response.data[0].embedding.slice(0, 5));"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.embeddings().create(\n    \"text-embedding-3-large\", \"Sample text to embed\");\n\nSystem.out.println(\n    response.getData().get(0).getEmbedding().size());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.embeddings().create(\n    \"text-embedding-3-large\", \"Sample text to embed\");\n\nSystem.out.println(\n    response.getData().get(0).getEmbedding().size());"
           }
         ]
       }
@@ -5428,6 +6380,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "eval_abc123def456",
+                      "object": "eval",
+                      "name": "My Evaluation",
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "eval_abc123def456",
+                  "last_id": "eval_abc123def456"
                 }
               }
             }
@@ -5504,12 +6470,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evals = evalClient.GetEvals();\n\nforeach (var e in evals)\n    Console.WriteLine($\"{e.Id} {e.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evals = evalClient.GetEvals();\n\nforeach (var e in evals)\n    Console.WriteLine($\"{e.Id} {e.Name}\");"
           },
           {
             "lang": "javascript",
@@ -5520,6 +6496,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evals = await openai.evals.list();\nfor await (const e of evals) {\n    console.log(e.id, e.name);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evals = openai.evals().list();\n\nfor (var e : evals) {\n    System.out.println(e.getId() + \" \" + e.getName());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evals = openai.evals().list();\n\nfor (var e : evals) {\n    System.out.println(e.getId() + \" \" + e.getName());\n}"
           }
         ]
       },
@@ -5554,6 +6540,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.Eval"
+                },
+                "example": {
+                  "id": "eval_abc123def456",
+                  "object": "eval",
+                  "name": "My Evaluation",
+                  "created_at": 1741312436,
+                  "data_source_config": {
+                    "type": "custom",
+                    "item_schema": {}
+                  },
+                  "testing_criteria": [],
+                  "metadata": {}
                 }
               }
             }
@@ -5707,12 +6705,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-eval\", \"data_source_config\": {\"type\": \"custom\", \"item_schema\": {}}, \"testing_criteria\": []}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-eval\", \"data_source_config\": {\"type\": \"custom\", \"item_schema\": {}}, \"testing_criteria\": []}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-eval\", \"data_source_config\": {\"type\": \"custom\", \"item_schema\": {}}, \"testing_criteria\": []}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-eval\", \"data_source_config\": {\"type\": \"custom\", \"item_schema\": {}}, \"testing_criteria\": []}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.CreateEvalAsync(\n    \"my-eval\",\n    new { type = \"custom\", item_schema = new { } },\n    new object[] { });\n\nConsole.WriteLine(evaluation.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.CreateEvalAsync(\n    \"my-eval\",\n    new { type = \"custom\", item_schema = new { } },\n    new object[] { });\n\nConsole.WriteLine(evaluation.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.create({\n    name: \"my-eval\",\n    data_source_config: { type: \"custom\", item_schema: {} },\n    testing_criteria: [],\n});\nconsole.log(evaluation.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.create({\n    name: \"my-eval\",\n    data_source_config: { type: \"custom\", item_schema: {} },\n    testing_criteria: [],\n});\nconsole.log(evaluation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals().create(\n    \"my-eval\",\n    Map.of(\"type\", \"custom\", \"item_schema\", Map.of()),\n    List.of());\n\nSystem.out.println(evaluation.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals().create(\n    \"my-eval\",\n    Map.of(\"type\", \"custom\", \"item_schema\", Map.of()),\n    List.of());\n\nSystem.out.println(evaluation.getId());"
           }
         ]
       }
@@ -5758,6 +6786,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.Eval"
+                },
+                "example": {
+                  "id": "eval_abc123def456",
+                  "object": "eval",
+                  "name": "My Evaluation",
+                  "created_at": 1741312436,
+                  "data_source_config": {
+                    "type": "custom",
+                    "item_schema": {}
+                  },
+                  "testing_criteria": [],
+                  "metadata": {}
                 }
               }
             }
@@ -5834,12 +6874,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.GetEvalAsync(\"eval_abc123\");\n\nConsole.WriteLine($\"{evaluation.Value.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.GetEvalAsync(\"eval_abc123\");\n\nConsole.WriteLine($\"{evaluation.Value.Name}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.retrieve(\"eval_abc123\");\nconsole.log(evaluation.name, evaluation.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.retrieve(\"eval_abc123\");\nconsole.log(evaluation.name, evaluation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals()\n    .retrieve(\"eval_abc123\");\n\nSystem.out.println(evaluation.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals()\n    .retrieve(\"eval_abc123\");\n\nSystem.out.println(evaluation.getName());"
           }
         ]
       },
@@ -5882,6 +6952,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.Eval"
+                },
+                "example": {
+                  "id": "eval_abc123def456",
+                  "object": "eval",
+                  "name": "Updated Evaluation",
+                  "created_at": 1741312436,
+                  "data_source_config": {
+                    "type": "custom",
+                    "item_schema": {}
+                  },
+                  "testing_criteria": [],
+                  "metadata": {}
                 }
               }
             }
@@ -5976,12 +7058,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.UpdateEvalAsync(\n    \"eval_abc123\", name: \"updated-name\");\n\nConsole.WriteLine(evaluation.Value.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.UpdateEvalAsync(\n    \"eval_abc123\", name: \"updated-name\");\n\nConsole.WriteLine(evaluation.Value.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.update(\"eval_abc123\", {\n    name: \"updated-name\",\n});\nconsole.log(evaluation.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.update(\"eval_abc123\", {\n    name: \"updated-name\",\n});\nconsole.log(evaluation.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals()\n    .update(\"eval_abc123\", Map.of(\"name\", \"updated-name\"));\n\nSystem.out.println(evaluation.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals()\n    .update(\"eval_abc123\", Map.of(\"name\", \"updated-name\"));\n\nSystem.out.println(evaluation.getName());"
           }
         ]
       },
@@ -6043,6 +7155,11 @@
                       "type": "string"
                     }
                   }
+                },
+                "example": {
+                  "id": "eval_abc123def456",
+                  "object": "eval",
+                  "deleted": true
                 }
               }
             }
@@ -6119,12 +7236,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.DeleteEvalAsync(\"eval_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.DeleteEvalAsync(\"eval_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.delete(\"eval_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.delete(\"eval_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().delete(\"eval_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().delete(\"eval_abc123\");"
           }
         ]
       }
@@ -6220,6 +7367,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRunList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "evalrun_abc123def456",
+                      "object": "eval.run",
+                      "eval_id": "eval_abc123def456",
+                      "status": "completed",
+                      "created_at": 1741312436,
+                      "model": "gpt-4o-2024-11-20",
+                      "result_counts": {
+                        "total": 50,
+                        "passed": 45,
+                        "failed": 3,
+                        "errored": 2
+                      }
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "evalrun_abc123def456",
+                  "last_id": "evalrun_abc123def456"
                 }
               }
             }
@@ -6296,12 +7465,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar runs = evalClient.GetEvalRuns(\"eval_abc123\");\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Id} {run.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar runs = evalClient.GetEvalRuns(\"eval_abc123\");\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Id} {run.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst runs = await openai.evals.runs.list(\"eval_abc123\");\nfor await (const run of runs) {\n    console.log(run.id, run.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst runs = await openai.evals.runs.list(\"eval_abc123\");\nfor await (const run of runs) {\n    console.log(run.id, run.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar runs = openai.evals().runs().list(\"eval_abc123\");\n\nfor (var run : runs) {\n    System.out.println(run.getId() + \" \" + run.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar runs = openai.evals().runs().list(\"eval_abc123\");\n\nfor (var run : runs) {\n    System.out.println(run.getId() + \" \" + run.getStatus());\n}"
           }
         ]
       },
@@ -6344,6 +7543,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRun"
+                },
+                "example": {
+                  "id": "evalrun_abc123def456",
+                  "object": "eval.run",
+                  "eval_id": "eval_abc123def456",
+                  "status": "queued",
+                  "created_at": 1741312436,
+                  "model": "gpt-4o-2024-11-20",
+                  "result_counts": {
+                    "total": 0,
+                    "passed": 0,
+                    "failed": 0,
+                    "errored": 0
+                  }
                 }
               }
             }
@@ -6430,12 +7643,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"data_source\": {\"type\": \"completions\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"data_source\": {\"type\": \"completions\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"data_source\": {\"type\": \"completions\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"data_source\": {\"type\": \"completions\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar run = await evalClient.CreateEvalRunAsync(\n    \"eval_abc123\", \"gpt-4o\",\n    new { type = \"completions\" });\n\nConsole.WriteLine(run.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar run = await evalClient.CreateEvalRunAsync(\n    \"eval_abc123\", \"gpt-4o\",\n    new { type = \"completions\" });\n\nConsole.WriteLine(run.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.evals.runs.create(\"eval_abc123\", {\n    model: \"gpt-4o\",\n    data_source: { type: \"completions\" },\n});\nconsole.log(run.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.evals.runs.create(\"eval_abc123\", {\n    model: \"gpt-4o\",\n    data_source: { type: \"completions\" },\n});\nconsole.log(run.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.evals().runs().create(\n    \"eval_abc123\", \"gpt-4o\",\n    Map.of(\"type\", \"completions\"));\n\nSystem.out.println(run.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.evals().runs().create(\n    \"eval_abc123\", \"gpt-4o\",\n    Map.of(\"type\", \"completions\"));\n\nSystem.out.println(run.getId());"
           }
         ]
       }
@@ -6488,6 +7731,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRun"
+                },
+                "example": {
+                  "id": "evalrun_abc123def456",
+                  "object": "eval.run",
+                  "eval_id": "eval_abc123def456",
+                  "status": "completed",
+                  "created_at": 1741312436,
+                  "model": "gpt-4o-2024-11-20",
+                  "result_counts": {
+                    "total": 50,
+                    "passed": 45,
+                    "failed": 3,
+                    "errored": 2
+                  }
                 }
               }
             }
@@ -6564,12 +7821,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar run = await evalClient.GetEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar run = await evalClient.GetEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.evals.runs.retrieve(\n    \"eval_abc123\", \"run_abc123\"\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.evals.runs.retrieve(\n    \"eval_abc123\", \"run_abc123\"\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.evals().runs()\n    .retrieve(\"eval_abc123\", \"run_abc123\");\n\nSystem.out.println(run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.evals().runs()\n    .retrieve(\"eval_abc123\", \"run_abc123\");\n\nSystem.out.println(run.getStatus());"
           }
         ]
       },
@@ -6620,6 +7907,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRun"
+                },
+                "example": {
+                  "id": "evalrun_abc123def456",
+                  "object": "eval.run",
+                  "eval_id": "eval_abc123def456",
+                  "status": "canceled",
+                  "created_at": 1741312436,
+                  "model": "gpt-4o-2024-11-20"
                 }
               }
             }
@@ -6696,12 +7991,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.CancelEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.CancelEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.runs.cancel(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.runs.cancel(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().runs()\n    .cancel(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().runs()\n    .cancel(\"eval_abc123\", \"run_abc123\");"
           }
         ]
       },
@@ -6771,6 +8096,11 @@
                       "type": "string"
                     }
                   }
+                },
+                "example": {
+                  "id": "evalrun_abc123def456",
+                  "object": "eval.run",
+                  "deleted": true
                 }
               }
             }
@@ -6847,12 +8177,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.DeleteEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.DeleteEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.runs.delete(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.runs.delete(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().runs()\n    .delete(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().runs()\n    .delete(\"eval_abc123\", \"run_abc123\");"
           }
         ]
       }
@@ -6952,6 +8312,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRunOutputItemList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "evalrunitem_abc123",
+                      "object": "eval.run.output_item",
+                      "eval_run_id": "evalrun_abc123def456",
+                      "status": "pass",
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "evalrunitem_abc123",
+                  "last_id": "evalrunitem_abc123"
                 }
               }
             }
@@ -7028,12 +8403,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar items = evalClient.GetEvalRunOutputItems(\n    \"eval_abc123\", \"run_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine(item.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar items = evalClient.GetEvalRunOutputItems(\n    \"eval_abc123\", \"run_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine(item.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.evals.runs.outputItems\n    .list(\"eval_abc123\", \"run_abc123\");\nfor await (const item of items) {\n    console.log(item.id);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.evals.runs.outputItems\n    .list(\"eval_abc123\", \"run_abc123\");\nfor await (const item of items) {\n    console.log(item.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.evals().runs().outputItems()\n    .list(\"eval_abc123\", \"run_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.evals().runs().outputItems()\n    .list(\"eval_abc123\", \"run_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getId());\n}"
           }
         ]
       }
@@ -7094,6 +8499,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRunOutputItem"
+                },
+                "example": {
+                  "id": "evalrunitem_abc123",
+                  "object": "eval.run.output_item",
+                  "eval_run_id": "evalrun_abc123def456",
+                  "status": "pass",
+                  "created_at": 1741312436
                 }
               }
             }
@@ -7170,12 +8582,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar item = await evalClient.GetEvalRunOutputItemAsync(\n    \"eval_abc123\", \"run_abc123\", \"item_abc123\");\n\nConsole.WriteLine(item.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar item = await evalClient.GetEvalRunOutputItemAsync(\n    \"eval_abc123\", \"run_abc123\", \"item_abc123\");\n\nConsole.WriteLine(item.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst item = await openai.evals.runs.outputItems\n    .retrieve(\"eval_abc123\", \"run_abc123\", \"item_abc123\");\nconsole.log(item.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst item = await openai.evals.runs.outputItems\n    .retrieve(\"eval_abc123\", \"run_abc123\", \"item_abc123\");\nconsole.log(item.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar item = openai.evals().runs().outputItems()\n    .retrieve(\"eval_abc123\", \"run_abc123\",\n        \"item_abc123\");\n\nSystem.out.println(item.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar item = openai.evals().runs().outputItems()\n    .retrieve(\"eval_abc123\", \"run_abc123\",\n        \"item_abc123\");\n\nSystem.out.println(item.getId());"
           }
         ]
       }
@@ -7282,6 +8724,14 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "file-abc123def456",
+                  "object": "file",
+                  "bytes": 140,
+                  "created_at": 1741312436,
+                  "filename": "training_data.jsonl",
+                  "purpose": "fine-tune"
                 }
               }
             }
@@ -7358,22 +8808,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nfile = openai.files.create(\n    file=open(\"data.jsonl\", \"rb\"),\n    purpose=\"fine-tune\",\n)\nprint(file.id)\n# Output: file-abc123def456"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nfile = openai.files.create(\n    file=open(\"data.jsonl\", \"rb\"),\n    purpose=\"fine-tune\",\n)\nprint(file.id)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nfile = openai.files.create(\n    file=open(\"data.jsonl\", \"rb\"),\n    purpose=\"fine-tune\",\n)\nprint(file.id)\n# Output: file-abc123def456"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nfile = openai.files.create(\n    file=open(\"data.jsonl\", \"rb\"),\n    purpose=\"fine-tune\",\n)\nprint(file.id)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@data.jsonl\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@data.jsonl\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@data.jsonl\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@data.jsonl\""
           },
           {
             "lang": "csharp",
@@ -7394,6 +8844,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.files.create({\n    file: fs.createReadStream(\"data.jsonl\"),\n    purpose: \"fine-tune\",\n});\nconsole.log(file.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.files().create(\n    Path.of(\"data.jsonl\"), \"fine-tune\");\n\nSystem.out.println(file.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.files().create(\n    Path.of(\"data.jsonl\"), \"fine-tune\");\n\nSystem.out.println(file.getId());"
           }
         ]
       },
@@ -7467,6 +8927,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFilesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "file-abc123def456",
+                      "object": "file",
+                      "bytes": 140,
+                      "created_at": 1741312436,
+                      "filename": "training_data.jsonl",
+                      "purpose": "fine-tune"
+                    }
+                  ]
                 }
               }
             }
@@ -7543,12 +9016,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -7569,6 +9042,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.files.list();\nfor await (const f of files) {\n    console.log(f.id, f.filename);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.files().list();\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getFilename());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.files().list();\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getFilename());\n}"
           }
         ]
       }
@@ -7684,6 +9167,14 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "file-abc123def456",
+                  "object": "file",
+                  "bytes": 140,
+                  "created_at": 1741312436,
+                  "filename": "training_data.jsonl",
+                  "purpose": "fine-tune"
                 }
               }
             }
@@ -7760,12 +9251,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nvar file = await fileClient.GetFileAsync(\"file-abc123\");\n\nConsole.WriteLine($\"{file.Value.Filename} {file.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nvar file = await fileClient.GetFileAsync(\"file-abc123\");\n\nConsole.WriteLine($\"{file.Value.Filename} {file.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.files.retrieve(\"file-abc123\");\nconsole.log(file.filename, file.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.files.retrieve(\"file-abc123\");\nconsole.log(file.filename, file.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.files().retrieve(\"file-abc123\");\n\nSystem.out.println(file.getFilename() + \" \" + file.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.files().retrieve(\"file-abc123\");\n\nSystem.out.println(file.getFilename() + \" \" + file.getStatus());"
           }
         ]
       },
@@ -7808,6 +9329,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteFileResponse"
+                },
+                "example": {
+                  "id": "file-abc123def456",
+                  "object": "file",
+                  "deleted": true
                 }
               }
             }
@@ -7884,12 +9410,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nawait fileClient.DeleteFileAsync(\"file-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nawait fileClient.DeleteFileAsync(\"file-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.files.delete(\"file-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.files.delete(\"file-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.files().delete(\"file-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.files().delete(\"file-abc123\");"
           }
         ]
       }
@@ -8010,12 +9566,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/files/file-abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/files/file-abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/files/file-abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/files/file-abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nvar content = await fileClient.DownloadFileAsync(\"file-abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nvar content = await fileClient.DownloadFileAsync(\"file-abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.files.content(\"file-abc123\");\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.files.content(\"file-abc123\");\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.files().content(\"file-abc123\");\n\nSystem.out.println(new String(content));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.files().content(\"file-abc123\");\n\nSystem.out.println(new String(content));"
           }
         ]
       }
@@ -8043,6 +9629,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunGraderResponse"
+                },
+                "example": {
+                  "result": {
+                    "score": 0.95,
+                    "passed": true,
+                    "explanation": "The response accurately answered the question."
+                  }
                 }
               }
             }
@@ -8129,12 +9722,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/run\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}, \"model_sample\": \"Hello\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/run\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}, \"model_sample\": \"Hello\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/run\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}, \"model_sample\": \"Hello\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/run\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}, \"model_sample\": \"Hello\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar result = await ftClient.RunGraderAsync(\n    new { type = \"python\", source = \"return 1.0\" },\n    \"Hello world\");\n\nConsole.WriteLine(result);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar result = await ftClient.RunGraderAsync(\n    new { type = \"python\", source = \"return 1.0\" },\n    \"Hello world\");\n\nConsole.WriteLine(result);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst result = await openai.fineTuning.alpha.graders.run({\n    grader: { type: \"python\", source: \"return 1.0\" },\n    model_sample: \"Hello world\",\n});\nconsole.log(result);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst result = await openai.fineTuning.alpha.graders.run({\n    grader: { type: \"python\", source: \"return 1.0\" },\n    model_sample: \"Hello world\",\n});\nconsole.log(result);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar result = openai.fineTuning().alpha().graders()\n    .run(Map.of(\"type\", \"python\", \"source\", \"return 1.0\"),\n        \"Hello world\");\n\nSystem.out.println(result);"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar result = openai.fineTuning().alpha().graders()\n    .run(Map.of(\"type\", \"python\", \"source\", \"return 1.0\"),\n        \"Hello world\");\n\nSystem.out.println(result);"
           }
         ]
       }
@@ -8162,6 +9785,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ValidateGraderResponse"
+                },
+                "example": {
+                  "valid": true,
+                  "errors": []
                 }
               }
             }
@@ -8272,12 +9899,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/validate\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/validate\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/validate\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/validate\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar result = await ftClient.ValidateGraderAsync(\n    new { type = \"python\", source = \"return 1.0\" });\n\nConsole.WriteLine(result);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar result = await ftClient.ValidateGraderAsync(\n    new { type = \"python\", source = \"return 1.0\" });\n\nConsole.WriteLine(result);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst result = await openai.fineTuning.alpha.graders.validate({\n    grader: { type: \"python\", source: \"return 1.0\" },\n});\nconsole.log(result);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst result = await openai.fineTuning.alpha.graders.validate({\n    grader: { type: \"python\", source: \"return 1.0\" },\n});\nconsole.log(result);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar result = openai.fineTuning().alpha().graders()\n    .validate(Map.of(\"type\", \"python\",\n        \"source\", \"return 1.0\"));\n\nSystem.out.println(result);"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar result = openai.fineTuning().alpha().graders()\n    .validate(Map.of(\"type\", \"python\",\n        \"source\", \"return 1.0\"));\n\nSystem.out.println(result);"
           }
         ]
       }
@@ -8370,6 +10027,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFineTuningCheckpointPermissionResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "ftckptperm-abc123",
+                      "object": "fine_tuning.job.checkpoint.permission",
+                      "created_at": 1741312436,
+                      "project_id": "proj-abc123"
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "ftckptperm-abc123",
+                  "last_id": "ftckptperm-abc123"
                 }
               }
             }
@@ -8446,12 +10117,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar permissions = ftClient.GetCheckpointPermissions(\n    \"ft:gpt-4o:org:suffix:id\");\n\nforeach (var p in permissions)\n    Console.WriteLine(p.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar permissions = ftClient.GetCheckpointPermissions(\n    \"ft:gpt-4o:org:suffix:id\");\n\nforeach (var p in permissions)\n    Console.WriteLine(p.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst permissions = await openai.fineTuning.checkpoints\n    .permissions.list(\"ft:gpt-4o:org:suffix:id\");\nfor await (const p of permissions) {\n    console.log(p.id);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst permissions = await openai.fineTuning.checkpoints\n    .permissions.list(\"ft:gpt-4o:org:suffix:id\");\nfor await (const p of permissions) {\n    console.log(p.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar permissions = openai.fineTuning().checkpoints()\n    .permissions().list(\"ft:gpt-4o:org:suffix:id\");\n\nfor (var p : permissions) {\n    System.out.println(p.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar permissions = openai.fineTuning().checkpoints()\n    .permissions().list(\"ft:gpt-4o:org:suffix:id\");\n\nfor (var p : permissions) {\n    System.out.println(p.getId());\n}"
           }
         ]
       },
@@ -8495,6 +10196,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFineTuningCheckpointPermissionResponse"
+                },
+                "example": {
+                  "id": "ftckptperm-abc123",
+                  "object": "fine_tuning.job.checkpoint.permission",
+                  "created_at": 1741312436,
+                  "project_id": "proj-abc123"
                 }
               }
             }
@@ -8581,12 +10288,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"project_ids\": [\"proj_abc123\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"project_ids\": [\"proj_abc123\"]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"project_ids\": [\"proj_abc123\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"project_ids\": [\"proj_abc123\"]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CreateCheckpointPermissionAsync(\n    \"ft:gpt-4o:org:suffix:id\",\n    new[] { \"proj_abc123\" });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CreateCheckpointPermissionAsync(\n    \"ft:gpt-4o:org:suffix:id\",\n    new[] { \"proj_abc123\" });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.checkpoints.permissions.create(\n    \"ft:gpt-4o:org:suffix:id\",\n    { project_ids: [\"proj_abc123\"] }\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.checkpoints.permissions.create(\n    \"ft:gpt-4o:org:suffix:id\",\n    { project_ids: [\"proj_abc123\"] }\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().checkpoints().permissions()\n    .create(\"ft:gpt-4o:org:suffix:id\",\n        List.of(\"proj_abc123\"));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().checkpoints().permissions()\n    .create(\"ft:gpt-4o:org:suffix:id\",\n        List.of(\"proj_abc123\"));"
           }
         ]
       }
@@ -8641,6 +10378,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteFineTuningCheckpointPermissionResponse"
+                },
+                "example": {
+                  "id": "ftckptperm-abc123",
+                  "object": "fine_tuning.job.checkpoint.permission",
+                  "deleted": true
                 }
               }
             }
@@ -8717,12 +10459,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions/perm_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions/perm_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions/perm_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions/perm_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.DeleteCheckpointPermissionAsync(\n    \"ft:gpt-4o:org:suffix:id\", \"perm_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.DeleteCheckpointPermissionAsync(\n    \"ft:gpt-4o:org:suffix:id\", \"perm_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.checkpoints.permissions.delete(\n    \"ft:gpt-4o:org:suffix:id\", \"perm_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.checkpoints.permissions.delete(\n    \"ft:gpt-4o:org:suffix:id\", \"perm_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().checkpoints().permissions()\n    .delete(\"ft:gpt-4o:org:suffix:id\", \"perm_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().checkpoints().permissions()\n    .delete(\"ft:gpt-4o:org:suffix:id\", \"perm_abc123\");"
           }
         ]
       }
@@ -8759,6 +10531,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "status": "validating_files",
+                  "training_file": "file-abc123def456",
+                  "hyperparameters": {
+                    "n_epochs": "auto",
+                    "batch_size": "auto",
+                    "learning_rate_multiplier": "auto"
+                  },
+                  "organization_id": "org-abc123"
                 }
               }
             }
@@ -8835,22 +10621,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\njob = openai.fine_tuning.jobs.create(\n    model=\"gpt-4o-mini-2024-07-18\",\n    training_file=\"file-abc123\",\n)\nprint(job.id, job.status)\n# Output: ftjob-abc123 validating_files"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\njob = openai.fine_tuning.jobs.create(\n    model=\"gpt-4o-mini-2024-07-18\",\n    training_file=\"file-abc123\",\n)\nprint(job.id, job.status)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\njob = openai.fine_tuning.jobs.create(\n    model=\"gpt-4o-mini-2024-07-18\",\n    training_file=\"file-abc123\",\n)\nprint(job.id, job.status)\n# Output: ftjob-abc123 validating_files"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\njob = openai.fine_tuning.jobs.create(\n    model=\"gpt-4o-mini-2024-07-18\",\n    training_file=\"file-abc123\",\n)\nprint(job.id, job.status)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-mini-2024-07-18\", \"training_file\": \"file-abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-mini-2024-07-18\", \"training_file\": \"file-abc123\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-mini-2024-07-18\", \"training_file\": \"file-abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-mini-2024-07-18\", \"training_file\": \"file-abc123\"}'"
           },
           {
             "lang": "csharp",
@@ -8871,6 +10657,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.fineTuning.jobs.create({\n    model: \"gpt-4o-mini-2024-07-18\",\n    training_file: \"file-abc123\",\n});\nconsole.log(job.id, job.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.fineTuning().jobs().create(\n    \"gpt-4o-mini-2024-07-18\", \"file-abc123\");\n\nSystem.out.println(job.getId() + \" \" + job.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.fineTuning().jobs().create(\n    \"gpt-4o-mini-2024-07-18\", \"file-abc123\");\n\nSystem.out.println(job.getId() + \" \" + job.getStatus());"
           }
         ]
       },
@@ -8927,6 +10723,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListPaginatedFineTuningJobsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "ftjob-abc123def456",
+                      "object": "fine_tuning.job",
+                      "model": "gpt-4o-mini-2024-07-18",
+                      "created_at": 1741312436,
+                      "status": "succeeded",
+                      "training_file": "file-abc123def456",
+                      "fine_tuned_model": "ft:gpt-4o-mini:my-org:custom-suffix:abc123"
+                    }
+                  ],
+                  "has_more": false
                 }
               }
             }
@@ -9003,12 +10814,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar jobs = ftClient.GetJobs();\n\nforeach (var job in jobs)\n    Console.WriteLine($\"{job.Id} {job.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar jobs = ftClient.GetJobs();\n\nforeach (var job in jobs)\n    Console.WriteLine($\"{job.Id} {job.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst jobs = await openai.fineTuning.jobs.list();\nfor await (const job of jobs) {\n    console.log(job.id, job.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst jobs = await openai.fineTuning.jobs.list();\nfor await (const job of jobs) {\n    console.log(job.id, job.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar jobs = openai.fineTuning().jobs().list();\n\nfor (var job : jobs) {\n    System.out.println(job.getId() + \" \" + job.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar jobs = openai.fineTuning().jobs().list();\n\nfor (var job : jobs) {\n    System.out.println(job.getId() + \" \" + job.getStatus());\n}"
           }
         ]
       }
@@ -9054,6 +10895,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "finished_at": 1741315036,
+                  "status": "succeeded",
+                  "training_file": "file-abc123def456",
+                  "fine_tuned_model": "ft:gpt-4o-mini:my-org:custom-suffix:abc123",
+                  "trained_tokens": 52814,
+                  "result_files": [
+                    "file-result123"
+                  ]
                 }
               }
             }
@@ -9130,12 +10985,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar job = await ftClient.GetJobAsync(\"ftjob-abc123\");\n\nConsole.WriteLine($\"{job.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar job = await ftClient.GetJobAsync(\"ftjob-abc123\");\n\nConsole.WriteLine($\"{job.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.fineTuning.jobs.retrieve(\"ftjob-abc123\");\nconsole.log(job.status, job.trained_tokens);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.fineTuning.jobs.retrieve(\"ftjob-abc123\");\nconsole.log(job.status, job.trained_tokens);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.fineTuning().jobs()\n    .retrieve(\"ftjob-abc123\");\n\nSystem.out.println(job.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.fineTuning().jobs()\n    .retrieve(\"ftjob-abc123\");\n\nSystem.out.println(job.getStatus());"
           }
         ]
       }
@@ -9181,6 +11066,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "status": "cancelled",
+                  "training_file": "file-abc123def456"
                 }
               }
             }
@@ -9257,12 +11150,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CancelJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CancelJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.cancel(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.cancel(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().cancel(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().cancel(\"ftjob-abc123\");"
           }
         ]
       }
@@ -9330,6 +11253,27 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFineTuningJobCheckpointsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "ftckpt-abc123def456",
+                      "object": "fine_tuning.job.checkpoint",
+                      "created_at": 1741313436,
+                      "fine_tuning_job_id": "ftjob-abc123def456",
+                      "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+                      "step_number": 100,
+                      "metrics": {
+                        "step": 100,
+                        "train_loss": 0.234,
+                        "train_mean_token_accuracy": 0.891
+                      }
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "ftckpt-abc123def456",
+                  "last_id": "ftckpt-abc123def456"
                 }
               }
             }
@@ -9406,12 +11350,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar checkpoints = ftClient.GetJobCheckpoints(\"ftjob-abc123\");\n\nforeach (var cp in checkpoints)\n    Console.WriteLine($\"{cp.Id} step {cp.StepNumber}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar checkpoints = ftClient.GetJobCheckpoints(\"ftjob-abc123\");\n\nforeach (var cp in checkpoints)\n    Console.WriteLine($\"{cp.Id} step {cp.StepNumber}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst checkpoints = await openai.fineTuning.jobs.checkpoints\n    .list(\"ftjob-abc123\");\nfor await (const cp of checkpoints) {\n    console.log(cp.id, cp.step_number);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst checkpoints = await openai.fineTuning.jobs.checkpoints\n    .list(\"ftjob-abc123\");\nfor await (const cp of checkpoints) {\n    console.log(cp.id, cp.step_number);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar checkpoints = openai.fineTuning().jobs()\n    .checkpoints().list(\"ftjob-abc123\");\n\nfor (var cp : checkpoints) {\n    System.out.println(cp.getId() + \" step \" + cp.getStepNumber());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar checkpoints = openai.fineTuning().jobs()\n    .checkpoints().list(\"ftjob-abc123\");\n\nfor (var cp : checkpoints) {\n    System.out.println(cp.getId() + \" step \" + cp.getStepNumber());\n}"
           }
         ]
       }
@@ -9487,6 +11461,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CopyModelResponse"
+                },
+                "example": {
+                  "id": "ftckpt-copy123",
+                  "object": "fine_tuning.job.checkpoint",
+                  "created_at": 1741312436,
+                  "fine_tuning_job_id": "ftjob-abc123def456",
+                  "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+                  "step_number": 100,
+                  "metrics": {
+                    "step": 100,
+                    "train_loss": 0.234
+                  }
                 }
               }
             }
@@ -9573,12 +11559,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CopyCheckpointAsync(\n    \"ftjob-abc123\", \"ftckpt-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CopyCheckpointAsync(\n    \"ftjob-abc123\", \"ftckpt-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.checkpoints.copy(\n    \"ftjob-abc123\", \"ftckpt-abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.checkpoints.copy(\n    \"ftjob-abc123\", \"ftckpt-abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().checkpoints()\n    .copy(\"ftjob-abc123\", \"ftckpt-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().checkpoints()\n    .copy(\"ftjob-abc123\", \"ftckpt-abc123\");"
           }
         ]
       },
@@ -9652,6 +11668,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CopyModelResponse"
+                },
+                "example": {
+                  "id": "ftckpt-abc123def456",
+                  "object": "fine_tuning.job.checkpoint",
+                  "created_at": 1741313436,
+                  "fine_tuning_job_id": "ftjob-abc123def456",
+                  "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+                  "step_number": 100,
+                  "metrics": {
+                    "step": 100,
+                    "train_loss": 0.234,
+                    "train_mean_token_accuracy": 0.891
+                  }
                 }
               }
             }
@@ -9728,12 +11757,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar checkpoint = await ftClient.GetCheckpointAsync(\n    \"ftjob-abc123\", \"ftckpt-abc123\");\n\nConsole.WriteLine(checkpoint.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar checkpoint = await ftClient.GetCheckpointAsync(\n    \"ftjob-abc123\", \"ftckpt-abc123\");\n\nConsole.WriteLine(checkpoint.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst checkpoint = await openai.fineTuning.jobs.checkpoints\n    .retrieve(\"ftjob-abc123\", \"ftckpt-abc123\");\nconsole.log(checkpoint.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst checkpoint = await openai.fineTuning.jobs.checkpoints\n    .retrieve(\"ftjob-abc123\", \"ftckpt-abc123\");\nconsole.log(checkpoint.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar checkpoint = openai.fineTuning().jobs()\n    .checkpoints().retrieve(\"ftjob-abc123\", \"ftckpt-abc123\");\n\nSystem.out.println(checkpoint.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar checkpoint = openai.fineTuning().jobs()\n    .checkpoints().retrieve(\"ftjob-abc123\", \"ftckpt-abc123\");\n\nSystem.out.println(checkpoint.getId());"
           }
         ]
       }
@@ -9801,6 +11860,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFineTuningJobEventsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "ftevent-abc123",
+                      "object": "fine_tuning.job.event",
+                      "created_at": 1741312436,
+                      "level": "info",
+                      "message": "Training started"
+                    }
+                  ],
+                  "has_more": false
                 }
               }
             }
@@ -9877,12 +11949,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/events\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/events\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/events\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/events\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar events = ftClient.GetJobEvents(\"ftjob-abc123\");\n\nforeach (var evt in events)\n    Console.WriteLine(evt.Message);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar events = ftClient.GetJobEvents(\"ftjob-abc123\");\n\nforeach (var evt in events)\n    Console.WriteLine(evt.Message);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst events = await openai.fineTuning.jobs.listEvents(\"ftjob-abc123\");\nfor await (const event of events) {\n    console.log(event.message);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst events = await openai.fineTuning.jobs.listEvents(\"ftjob-abc123\");\nfor await (const event of events) {\n    console.log(event.message);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar events = openai.fineTuning().jobs()\n    .listEvents(\"ftjob-abc123\");\n\nfor (var event : events) {\n    System.out.println(event.getMessage());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar events = openai.fineTuning().jobs()\n    .listEvents(\"ftjob-abc123\");\n\nfor (var event : events) {\n    System.out.println(event.getMessage());\n}"
           }
         ]
       }
@@ -9928,6 +12030,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "status": "paused",
+                  "training_file": "file-abc123def456"
                 }
               }
             }
@@ -10004,12 +12114,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/pause\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/pause\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/pause\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/pause\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.PauseJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.PauseJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.pause(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.pause(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().pause(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().pause(\"ftjob-abc123\");"
           }
         ]
       }
@@ -10055,6 +12195,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "status": "running",
+                  "training_file": "file-abc123def456"
                 }
               }
             }
@@ -10131,12 +12279,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/resume\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/resume\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/resume\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/resume\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.ResumeJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.ResumeJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.resume(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.resume(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().resume(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().resume(\"ftjob-abc123\");"
           }
         ]
       }
@@ -10172,6 +12350,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ImagesResponse"
+                },
+                "example": {
+                  "created": 1741312436,
+                  "data": [
+                    {
+                      "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/edited-image.png"
+                    }
+                  ]
                 }
               }
             }
@@ -10258,12 +12444,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/images/edits\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F image=\"@image.png\" \\\n  -F prompt=\"Add a sunset\" \\\n  -F n=1 \\\n  -F size=\"1024x1024\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/images/edits\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F image=\"@image.png\" \\\n  -F prompt=\"Add a sunset\" \\\n  -F n=1 \\\n  -F size=\"1024x1024\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/images/edits\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F image=\"@image.png\" \\\n  -F prompt=\"Add a sunset\" \\\n  -F n=1 \\\n  -F size=\"1024x1024\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/images/edits\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F image=\"@image.png\" \\\n  -F prompt=\"Add a sunset\" \\\n  -F n=1 \\\n  -F size=\"1024x1024\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar imageClient = client.OpenAI.GetImageClient(\"dall-e-2\");\nvar result = await imageClient.GenerateImageEditAsync(\n    File.OpenRead(\"image.png\"),\n    \"image.png\",\n    \"Add a sunset in the background\",\n    new ImageEditOptions { Size = GeneratedImageSize.W1024xH1024 });\n\nConsole.WriteLine(result.Value.ImageUri);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar imageClient = client.OpenAI.GetImageClient(\"dall-e-2\");\nvar result = await imageClient.GenerateImageEditAsync(\n    File.OpenRead(\"image.png\"),\n    \"image.png\",\n    \"Add a sunset in the background\",\n    new ImageEditOptions { Size = GeneratedImageSize.W1024xH1024 });\n\nConsole.WriteLine(result.Value.ImageUri);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.images.edit({\n    image: fs.createReadStream(\"image.png\"),\n    prompt: \"Add a sunset in the background\",\n    n: 1,\n    size: \"1024x1024\",\n});\nconsole.log(response.data[0].url);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.images.edit({\n    image: fs.createReadStream(\"image.png\"),\n    prompt: \"Add a sunset in the background\",\n    n: 1,\n    size: \"1024x1024\",\n});\nconsole.log(response.data[0].url);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.images().edit(\n    Path.of(\"image.png\"),\n    \"Add a sunset in the background\",\n    1, \"1024x1024\");\n\nSystem.out.println(response.getData().get(0).getUrl());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.images().edit(\n    Path.of(\"image.png\"),\n    \"Add a sunset in the background\",\n    1, \"1024x1024\");\n\nSystem.out.println(response.getData().get(0).getUrl());"
           }
         ]
       }
@@ -10299,6 +12515,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ImagesResponse"
+                },
+                "example": {
+                  "created": 1741312436,
+                  "data": [
+                    {
+                      "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/generated-image.png",
+                      "revised_prompt": "A beautiful sunset over the ocean with vibrant orange and purple hues."
+                    }
+                  ]
                 }
               }
             }
@@ -10385,12 +12610,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/images/generations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"dall-e-3\", \"prompt\": \"A white cat on a windowsill\", \"n\": 1, \"size\": \"1024x1024\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/images/generations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"dall-e-3\", \"prompt\": \"A white cat on a windowsill\", \"n\": 1, \"size\": \"1024x1024\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/images/generations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"dall-e-3\", \"prompt\": \"A white cat on a windowsill\", \"n\": 1, \"size\": \"1024x1024\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/images/generations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"dall-e-3\", \"prompt\": \"A white cat on a windowsill\", \"n\": 1, \"size\": \"1024x1024\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar imageClient = client.OpenAI.GetImageClient(\"dall-e-3\");\nvar result = await imageClient.GenerateImageAsync(\n    \"A white cat sitting on a windowsill\",\n    new ImageGenerationOptions { Size = GeneratedImageSize.W1024xH1024 });\n\nConsole.WriteLine(result.Value.ImageUri);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar imageClient = client.OpenAI.GetImageClient(\"dall-e-3\");\nvar result = await imageClient.GenerateImageAsync(\n    \"A white cat sitting on a windowsill\",\n    new ImageGenerationOptions { Size = GeneratedImageSize.W1024xH1024 });\n\nConsole.WriteLine(result.Value.ImageUri);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.images.generate({\n    model: \"dall-e-3\",\n    prompt: \"A white cat sitting on a windowsill\",\n    n: 1,\n    size: \"1024x1024\",\n});\nconsole.log(response.data[0].url);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.images.generate({\n    model: \"dall-e-3\",\n    prompt: \"A white cat sitting on a windowsill\",\n    n: 1,\n    size: \"1024x1024\",\n});\nconsole.log(response.data[0].url);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.images().generate(\n    \"dall-e-3\",\n    \"A white cat sitting on a windowsill\",\n    1, \"1024x1024\");\n\nSystem.out.println(response.getData().get(0).getUrl());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.images().generate(\n    \"dall-e-3\",\n    \"A white cat sitting on a windowsill\",\n    1, \"1024x1024\");\n\nSystem.out.println(response.getData().get(0).getUrl());"
           }
         ]
       }
@@ -10426,6 +12681,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ImagesResponse"
+                },
+                "example": {
+                  "created": 1741312436,
+                  "data": [
+                    {
+                      "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/variation-image.png"
+                    }
+                  ]
                 }
               }
             }
@@ -10512,12 +12775,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/images/variations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F image=\"@image.png\" \\\n  -F n=1 \\\n  -F size=\"1024x1024\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/images/variations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F image=\"@image.png\" \\\n  -F n=1 \\\n  -F size=\"1024x1024\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/images/variations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F image=\"@image.png\" \\\n  -F n=1 \\\n  -F size=\"1024x1024\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/images/variations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F image=\"@image.png\" \\\n  -F n=1 \\\n  -F size=\"1024x1024\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar imageClient = client.OpenAI.GetImageClient(\"dall-e-2\");\nvar result = await imageClient.GenerateImageVariationAsync(\n    File.OpenRead(\"image.png\"),\n    \"image.png\",\n    new ImageVariationOptions { Size = GeneratedImageSize.W1024xH1024 });\n\nConsole.WriteLine(result.Value.ImageUri);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar imageClient = client.OpenAI.GetImageClient(\"dall-e-2\");\nvar result = await imageClient.GenerateImageVariationAsync(\n    File.OpenRead(\"image.png\"),\n    \"image.png\",\n    new ImageVariationOptions { Size = GeneratedImageSize.W1024xH1024 });\n\nConsole.WriteLine(result.Value.ImageUri);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.images.createVariation({\n    image: fs.createReadStream(\"image.png\"),\n    n: 1,\n    size: \"1024x1024\",\n});\nconsole.log(response.data[0].url);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.images.createVariation({\n    image: fs.createReadStream(\"image.png\"),\n    n: 1,\n    size: \"1024x1024\",\n});\nconsole.log(response.data[0].url);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.images().createVariation(\n    Path.of(\"image.png\"), 1, \"1024x1024\");\n\nSystem.out.println(response.getData().get(0).getUrl());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.images().createVariation(\n    Path.of(\"image.png\"), 1, \"1024x1024\");\n\nSystem.out.println(response.getData().get(0).getUrl());"
           }
         ]
       }
@@ -10554,6 +12847,29 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListModelsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "gpt-4o",
+                      "object": "model",
+                      "created": 1715367049,
+                      "owned_by": "system"
+                    },
+                    {
+                      "id": "gpt-4o-mini",
+                      "object": "model",
+                      "created": 1721172741,
+                      "owned_by": "system"
+                    },
+                    {
+                      "id": "text-embedding-3-large",
+                      "object": "model",
+                      "created": 1705953180,
+                      "owned_by": "system"
+                    }
+                  ]
                 }
               }
             }
@@ -10620,22 +12936,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nmodels = openai.models.list()\nfor model in models:\n    print(model.id)\n# Output:\n# gpt-4o\n# gpt-4o-mini\n# text-embedding-3-large"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nmodels = openai.models.list()\nfor model in models:\n    print(model.id)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nmodels = openai.models.list()\nfor model in models:\n    print(model.id)\n# Output:\n# gpt-4o\n# gpt-4o-mini\n# text-embedding-3-large"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nmodels = openai.models.list()\nfor model in models:\n    print(model.id)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/models\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/models\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/models\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/models\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -10656,6 +12972,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst models = await openai.models.list();\nfor await (const model of models) {\n    console.log(model.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar models = openai.models().list();\n\nfor (var model : models) {\n    System.out.println(model.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar models = openai.models().list();\n\nfor (var model : models) {\n    System.out.println(model.getId());\n}"
           }
         ]
       }
@@ -10701,6 +13027,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.Model"
+                },
+                "example": {
+                  "id": "gpt-4o",
+                  "object": "model",
+                  "created": 1715367049,
+                  "owned_by": "system"
                 }
               }
             }
@@ -10777,12 +13109,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/models/gpt-4o\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/models/gpt-4o\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/models/gpt-4o\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/models/gpt-4o\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar model = client.OpenAI.GetOpenAIModelClient()\n    .GetModel(\"gpt-4o\");\n\nConsole.WriteLine($\"{model.Value.Id} {model.Value.OwnedBy}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar model = client.OpenAI.GetOpenAIModelClient()\n    .GetModel(\"gpt-4o\");\n\nConsole.WriteLine($\"{model.Value.Id} {model.Value.OwnedBy}\");"
           },
           {
             "lang": "javascript",
@@ -10793,6 +13135,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst model = await openai.models.retrieve(\"gpt-4o\");\nconsole.log(model.id, model.owned_by);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar model = openai.models().retrieve(\"gpt-4o\");\n\nSystem.out.println(model.getId() + \" \" + model.getOwnedBy());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar model = openai.models().retrieve(\"gpt-4o\");\n\nSystem.out.println(model.getId() + \" \" + model.getOwnedBy());"
           }
         ]
       },
@@ -10836,6 +13188,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteModelResponse"
+                },
+                "example": {
+                  "id": "ft:gpt-4o-mini:my-org:custom-suffix:abc123",
+                  "object": "model",
+                  "deleted": true
                 }
               }
             }
@@ -10912,12 +13269,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/models/ft:gpt-4o:org:suffix:id\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/models/ft:gpt-4o:org:suffix:id\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/models/ft:gpt-4o:org:suffix:id\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/models/ft:gpt-4o:org:suffix:id\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.OpenAI.GetOpenAIModelClient()\n    .DeleteModel(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.OpenAI.GetOpenAIModelClient()\n    .DeleteModel(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.models.delete(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.models.delete(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.models()\n    .delete(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.models()\n    .delete(\"ft:gpt-4o:your-org:custom-suffix:id\");"
           }
         ]
       }
@@ -11045,12 +13432,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\", \"sdp\": \"YOUR_SDP_OFFER\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\", \"sdp\": \"YOUR_SDP_OFFER\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\", \"sdp\": \"YOUR_SDP_OFFER\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\", \"sdp\": \"YOUR_SDP_OFFER\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar call = await realtimeClient.CreateCallAsync(\n    \"gpt-4o-realtime-preview\", \"YOUR_SDP_OFFER\");\n\nConsole.WriteLine(call.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar call = await realtimeClient.CreateCallAsync(\n    \"gpt-4o-realtime-preview\", \"YOUR_SDP_OFFER\");\n\nConsole.WriteLine(call.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst call = await openai.realtime.calls.create({\n    model: \"gpt-4o-realtime-preview\",\n    sdp: \"YOUR_SDP_OFFER\",\n});\nconsole.log(call.id, call.sdp);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst call = await openai.realtime.calls.create({\n    model: \"gpt-4o-realtime-preview\",\n    sdp: \"YOUR_SDP_OFFER\",\n});\nconsole.log(call.id, call.sdp);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar call = openai.realtime().calls().create(\n    \"gpt-4o-realtime-preview\", \"YOUR_SDP_OFFER\");\n\nSystem.out.println(call.getId() + \" \" + call.getSdp());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar call = openai.realtime().calls().create(\n    \"gpt-4o-realtime-preview\", \"YOUR_SDP_OFFER\");\n\nSystem.out.println(call.getId() + \" \" + call.getSdp());"
           }
         ]
       }
@@ -11082,7 +13499,17 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded."
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "call_abc123",
+                  "object": "realtime.call",
+                  "sdp": "v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\n",
+                  "status": "accepted"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -11167,12 +13594,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/accept\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/accept\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/accept\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/accept\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.AcceptCallAsync(\n    \"call_abc123\", \"gpt-4o-realtime-preview\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.AcceptCallAsync(\n    \"call_abc123\", \"gpt-4o-realtime-preview\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.accept(\"call_abc123\", {\n    model: \"gpt-4o-realtime-preview\",\n});"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.accept(\"call_abc123\", {\n    model: \"gpt-4o-realtime-preview\",\n});"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .accept(\"call_abc123\", \"gpt-4o-realtime-preview\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .accept(\"call_abc123\", \"gpt-4o-realtime-preview\");"
           }
         ]
       }
@@ -11204,7 +13661,16 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded."
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "call_abc123",
+                  "object": "realtime.call",
+                  "status": "ended"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -11278,12 +13744,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/hangup\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/hangup\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/hangup\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/hangup\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.HangupCallAsync(\"call_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.HangupCallAsync(\"call_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.hangup(\"call_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.hangup(\"call_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls().hangup(\"call_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls().hangup(\"call_abc123\");"
           }
         ]
       }
@@ -11315,7 +13811,16 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded."
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "call_abc123",
+                  "object": "realtime.call",
+                  "status": "referred"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -11400,12 +13905,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/refer\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"refer_to\": \"sip:dest@example.com\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/refer\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"refer_to\": \"sip:dest@example.com\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/refer\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"refer_to\": \"sip:dest@example.com\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/refer\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"refer_to\": \"sip:dest@example.com\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.ReferCallAsync(\n    \"call_abc123\", \"sip:destination@example.com\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.ReferCallAsync(\n    \"call_abc123\", \"sip:destination@example.com\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.refer(\"call_abc123\", {\n    refer_to: \"sip:destination@example.com\",\n});"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.refer(\"call_abc123\", {\n    refer_to: \"sip:destination@example.com\",\n});"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .refer(\"call_abc123\", \"sip:destination@example.com\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .refer(\"call_abc123\", \"sip:destination@example.com\");"
           }
         ]
       }
@@ -11437,7 +13972,16 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded."
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "call_abc123",
+                  "object": "realtime.call",
+                  "status": "rejected"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -11522,12 +14066,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/reject\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"reason\": \"busy\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/reject\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"reason\": \"busy\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/reject\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"reason\": \"busy\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/reject\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"reason\": \"busy\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.RejectCallAsync(\n    \"call_abc123\", \"busy\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.RejectCallAsync(\n    \"call_abc123\", \"busy\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.reject(\"call_abc123\", {\n    reason: \"busy\",\n});"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.reject(\"call_abc123\", {\n    reason: \"busy\",\n});"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .reject(\"call_abc123\", \"busy\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .reject(\"call_abc123\", \"busy\");"
           }
         ]
       }
@@ -11564,6 +14138,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RealtimeCreateClientSecretResponse"
+                },
+                "example": {
+                  "id": "sess_abc123def456",
+                  "object": "realtime.session",
+                  "client_secret": {
+                    "value": "ek_abc123def456ghi789",
+                    "expires_at": 1741316036
+                  }
                 }
               }
             }
@@ -11651,12 +14233,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/client_secrets\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/client_secrets\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/client_secrets\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/client_secrets\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar secret = await realtimeClient.CreateClientSecretAsync(\n    \"gpt-4o-realtime-preview\");\n\nConsole.WriteLine(secret.Value.ClientSecret.Value);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar secret = await realtimeClient.CreateClientSecretAsync(\n    \"gpt-4o-realtime-preview\");\n\nConsole.WriteLine(secret.Value.ClientSecret.Value);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst secret = await openai.realtime.clientSecrets.create({\n    model: \"gpt-4o-realtime-preview\",\n});\nconsole.log(secret.client_secret.value);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst secret = await openai.realtime.clientSecrets.create({\n    model: \"gpt-4o-realtime-preview\",\n});\nconsole.log(secret.client_secret.value);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar secret = openai.realtime().clientSecrets()\n    .create(\"gpt-4o-realtime-preview\");\n\nSystem.out.println(secret.getClientSecret().getValue());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar secret = openai.realtime().clientSecrets()\n    .create(\"gpt-4o-realtime-preview\");\n\nSystem.out.println(secret.getClientSecret().getValue());"
           }
         ]
       }
@@ -11693,6 +14305,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RealtimeSessionCreateResponse"
+                },
+                "example": {
+                  "id": "sess_abc123def456",
+                  "object": "realtime.session",
+                  "model": "gpt-4o-realtime-preview",
+                  "modalities": [
+                    "text",
+                    "audio"
+                  ],
+                  "voice": "alloy",
+                  "input_audio_format": "pcm16",
+                  "output_audio_format": "pcm16",
+                  "turn_detection": {
+                    "type": "server_vad"
+                  }
                 }
               }
             }
@@ -11780,12 +14407,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/sessions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/sessions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/sessions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/sessions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar session = await realtimeClient.CreateSessionAsync(\n    \"gpt-4o-realtime-preview\");\n\nConsole.WriteLine(session.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar session = await realtimeClient.CreateSessionAsync(\n    \"gpt-4o-realtime-preview\");\n\nConsole.WriteLine(session.Value.Id);"
           },
           {
             "lang": "javascript",
@@ -11796,6 +14433,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst session = await openai.realtime.sessions.create({\n    model: \"gpt-4o-realtime-preview\",\n});\nconsole.log(session.id, session.client_secret.value);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar session = openai.realtime().sessions()\n    .create(\"gpt-4o-realtime-preview\");\n\nSystem.out.println(session.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar session = openai.realtime().sessions()\n    .create(\"gpt-4o-realtime-preview\");\n\nSystem.out.println(session.getId());"
           }
         ]
       }
@@ -11832,6 +14479,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RealtimeTranscriptionSessionCreateResponse"
+                },
+                "example": {
+                  "id": "sess_trans_abc123",
+                  "object": "realtime.transcription_session",
+                  "model": "gpt-4o-transcribe",
+                  "input_audio_format": "pcm16"
                 }
               }
             }
@@ -11919,12 +14572,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/transcription_sessions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-transcribe\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/transcription_sessions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-transcribe\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/transcription_sessions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-transcribe\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/transcription_sessions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-transcribe\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar session = await realtimeClient\n    .CreateTranscriptionSessionAsync(\"gpt-4o-transcribe\");\n\nConsole.WriteLine(session.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar session = await realtimeClient\n    .CreateTranscriptionSessionAsync(\"gpt-4o-transcribe\");\n\nConsole.WriteLine(session.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst session = await openai.realtime.transcriptionSessions\n    .create({ model: \"gpt-4o-transcribe\" });\nconsole.log(session.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst session = await openai.realtime.transcriptionSessions\n    .create({ model: \"gpt-4o-transcribe\" });\nconsole.log(session.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar session = openai.realtime().transcriptionSessions()\n    .create(\"gpt-4o-transcribe\");\n\nSystem.out.println(session.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar session = openai.realtime().transcriptionSessions()\n    .create(\"gpt-4o-transcribe\");\n\nSystem.out.println(session.getId());"
           }
         ]
       }
@@ -12245,6 +14928,32 @@
                       "description": "The content filter results from RAI."
                     }
                   }
+                },
+                "example": {
+                  "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+                  "object": "response",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "output": [
+                    {
+                      "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                      "type": "message",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "The capital of France is Paris.",
+                          "annotations": []
+                        }
+                      ]
+                    }
+                  ],
+                  "model": "gpt-4o-2024-11-20",
+                  "usage": {
+                    "input_tokens": 13,
+                    "output_tokens": 8,
+                    "total_tokens": 21
+                  }
                 }
               },
               "text/event-stream": {}
@@ -12322,22 +15031,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.create(\n    model=\"gpt-4o\",\n    input=\"What is the capital of France?\",\n)\nprint(response.output_text)\n# Output: \"The capital of France is Paris.\""
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.create(\n    model=\"gpt-4o\",\n    input=\"What is the capital of France?\",\n)\nprint(response.output_text)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.create(\n    model=\"gpt-4o\",\n    input=\"What is the capital of France?\",\n)\nprint(response.output_text)\n# Output: \"The capital of France is Paris.\""
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.create(\n    model=\"gpt-4o\",\n    input=\"What is the capital of France?\",\n)\nprint(response.output_text)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/responses\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"input\": \"What is the capital of France?\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/responses\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"input\": \"What is the capital of France?\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/responses\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"input\": \"What is the capital of France?\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/responses\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"input\": \"What is the capital of France?\"}'"
           },
           {
             "lang": "csharp",
@@ -12358,6 +15067,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.responses.create({\n    model: \"gpt-4o\",\n    input: \"What is the capital of France?\",\n});\nconsole.log(response.output_text);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.responses()\n    .create(\"gpt-4o\", \"What is the capital of France?\");\n\nSystem.out.println(response.getOutputText());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.responses()\n    .create(\"gpt-4o\", \"What is the capital of France?\");\n\nSystem.out.println(response.getOutputText());"
           }
         ]
       }
@@ -12731,6 +15450,32 @@
                       "description": "The content filter results from RAI."
                     }
                   }
+                },
+                "example": {
+                  "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+                  "object": "response",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "output": [
+                    {
+                      "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                      "type": "message",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "The capital of France is Paris.",
+                          "annotations": []
+                        }
+                      ]
+                    }
+                  ],
+                  "model": "gpt-4o-2024-11-20",
+                  "usage": {
+                    "input_tokens": 13,
+                    "output_tokens": 8,
+                    "total_tokens": 21
+                  }
                 }
               }
             }
@@ -12797,22 +15542,52 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.retrieve(\"resp_abc123\")\nprint(response.status, response.output_text)\n# Output: completed The capital of France is Paris."
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.retrieve(\"resp_abc123\")\nprint(response.status, response.output_text)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.retrieve(\"resp_abc123\")\nprint(response.status, response.output_text)\n# Output: completed The capital of France is Paris."
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.retrieve(\"resp_abc123\")\nprint(response.status, response.output_text)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nvar response = await responsesClient\n    .GetResponseAsync(\"resp_abc123\");\n\nConsole.WriteLine(response.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nvar response = await responsesClient\n    .GetResponseAsync(\"resp_abc123\");\n\nConsole.WriteLine(response.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.responses.retrieve(\"resp_abc123\");\nconsole.log(response.status, response.output_text);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.responses.retrieve(\"resp_abc123\");\nconsole.log(response.status, response.output_text);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.responses().retrieve(\"resp_abc123\");\n\nSystem.out.println(response.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.responses().retrieve(\"resp_abc123\");\n\nSystem.out.println(response.getStatus());"
           }
         ]
       },
@@ -12877,6 +15652,11 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+                  "object": "response",
+                  "deleted": true
                 }
               }
             }
@@ -12953,12 +15733,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nawait responsesClient.DeleteResponseAsync(\"resp_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nawait responsesClient.DeleteResponseAsync(\"resp_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.responses.delete(\"resp_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.responses.delete(\"resp_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.responses().delete(\"resp_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.responses().delete(\"resp_abc123\");"
           }
         ]
       }
@@ -13287,6 +16097,19 @@
                       "description": "The content filter results from RAI."
                     }
                   }
+                },
+                "example": {
+                  "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+                  "object": "response",
+                  "created_at": 1741312436,
+                  "status": "cancelled",
+                  "output": [],
+                  "model": "gpt-4o-2024-11-20",
+                  "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0
+                  }
                 }
               }
             }
@@ -13363,12 +16186,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/responses/resp_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/responses/resp_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/responses/resp_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/responses/resp_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nawait responsesClient.CancelResponseAsync(\"resp_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nawait responsesClient.CancelResponseAsync(\"resp_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.responses.cancel(\"resp_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.responses.cancel(\"resp_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.responses().cancel(\"resp_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.responses().cancel(\"resp_abc123\");"
           }
         ]
       }
@@ -13459,6 +16312,25 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ResponseItemList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                      "type": "message",
+                      "role": "user",
+                      "content": [
+                        {
+                          "type": "input_text",
+                          "text": "What is the capital of France?"
+                        }
+                      ]
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                  "last_id": "msg_67cb71b5c1988190b5fba3b237c63581"
                 }
               }
             }
@@ -13535,12 +16407,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/responses/resp_abc123/input_items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/responses/resp_abc123/input_items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/responses/resp_abc123/input_items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/responses/resp_abc123/input_items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nvar items = responsesClient.GetResponseInputItems(\"resp_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine(item.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nvar items = responsesClient.GetResponseInputItems(\"resp_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine(item.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.responses.inputItems.list(\"resp_abc123\");\nfor await (const item of items) {\n    console.log(item.type, item.id);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.responses.inputItems.list(\"resp_abc123\");\nfor await (const item of items) {\n    console.log(item.type, item.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.responses().inputItems()\n    .list(\"resp_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getType() + \" \" + item.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.responses().inputItems()\n    .list(\"resp_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getType() + \" \" + item.getId());\n}"
           }
         ]
       }
@@ -13576,6 +16478,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ThreadObject"
+                },
+                "example": {
+                  "id": "thread_abc123def456",
+                  "object": "thread",
+                  "created_at": 1741312436,
+                  "metadata": {}
                 }
               }
             }
@@ -13662,12 +16570,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar thread = await threadClient.CreateThreadAsync();\n\nConsole.WriteLine(thread.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar thread = await threadClient.CreateThreadAsync();\n\nConsole.WriteLine(thread.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.create();\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.create();\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar thread = openai.beta().threads().create();\n\nSystem.out.println(thread.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar thread = openai.beta().threads().create();\n\nSystem.out.println(thread.getId());"
           }
         ]
       }
@@ -13694,6 +16632,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_xyz789ghi012",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "queued",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -13780,12 +16727,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\", \"thread\": {\"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\", \"thread\": {\"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\", \"thread\": {\"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\", \"thread\": {\"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.CreateThreadAndRunAsync(\n    \"asst_abc123\",\n    new ThreadCreationOptions\n    {\n        InitialMessages = { new ThreadInitializationMessage(\n            MessageRole.User, new[] { MessageContent.FromText(\"Hello\") }) },\n    });\n\nConsole.WriteLine(run.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.CreateThreadAndRunAsync(\n    \"asst_abc123\",\n    new ThreadCreationOptions\n    {\n        InitialMessages = { new ThreadInitializationMessage(\n            MessageRole.User, new[] { MessageContent.FromText(\"Hello\") }) },\n    });\n\nConsole.WriteLine(run.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.createAndRun({\n    assistant_id: \"asst_abc123\",\n    thread: { messages: [{ role: \"user\", content: \"Hello\" }] },\n});\nconsole.log(run.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.createAndRun({\n    assistant_id: \"asst_abc123\",\n    thread: { messages: [{ role: \"user\", content: \"Hello\" }] },\n});\nconsole.log(run.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().createAndRun(\n    \"asst_abc123\",\n    Map.of(\"messages\", List.of(\n        Map.of(\"role\", \"user\", \"content\", \"Hello\"))));\n\nSystem.out.println(run.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().createAndRun(\n    \"asst_abc123\",\n    Map.of(\"messages\", List.of(\n        Map.of(\"role\", \"user\", \"content\", \"Hello\"))));\n\nSystem.out.println(run.getId());"
           }
         ]
       }
@@ -13829,6 +16806,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteThreadResponse"
+                },
+                "example": {
+                  "id": "thread_abc123def456",
+                  "object": "thread",
+                  "deleted": true
                 }
               }
             }
@@ -13905,12 +16887,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.DeleteThreadAsync(\"thread_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.DeleteThreadAsync(\"thread_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.delete(\"thread_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.delete(\"thread_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().delete(\"thread_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().delete(\"thread_abc123\");"
           }
         ]
       },
@@ -13952,6 +16964,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ThreadObject"
+                },
+                "example": {
+                  "id": "thread_abc123def456",
+                  "object": "thread",
+                  "created_at": 1741312436,
+                  "metadata": {}
                 }
               }
             }
@@ -14028,12 +17046,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar thread = await threadClient.GetThreadAsync(\"thread_abc123\");\n\nConsole.WriteLine(thread.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar thread = await threadClient.GetThreadAsync(\"thread_abc123\");\n\nConsole.WriteLine(thread.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.retrieve(\"thread_abc123\");\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.retrieve(\"thread_abc123\");\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar thread = openai.beta().threads()\n    .retrieve(\"thread_abc123\");\n\nSystem.out.println(thread.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar thread = openai.beta().threads()\n    .retrieve(\"thread_abc123\");\n\nSystem.out.println(thread.getId());"
           }
         ]
       },
@@ -14075,6 +17123,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ThreadObject"
+                },
+                "example": {
+                  "id": "thread_abc123def456",
+                  "object": "thread",
+                  "created_at": 1741312436,
+                  "metadata": {
+                    "project": "my-project"
+                  }
                 }
               }
             }
@@ -14161,12 +17217,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"science\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"science\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"science\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"science\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyThreadAsync(\"thread_abc123\",\n    new ThreadModificationOptions\n    {\n        Metadata = { [\"topic\"] = \"science\" },\n    });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyThreadAsync(\"thread_abc123\",\n    new ThreadModificationOptions\n    {\n        Metadata = { [\"topic\"] = \"science\" },\n    });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.update(\"thread_abc123\", {\n    metadata: { topic: \"science\" },\n});\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.update(\"thread_abc123\", {\n    metadata: { topic: \"science\" },\n});\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().update(\"thread_abc123\",\n    Map.of(\"metadata\", Map.of(\"topic\", \"science\")));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().update(\"thread_abc123\",\n    Map.of(\"metadata\", Map.of(\"topic\", \"science\")));"
           }
         ]
       }
@@ -14261,6 +17347,31 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListMessagesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "msg_abc123def456",
+                      "object": "thread.message",
+                      "created_at": 1741312436,
+                      "thread_id": "thread_abc123def456",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "text",
+                          "text": {
+                            "value": "Hello! How can I help you?",
+                            "annotations": []
+                          }
+                        }
+                      ],
+                      "status": "completed"
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "msg_abc123def456",
+                  "last_id": "msg_abc123def456"
                 }
               }
             }
@@ -14337,12 +17448,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar messages = threadClient.GetMessages(\"thread_abc123\");\n\nforeach (var msg in messages)\n    Console.WriteLine($\"{msg.Role} {msg.Content[0].Text}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar messages = threadClient.GetMessages(\"thread_abc123\");\n\nforeach (var msg in messages)\n    Console.WriteLine($\"{msg.Role} {msg.Content[0].Text}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst messages = await openai.beta.threads.messages.list(\"thread_abc123\");\nfor await (const msg of messages) {\n    console.log(msg.role, msg.content[0].text.value);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst messages = await openai.beta.threads.messages.list(\"thread_abc123\");\nfor await (const msg of messages) {\n    console.log(msg.role, msg.content[0].text.value);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar messages = openai.beta().threads().messages()\n    .list(\"thread_abc123\");\n\nfor (var msg : messages) {\n    System.out.println(msg.getRole() + \" \"\n        + msg.getContent().get(0).getText().getValue());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar messages = openai.beta().threads().messages()\n    .list(\"thread_abc123\");\n\nfor (var msg : messages) {\n    System.out.println(msg.getRole() + \" \"\n        + msg.getContent().get(0).getText().getValue());\n}"
           }
         ]
       },
@@ -14384,6 +17525,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.MessageObject"
+                },
+                "example": {
+                  "id": "msg_abc123def456",
+                  "object": "thread.message",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "value": "What is the weather today?",
+                        "annotations": []
+                      }
+                    }
+                  ],
+                  "status": "completed"
                 }
               }
             }
@@ -14470,12 +17628,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"role\": \"user\", \"content\": \"What is the capital of France?\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"role\": \"user\", \"content\": \"What is the capital of France?\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"role\": \"user\", \"content\": \"What is the capital of France?\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"role\": \"user\", \"content\": \"What is the capital of France?\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar message = await threadClient.CreateMessageAsync(\n    \"thread_abc123\", MessageRole.User,\n    new[] { MessageContent.FromText(\"What is the capital of France?\") });\n\nConsole.WriteLine(message.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar message = await threadClient.CreateMessageAsync(\n    \"thread_abc123\", MessageRole.User,\n    new[] { MessageContent.FromText(\"What is the capital of France?\") });\n\nConsole.WriteLine(message.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst message = await openai.beta.threads.messages.create(\n    \"thread_abc123\",\n    { role: \"user\", content: \"What is the capital of France?\" }\n);\nconsole.log(message.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst message = await openai.beta.threads.messages.create(\n    \"thread_abc123\",\n    { role: \"user\", content: \"What is the capital of France?\" }\n);\nconsole.log(message.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar message = openai.beta().threads().messages()\n    .create(\"thread_abc123\", \"user\",\n        \"What is the capital of France?\");\n\nSystem.out.println(message.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar message = openai.beta().threads().messages()\n    .create(\"thread_abc123\", \"user\",\n        \"What is the capital of France?\");\n\nSystem.out.println(message.getId());"
           }
         ]
       }
@@ -14527,6 +17715,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteMessageResponse"
+                },
+                "example": {
+                  "id": "msg_abc123def456",
+                  "object": "thread.message",
+                  "deleted": true
                 }
               }
             }
@@ -14603,12 +17796,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.DeleteMessageAsync(\n    \"thread_abc123\", \"msg_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.DeleteMessageAsync(\n    \"thread_abc123\", \"msg_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.messages.delete(\n    \"thread_abc123\", \"msg_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.messages.delete(\n    \"thread_abc123\", \"msg_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().messages()\n    .delete(\"thread_abc123\", \"msg_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().messages()\n    .delete(\"thread_abc123\", \"msg_abc123\");"
           }
         ]
       },
@@ -14658,6 +17881,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.MessageObject"
+                },
+                "example": {
+                  "id": "msg_abc123def456",
+                  "object": "thread.message",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "value": "What is the weather today?",
+                        "annotations": []
+                      }
+                    }
+                  ],
+                  "status": "completed"
                 }
               }
             }
@@ -14734,12 +17974,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar message = await threadClient.GetMessageAsync(\n    \"thread_abc123\", \"msg_abc123\");\n\nConsole.WriteLine(message.Value.Content[0].Text);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar message = await threadClient.GetMessageAsync(\n    \"thread_abc123\", \"msg_abc123\");\n\nConsole.WriteLine(message.Value.Content[0].Text);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst message = await openai.beta.threads.messages.retrieve(\n    \"thread_abc123\", \"msg_abc123\"\n);\nconsole.log(message.content[0].text.value);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst message = await openai.beta.threads.messages.retrieve(\n    \"thread_abc123\", \"msg_abc123\"\n);\nconsole.log(message.content[0].text.value);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar message = openai.beta().threads().messages()\n    .retrieve(\"thread_abc123\", \"msg_abc123\");\n\nSystem.out.println(\n    message.getContent().get(0).getText().getValue());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar message = openai.beta().threads().messages()\n    .retrieve(\"thread_abc123\", \"msg_abc123\");\n\nSystem.out.println(\n    message.getContent().get(0).getText().getValue());"
           }
         ]
       },
@@ -14789,6 +18059,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.MessageObject"
+                },
+                "example": {
+                  "id": "msg_abc123def456",
+                  "object": "thread.message",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "value": "What is the weather today?",
+                        "annotations": []
+                      }
+                    }
+                  ],
+                  "status": "completed",
+                  "metadata": {
+                    "priority": "high"
+                  }
                 }
               }
             }
@@ -14875,12 +18165,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"reviewed\": \"true\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"reviewed\": \"true\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"reviewed\": \"true\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"reviewed\": \"true\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyMessageAsync(\n    \"thread_abc123\", \"msg_abc123\",\n    new MessageModificationOptions\n    {\n        Metadata = { [\"reviewed\"] = \"true\" },\n    });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyMessageAsync(\n    \"thread_abc123\", \"msg_abc123\",\n    new MessageModificationOptions\n    {\n        Metadata = { [\"reviewed\"] = \"true\" },\n    });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.messages.update(\n    \"thread_abc123\", \"msg_abc123\",\n    { metadata: { reviewed: \"true\" } }\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.messages.update(\n    \"thread_abc123\", \"msg_abc123\",\n    { metadata: { reviewed: \"true\" } }\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().messages()\n    .update(\"thread_abc123\", \"msg_abc123\",\n        Map.of(\"metadata\", Map.of(\"reviewed\", \"true\")));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().messages()\n    .update(\"thread_abc123\", \"msg_abc123\",\n        Map.of(\"metadata\", Map.of(\"reviewed\", \"true\")));"
           }
         ]
       }
@@ -14915,6 +18235,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "queued",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -15001,12 +18330,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.CreateRunAsync(\n    \"thread_abc123\", \"asst_abc123\");\n\nConsole.WriteLine($\"{run.Value.Id} {run.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.CreateRunAsync(\n    \"thread_abc123\", \"asst_abc123\");\n\nConsole.WriteLine($\"{run.Value.Id} {run.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.create(\"thread_abc123\", {\n    assistant_id: \"asst_abc123\",\n});\nconsole.log(run.id, run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.create(\"thread_abc123\", {\n    assistant_id: \"asst_abc123\",\n});\nconsole.log(run.id, run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .create(\"thread_abc123\", \"asst_abc123\");\n\nSystem.out.println(run.getId() + \" \" + run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .create(\"thread_abc123\", \"asst_abc123\");\n\nSystem.out.println(run.getId() + \" \" + run.getStatus());"
           }
         ]
       },
@@ -15081,6 +18440,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListRunsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "run_abc123def456",
+                      "object": "thread.run",
+                      "created_at": 1741312436,
+                      "thread_id": "thread_abc123def456",
+                      "assistant_id": "asst_abc123def456",
+                      "status": "completed",
+                      "model": "gpt-4o"
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "run_abc123def456",
+                  "last_id": "run_abc123def456"
                 }
               }
             }
@@ -15157,12 +18533,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar runs = threadClient.GetRuns(\"thread_abc123\");\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Id} {run.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar runs = threadClient.GetRuns(\"thread_abc123\");\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Id} {run.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst runs = await openai.beta.threads.runs.list(\"thread_abc123\");\nfor await (const run of runs) {\n    console.log(run.id, run.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst runs = await openai.beta.threads.runs.list(\"thread_abc123\");\nfor await (const run of runs) {\n    console.log(run.id, run.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar runs = openai.beta().threads().runs()\n    .list(\"thread_abc123\");\n\nfor (var run : runs) {\n    System.out.println(run.getId() + \" \" + run.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar runs = openai.beta().threads().runs()\n    .list(\"thread_abc123\");\n\nfor (var run : runs) {\n    System.out.println(run.getId() + \" \" + run.getStatus());\n}"
           }
         ]
       }
@@ -15205,6 +18611,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "completed",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -15281,12 +18696,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.GetRunAsync(\n    \"thread_abc123\", \"run_abc123\");\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.GetRunAsync(\n    \"thread_abc123\", \"run_abc123\");\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.retrieve(\n    \"thread_abc123\", \"run_abc123\"\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.retrieve(\n    \"thread_abc123\", \"run_abc123\"\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .retrieve(\"thread_abc123\", \"run_abc123\");\n\nSystem.out.println(run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .retrieve(\"thread_abc123\", \"run_abc123\");\n\nSystem.out.println(run.getStatus());"
           }
         ]
       },
@@ -15327,6 +18772,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "completed",
+                  "model": "gpt-4o",
+                  "metadata": {
+                    "run_type": "evaluation"
+                  }
                 }
               }
             }
@@ -15413,12 +18870,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"priority\": \"high\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"priority\": \"high\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"priority\": \"high\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"priority\": \"high\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyRunAsync(\n    \"thread_abc123\", \"run_abc123\",\n    new RunModificationOptions\n    {\n        Metadata = { [\"priority\"] = \"high\" },\n    });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyRunAsync(\n    \"thread_abc123\", \"run_abc123\",\n    new RunModificationOptions\n    {\n        Metadata = { [\"priority\"] = \"high\" },\n    });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.runs.update(\n    \"thread_abc123\", \"run_abc123\",\n    { metadata: { priority: \"high\" } }\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.runs.update(\n    \"thread_abc123\", \"run_abc123\",\n    { metadata: { priority: \"high\" } }\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().runs()\n    .update(\"thread_abc123\", \"run_abc123\",\n        Map.of(\"metadata\", Map.of(\"priority\", \"high\")));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().runs()\n    .update(\"thread_abc123\", \"run_abc123\",\n        Map.of(\"metadata\", Map.of(\"priority\", \"high\")));"
           }
         ]
       }
@@ -15461,6 +18948,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "cancelling",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -15537,12 +19033,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.CancelRunAsync(\n    \"thread_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.CancelRunAsync(\n    \"thread_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.runs.cancel(\n    \"thread_abc123\", \"run_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.runs.cancel(\n    \"thread_abc123\", \"run_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().runs()\n    .cancel(\"thread_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().runs()\n    .cancel(\"thread_abc123\", \"run_abc123\");"
           }
         ]
       }
@@ -15627,6 +19153,30 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListRunStepsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "step_abc123def456",
+                      "object": "thread.run.step",
+                      "created_at": 1741312436,
+                      "run_id": "run_abc123def456",
+                      "assistant_id": "asst_abc123def456",
+                      "thread_id": "thread_abc123def456",
+                      "type": "message_creation",
+                      "status": "completed",
+                      "step_details": {
+                        "type": "message_creation",
+                        "message_creation": {
+                          "message_id": "msg_abc123def456"
+                        }
+                      }
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "step_abc123def456",
+                  "last_id": "step_abc123def456"
                 }
               }
             }
@@ -15703,12 +19253,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar steps = threadClient.GetRunSteps(\n    \"thread_abc123\", \"run_abc123\");\n\nforeach (var step in steps)\n    Console.WriteLine($\"{step.Id} {step.Type}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar steps = threadClient.GetRunSteps(\n    \"thread_abc123\", \"run_abc123\");\n\nforeach (var step in steps)\n    Console.WriteLine($\"{step.Id} {step.Type}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst steps = await openai.beta.threads.runs.steps.list(\n    \"thread_abc123\", \"run_abc123\"\n);\nfor await (const step of steps) {\n    console.log(step.id, step.type);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst steps = await openai.beta.threads.runs.steps.list(\n    \"thread_abc123\", \"run_abc123\"\n);\nfor await (const step of steps) {\n    console.log(step.id, step.type);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar steps = openai.beta().threads().runs().steps()\n    .list(\"thread_abc123\", \"run_abc123\");\n\nfor (var step : steps) {\n    System.out.println(step.getId() + \" \" + step.getType());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar steps = openai.beta().threads().runs().steps()\n    .list(\"thread_abc123\", \"run_abc123\");\n\nfor (var step : steps) {\n    System.out.println(step.getId() + \" \" + step.getType());\n}"
           }
         ]
       }
@@ -15759,6 +19339,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunStepObject"
+                },
+                "example": {
+                  "id": "step_abc123def456",
+                  "object": "thread.run.step",
+                  "created_at": 1741312436,
+                  "run_id": "run_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "thread_id": "thread_abc123def456",
+                  "type": "message_creation",
+                  "status": "completed",
+                  "step_details": {
+                    "type": "message_creation",
+                    "message_creation": {
+                      "message_id": "msg_abc123def456"
+                    }
+                  }
                 }
               }
             }
@@ -15835,12 +19431,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar step = await threadClient.GetRunStepAsync(\n    \"thread_abc123\", \"run_abc123\", \"step_abc123\");\n\nConsole.WriteLine($\"{step.Value.Type} {step.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar step = await threadClient.GetRunStepAsync(\n    \"thread_abc123\", \"run_abc123\", \"step_abc123\");\n\nConsole.WriteLine($\"{step.Value.Type} {step.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst step = await openai.beta.threads.runs.steps.retrieve(\n    \"thread_abc123\", \"run_abc123\", \"step_abc123\"\n);\nconsole.log(step.type, step.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst step = await openai.beta.threads.runs.steps.retrieve(\n    \"thread_abc123\", \"run_abc123\", \"step_abc123\"\n);\nconsole.log(step.type, step.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar step = openai.beta().threads().runs().steps()\n    .retrieve(\"thread_abc123\", \"run_abc123\",\n        \"step_abc123\");\n\nSystem.out.println(step.getType() + \" \" + step.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar step = openai.beta().threads().runs().steps()\n    .retrieve(\"thread_abc123\", \"run_abc123\",\n        \"step_abc123\");\n\nSystem.out.println(step.getType() + \" \" + step.getStatus());"
           }
         ]
       }
@@ -15883,6 +19509,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "queued",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -15969,12 +19604,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"tool_outputs\": [{\"tool_call_id\": \"call_abc123\", \"output\": \"result\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"tool_outputs\": [{\"tool_call_id\": \"call_abc123\", \"output\": \"result\"}]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"tool_outputs\": [{\"tool_call_id\": \"call_abc123\", \"output\": \"result\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"tool_outputs\": [{\"tool_call_id\": \"call_abc123\", \"output\": \"result\"}]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.SubmitToolOutputsToRunAsync(\n    \"thread_abc123\", \"run_abc123\",\n    new[] { new ToolOutput(\"call_abc123\", \"result\") });\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.SubmitToolOutputsToRunAsync(\n    \"thread_abc123\", \"run_abc123\",\n    new[] { new ToolOutput(\"call_abc123\", \"result\") });\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.submitToolOutputs(\n    \"thread_abc123\", \"run_abc123\",\n    { tool_outputs: [{ tool_call_id: \"call_abc123\", output: \"result\" }] }\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.submitToolOutputs(\n    \"thread_abc123\", \"run_abc123\",\n    { tool_outputs: [{ tool_call_id: \"call_abc123\", output: \"result\" }] }\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .submitToolOutputs(\"thread_abc123\", \"run_abc123\",\n        List.of(Map.of(\"tool_call_id\", \"call_abc123\",\n            \"output\", \"result\")));\n\nSystem.out.println(run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .submitToolOutputs(\"thread_abc123\", \"run_abc123\",\n        List.of(Map.of(\"tool_call_id\", \"call_abc123\",\n            \"output\", \"result\")));\n\nSystem.out.println(run.getStatus());"
           }
         ]
       }
@@ -16057,6 +19722,29 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListVectorStoresResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "vs_abc123def456",
+                      "object": "vector_store",
+                      "name": "Product Knowledge Base",
+                      "created_at": 1741312436,
+                      "status": "completed",
+                      "usage_bytes": 123456,
+                      "file_counts": {
+                        "in_progress": 0,
+                        "completed": 3,
+                        "failed": 0,
+                        "cancelled": 0,
+                        "total": 3
+                      }
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "vs_abc123def456",
+                  "last_id": "vs_abc123def456"
                 }
               }
             }
@@ -16133,12 +19821,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar stores = vsClient.GetVectorStores();\n\nforeach (var store in stores)\n    Console.WriteLine($\"{store.Id} {store.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar stores = vsClient.GetVectorStores();\n\nforeach (var store in stores)\n    Console.WriteLine($\"{store.Id} {store.Name}\");"
           },
           {
             "lang": "javascript",
@@ -16149,6 +19847,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst stores = await openai.vectorStores.list();\nfor await (const store of stores) {\n    console.log(store.id, store.name);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar stores = openai.vectorStores().list();\n\nfor (var store : stores) {\n    System.out.println(store.getId() + \" \" + store.getName());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar stores = openai.vectorStores().list();\n\nfor (var store : stores) {\n    System.out.println(store.getId() + \" \" + store.getName());\n}"
           }
         ]
       },
@@ -16183,6 +19891,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreObject"
+                },
+                "example": {
+                  "id": "vs_abc123def456",
+                  "object": "vector_store",
+                  "name": "Product Knowledge Base",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 0,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 0,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 0
+                  }
                 }
               }
             }
@@ -16269,12 +19992,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-vector-store\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-vector-store\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-vector-store\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-vector-store\"}'"
           },
           {
             "lang": "csharp",
@@ -16295,6 +20018,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.create({\n    name: \"my-vector-store\",\n});\nconsole.log(store.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar store = openai.vectorStores()\n    .create(\"my-vector-store\");\n\nSystem.out.println(store.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar store = openai.vectorStores()\n    .create(\"my-vector-store\");\n\nSystem.out.println(store.getId());"
           }
         ]
       }
@@ -16340,6 +20073,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreObject"
+                },
+                "example": {
+                  "id": "vs_abc123def456",
+                  "object": "vector_store",
+                  "name": "Product Knowledge Base",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 123456,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -16416,12 +20164,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar store = await vsClient.GetVectorStoreAsync(\"vs_abc123\");\n\nConsole.WriteLine($\"{store.Value.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar store = await vsClient.GetVectorStoreAsync(\"vs_abc123\");\n\nConsole.WriteLine($\"{store.Value.Name}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.retrieve(\"vs_abc123\");\nconsole.log(store.name, store.file_counts);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.retrieve(\"vs_abc123\");\nconsole.log(store.name, store.file_counts);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar store = openai.vectorStores()\n    .retrieve(\"vs_abc123\");\n\nSystem.out.println(store.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar store = openai.vectorStores()\n    .retrieve(\"vs_abc123\");\n\nSystem.out.println(store.getName());"
           }
         ]
       },
@@ -16465,6 +20243,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreObject"
+                },
+                "example": {
+                  "id": "vs_abc123def456",
+                  "object": "vector_store",
+                  "name": "Updated Knowledge Base",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 123456,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -16551,12 +20344,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.ModifyVectorStoreAsync(\"vs_abc123\",\n    new VectorStoreModificationOptions { Name = \"updated-name\" });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.ModifyVectorStoreAsync(\"vs_abc123\",\n    new VectorStoreModificationOptions { Name = \"updated-name\" });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.update(\"vs_abc123\", {\n    name: \"updated-name\",\n});\nconsole.log(store.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.update(\"vs_abc123\", {\n    name: \"updated-name\",\n});\nconsole.log(store.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().update(\"vs_abc123\",\n    Map.of(\"name\", \"updated-name\"));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().update(\"vs_abc123\",\n    Map.of(\"name\", \"updated-name\"));"
           }
         ]
       },
@@ -16600,6 +20423,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteVectorStoreResponse"
+                },
+                "example": {
+                  "id": "vs_abc123def456",
+                  "object": "vector_store",
+                  "deleted": true
                 }
               }
             }
@@ -16676,12 +20504,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.DeleteVectorStoreAsync(\"vs_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.DeleteVectorStoreAsync(\"vs_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.delete(\"vs_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.delete(\"vs_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().delete(\"vs_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().delete(\"vs_abc123\");"
           }
         ]
       }
@@ -16727,6 +20585,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileBatchObject"
+                },
+                "example": {
+                  "id": "vsfb_abc123def456",
+                  "object": "vector_store.file_batch",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "in_progress",
+                  "file_counts": {
+                    "in_progress": 3,
+                    "completed": 0,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -16813,12 +20685,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_ids\": [\"file_abc123\", \"file_def456\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_ids\": [\"file_abc123\", \"file_def456\"]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_ids\": [\"file_abc123\", \"file_def456\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_ids\": [\"file_abc123\", \"file_def456\"]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar batch = await vsClient.CreateBatchFileJobAsync(\n    \"vs_abc123\",\n    new[] { \"file_abc123\", \"file_def456\" });\n\nConsole.WriteLine($\"{batch.Value.BatchId} {batch.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar batch = await vsClient.CreateBatchFileJobAsync(\n    \"vs_abc123\",\n    new[] { \"file_abc123\", \"file_def456\" });\n\nConsole.WriteLine($\"{batch.Value.BatchId} {batch.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.vectorStores.fileBatches.create(\n    \"vs_abc123\",\n    { file_ids: [\"file_abc123\", \"file_def456\"] }\n);\nconsole.log(batch.id, batch.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.vectorStores.fileBatches.create(\n    \"vs_abc123\",\n    { file_ids: [\"file_abc123\", \"file_def456\"] }\n);\nconsole.log(batch.id, batch.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.vectorStores().fileBatches()\n    .create(\"vs_abc123\",\n        List.of(\"file_abc123\", \"file_def456\"));\n\nSystem.out.println(batch.getId() + \" \" + batch.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.vectorStores().fileBatches()\n    .create(\"vs_abc123\",\n        List.of(\"file_abc123\", \"file_def456\"));\n\nSystem.out.println(batch.getId() + \" \" + batch.getStatus());"
           }
         ]
       }
@@ -16873,6 +20775,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileBatchObject"
+                },
+                "example": {
+                  "id": "vsfb_abc123def456",
+                  "object": "vector_store.file_batch",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -16949,12 +20865,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar batch = await vsClient.GetBatchFileJobAsync(\n    \"vs_abc123\", \"vsfb_abc123\");\n\nConsole.WriteLine(batch.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar batch = await vsClient.GetBatchFileJobAsync(\n    \"vs_abc123\", \"vsfb_abc123\");\n\nConsole.WriteLine(batch.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.vectorStores.fileBatches.retrieve(\n    \"vs_abc123\", \"vsfb_abc123\"\n);\nconsole.log(batch.status, batch.file_counts);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.vectorStores.fileBatches.retrieve(\n    \"vs_abc123\", \"vsfb_abc123\"\n);\nconsole.log(batch.status, batch.file_counts);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.vectorStores().fileBatches()\n    .retrieve(\"vs_abc123\", \"vsfb_abc123\");\n\nSystem.out.println(batch.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.vectorStores().fileBatches()\n    .retrieve(\"vs_abc123\", \"vsfb_abc123\");\n\nSystem.out.println(batch.getStatus());"
           }
         ]
       }
@@ -17009,6 +20955,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileBatchObject"
+                },
+                "example": {
+                  "id": "vsfb_abc123def456",
+                  "object": "vector_store.file_batch",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "cancelling",
+                  "file_counts": {
+                    "in_progress": 1,
+                    "completed": 2,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -17085,12 +21045,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.CancelBatchFileJobAsync(\n    \"vs_abc123\", \"vsfb_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.CancelBatchFileJobAsync(\n    \"vs_abc123\", \"vsfb_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.fileBatches.cancel(\n    \"vs_abc123\", \"vsfb_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.fileBatches.cancel(\n    \"vs_abc123\", \"vsfb_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().fileBatches()\n    .cancel(\"vs_abc123\", \"vsfb_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().fileBatches()\n    .cancel(\"vs_abc123\", \"vsfb_abc123\");"
           }
         ]
       }
@@ -17207,6 +21197,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListVectorStoreFilesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "file-vs-abc123",
+                      "object": "vector_store.file",
+                      "vector_store_id": "vs_abc123def456",
+                      "created_at": 1741312436,
+                      "status": "completed",
+                      "usage_bytes": 12345
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "file-vs-abc123",
+                  "last_id": "file-vs-abc123"
                 }
               }
             }
@@ -17283,12 +21289,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar files = vsClient.GetFileAssociations(\n    \"vs_abc123\", \"vsfb_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar files = vsClient.GetFileAssociations(\n    \"vs_abc123\", \"vsfb_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.vectorStores.fileBatches.listFiles(\n    \"vs_abc123\", \"vsfb_abc123\"\n);\nfor await (const f of files) {\n    console.log(f.id, f.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.vectorStores.fileBatches.listFiles(\n    \"vs_abc123\", \"vsfb_abc123\"\n);\nfor await (const f of files) {\n    console.log(f.id, f.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.vectorStores().fileBatches()\n    .listFiles(\"vs_abc123\", \"vsfb_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.vectorStores().fileBatches()\n    .listFiles(\"vs_abc123\", \"vsfb_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getStatus());\n}"
           }
         ]
       }
@@ -17396,6 +21432,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListVectorStoreFilesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "file-vs-abc123",
+                      "object": "vector_store.file",
+                      "vector_store_id": "vs_abc123def456",
+                      "created_at": 1741312436,
+                      "status": "completed",
+                      "usage_bytes": 12345
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "file-vs-abc123",
+                  "last_id": "file-vs-abc123"
                 }
               }
             }
@@ -17472,12 +21524,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar files = vsClient.GetVectorStoreFiles(\"vs_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar files = vsClient.GetVectorStoreFiles(\"vs_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.vectorStores.files.list(\"vs_abc123\");\nfor await (const f of files) {\n    console.log(f.id, f.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.vectorStores.files.list(\"vs_abc123\");\nfor await (const f of files) {\n    console.log(f.id, f.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.vectorStores().files()\n    .list(\"vs_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.vectorStores().files()\n    .list(\"vs_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getStatus());\n}"
           }
         ]
       },
@@ -17521,6 +21603,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileObject"
+                },
+                "example": {
+                  "id": "file-vs-abc123",
+                  "object": "vector_store.file",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "in_progress",
+                  "usage_bytes": 0
                 }
               }
             }
@@ -17607,12 +21697,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_id\": \"file_abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_id\": \"file_abc123\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_id\": \"file_abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_id\": \"file_abc123\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar file = await vsClient.AddFileToVectorStoreAsync(\n    \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine($\"{file.Value.Id} {file.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar file = await vsClient.AddFileToVectorStoreAsync(\n    \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine($\"{file.Value.Id} {file.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.vectorStores.files.create(\"vs_abc123\", {\n    file_id: \"file_abc123\",\n});\nconsole.log(file.id, file.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.vectorStores.files.create(\"vs_abc123\", {\n    file_id: \"file_abc123\",\n});\nconsole.log(file.id, file.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.vectorStores().files()\n    .create(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getId() + \" \" + file.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.vectorStores().files()\n    .create(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getId() + \" \" + file.getStatus());"
           }
         ]
       }
@@ -17667,6 +21787,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileObject"
+                },
+                "example": {
+                  "id": "file-vs-abc123",
+                  "object": "vector_store.file",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 12345
                 }
               }
             }
@@ -17743,12 +21871,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar file = await vsClient.GetVectorStoreFileAsync(\n    \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine(file.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar file = await vsClient.GetVectorStoreFileAsync(\n    \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine(file.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.vectorStores.files.retrieve(\n    \"vs_abc123\", \"file_abc123\"\n);\nconsole.log(file.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.vectorStores.files.retrieve(\n    \"vs_abc123\", \"file_abc123\"\n);\nconsole.log(file.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.vectorStores().files()\n    .retrieve(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.vectorStores().files()\n    .retrieve(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getStatus());"
           }
         ]
       },
@@ -17798,6 +21956,17 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileObject"
+                },
+                "example": {
+                  "id": "file-vs-abc123",
+                  "object": "vector_store.file",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 12345,
+                  "attributes": {
+                    "category": "product-docs"
+                  }
                 }
               }
             }
@@ -17884,12 +22053,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"attributes\": {\"key\": \"value\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"attributes\": {\"key\": \"value\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"attributes\": {\"key\": \"value\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"attributes\": {\"key\": \"value\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.UpdateVectorStoreFileAttributesAsync(\n    \"vs_abc123\", \"file_abc123\",\n    new { key = \"value\" });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.UpdateVectorStoreFileAttributesAsync(\n    \"vs_abc123\", \"file_abc123\",\n    new { key = \"value\" });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.files.update(\n    \"vs_abc123\", \"file_abc123\",\n    { attributes: { key: \"value\" } }\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.files.update(\n    \"vs_abc123\", \"file_abc123\",\n    { attributes: { key: \"value\" } }\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().files().update(\n    \"vs_abc123\", \"file_abc123\",\n    Map.of(\"key\", \"value\"));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().files().update(\n    \"vs_abc123\", \"file_abc123\",\n    Map.of(\"key\", \"value\"));"
           }
         ]
       },
@@ -17942,6 +22141,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteVectorStoreFileResponse"
+                },
+                "example": {
+                  "id": "file-vs-abc123",
+                  "object": "vector_store.file",
+                  "deleted": true
                 }
               }
             }
@@ -18018,12 +22222,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.RemoveFileFromVectorStoreAsync(\n    \"vs_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.RemoveFileFromVectorStoreAsync(\n    \"vs_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.files.delete(\n    \"vs_abc123\", \"file_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.files.delete(\n    \"vs_abc123\", \"file_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().files()\n    .delete(\"vs_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().files()\n    .delete(\"vs_abc123\", \"file_abc123\");"
           }
         ]
       }
@@ -18078,6 +22312,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreSearchResultsPage"
+                },
+                "example": {
+                  "content": "This is the content of the file stored in the vector store."
                 }
               }
             }
@@ -18154,12 +22391,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar content = await vsClient\n    .GetVectorStoreFileContentAsync(\n        \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar content = await vsClient\n    .GetVectorStoreFileContentAsync(\n        \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.vectorStores.files.content(\n    \"vs_abc123\", \"file_abc123\"\n);\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.vectorStores.files.content(\n    \"vs_abc123\", \"file_abc123\"\n);\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.vectorStores().files()\n    .content(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(new String(content));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.vectorStores().files()\n    .content(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(new String(content));"
           }
         ]
       }
@@ -18205,6 +22472,24 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreSearchResultsPage"
+                },
+                "example": {
+                  "object": "vector_store.search_results.page",
+                  "data": [
+                    {
+                      "file_id": "file-vs-abc123",
+                      "filename": "product-docs.pdf",
+                      "score": 0.92,
+                      "content": [
+                        {
+                          "type": "text",
+                          "text": "Our product supports both REST API and SDK integrations."
+                        }
+                      ],
+                      "attributes": {}
+                    }
+                  ],
+                  "has_more": false
                 }
               }
             }
@@ -18291,12 +22576,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/search\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"query\": \"search query\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/search\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"query\": \"search query\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/search\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"query\": \"search query\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/search\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"query\": \"search query\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar results = vsClient.SearchVectorStore(\n    \"vs_abc123\", \"search query\");\n\nforeach (var result in results)\n    Console.WriteLine($\"{result.Score} {result.Content}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar results = vsClient.SearchVectorStore(\n    \"vs_abc123\", \"search query\");\n\nforeach (var result in results)\n    Console.WriteLine($\"{result.Score} {result.Content}\");"
           },
           {
             "lang": "javascript",
@@ -18307,6 +22602,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst results = await openai.vectorStores.search(\"vs_abc123\", {\n    query: \"search query\",\n});\nfor await (const result of results) {\n    console.log(result.score, result.content);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar results = openai.vectorStores()\n    .search(\"vs_abc123\", \"search query\");\n\nfor (var result : results) {\n    System.out.println(result.getScore()\n        + \" \" + result.getContent());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar results = openai.vectorStores()\n    .search(\"vs_abc123\", \"search query\");\n\nfor (var result : results) {\n    System.out.println(result.getScore()\n        + \" \" + result.getContent());\n}"
           }
         ]
       }
@@ -18343,6 +22648,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/VideoResource"
+                },
+                "example": {
+                  "id": "video_abc123def456",
+                  "object": "video",
+                  "status": "queued",
+                  "created_at": 1741312436,
+                  "model": "sora",
+                  "prompt": "A serene lake surrounded by mountains at sunrise."
                 }
               }
             }
@@ -18401,12 +22714,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/videos\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"sora\", \"prompt\": \"A mountain landscape at sunset\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/videos\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"sora\", \"prompt\": \"A mountain landscape at sunset\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/videos\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"sora\", \"prompt\": \"A mountain landscape at sunset\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/videos\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"sora\", \"prompt\": \"A mountain landscape at sunset\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar job = await videoClient.CreateVideoAsync(\n    \"sora\", \"A serene mountain landscape at sunset\");\n\nConsole.WriteLine($\"{job.Value.Id} {job.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar job = await videoClient.CreateVideoAsync(\n    \"sora\", \"A serene mountain landscape at sunset\");\n\nConsole.WriteLine($\"{job.Value.Id} {job.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.videos.create({\n    model: \"sora\",\n    prompt: \"A serene mountain landscape at sunset\",\n});\nconsole.log(job.id, job.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.videos.create({\n    model: \"sora\",\n    prompt: \"A serene mountain landscape at sunset\",\n});\nconsole.log(job.id, job.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.videos().create(\n    \"sora\", \"A serene mountain landscape at sunset\");\n\nSystem.out.println(job.getId() + \" \" + job.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.videos().create(\n    \"sora\", \"A serene mountain landscape at sunset\");\n\nSystem.out.println(job.getId() + \" \" + job.getStatus());"
           }
         ]
       },
@@ -18471,6 +22814,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/VideoList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "video_abc123def456",
+                      "object": "video",
+                      "status": "completed",
+                      "created_at": 1741312436,
+                      "model": "sora"
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "video_abc123def456",
+                  "last_id": "video_abc123def456"
                 }
               }
             }
@@ -18503,12 +22861,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/videos\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/videos\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/videos\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/videos\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar videos = videoClient.GetVideos();\n\nforeach (var v in videos)\n    Console.WriteLine($\"{v.Id} {v.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar videos = videoClient.GetVideos();\n\nforeach (var v in videos)\n    Console.WriteLine($\"{v.Id} {v.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst videos = await openai.videos.list();\nfor await (const v of videos) {\n    console.log(v.id, v.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst videos = await openai.videos.list();\nfor await (const v of videos) {\n    console.log(v.id, v.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar videos = openai.videos().list();\n\nfor (var v : videos) {\n    System.out.println(v.getId() + \" \" + v.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar videos = openai.videos().list();\n\nfor (var v : videos) {\n    System.out.println(v.getId() + \" \" + v.getStatus());\n}"
           }
         ]
       }
@@ -18548,6 +22936,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/VideoResource"
+                },
+                "example": {
+                  "id": "video_abc123def456",
+                  "object": "video",
+                  "status": "completed",
+                  "created_at": 1741312436,
+                  "model": "sora",
+                  "prompt": "A serene lake surrounded by mountains at sunrise."
                 }
               }
             }
@@ -18580,12 +22976,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/videos/video_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/videos/video_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/videos/video_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/videos/video_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar video = await videoClient.GetVideoAsync(\"video_abc123\");\n\nConsole.WriteLine(video.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar video = await videoClient.GetVideoAsync(\"video_abc123\");\n\nConsole.WriteLine(video.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst video = await openai.videos.retrieve(\"video_abc123\");\nconsole.log(video.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst video = await openai.videos.retrieve(\"video_abc123\");\nconsole.log(video.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar video = openai.videos().retrieve(\"video_abc123\");\n\nSystem.out.println(video.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar video = openai.videos().retrieve(\"video_abc123\");\n\nSystem.out.println(video.getStatus());"
           }
         ]
       },
@@ -18623,6 +23049,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DeletedVideoResource"
+                },
+                "example": {
+                  "id": "video_abc123def456",
+                  "object": "video",
+                  "deleted": true
                 }
               }
             }
@@ -18655,12 +23086,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/videos/video_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/videos/video_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/videos/video_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/videos/video_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar videoClient = client.OpenAI.GetVideoClient();\nawait videoClient.DeleteVideoAsync(\"video_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar videoClient = client.OpenAI.GetVideoClient();\nawait videoClient.DeleteVideoAsync(\"video_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.videos.delete(\"video_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.videos.delete(\"video_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.videos().delete(\"video_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.videos().delete(\"video_abc123\");"
           }
         ]
       }
@@ -18758,12 +23219,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/videos/video_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/videos/video_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/videos/video_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/videos/video_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar content = await videoClient\n    .GetVideoContentAsync(\"video_abc123\");\n\nConsole.WriteLine(content.Value.Url);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar content = await videoClient\n    .GetVideoContentAsync(\"video_abc123\");\n\nConsole.WriteLine(content.Value.Url);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.videos.content(\"video_abc123\");\nconsole.log(content.url);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.videos.content(\"video_abc123\");\nconsole.log(content.url);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.videos()\n    .content(\"video_abc123\");\n\nSystem.out.println(content.getUrl());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.videos()\n    .content(\"video_abc123\");\n\nSystem.out.println(content.getUrl());"
           }
         ]
       }
@@ -18793,6 +23284,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/VideoResource"
+                },
+                "example": {
+                  "id": "video_remix123",
+                  "object": "video",
+                  "status": "queued",
+                  "created_at": 1741312436,
+                  "model": "sora",
+                  "prompt": "Same scene but at sunset with warm colors."
                 }
               }
             }
@@ -18844,12 +23343,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/videos/video_abc123/remix\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"prompt\": \"Make it a night scene\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/videos/video_abc123/remix\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"prompt\": \"Make it a night scene\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/videos/video_abc123/remix\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"prompt\": \"Make it a night scene\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/videos/video_abc123/remix\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"prompt\": \"Make it a night scene\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar job = await videoClient.RemixVideoAsync(\n    \"video_abc123\", \"Make it a night scene\");\n\nConsole.WriteLine(job.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar videoClient = client.OpenAI.GetVideoClient();\nvar job = await videoClient.RemixVideoAsync(\n    \"video_abc123\", \"Make it a night scene\");\n\nConsole.WriteLine(job.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.videos.remix(\"video_abc123\", {\n    prompt: \"Make it a night scene\",\n});\nconsole.log(job.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.videos.remix(\"video_abc123\", {\n    prompt: \"Make it a night scene\",\n});\nconsole.log(job.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.videos().remix(\n    \"video_abc123\", \"Make it a night scene\");\n\nSystem.out.println(job.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.videos().remix(\n    \"video_abc123\", \"Make it a night scene\");\n\nSystem.out.println(job.getId());"
           }
         ]
       }

--- a/docs-vnext/openapi/openai-v1-stable.json
+++ b/docs-vnext/openapi/openai-v1-stable.json
@@ -230,6 +230,15 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "batch_abc123def456",
+                  "object": "batch",
+                  "endpoint": "/v1/chat/completions",
+                  "input_file_id": "file-abc123def456",
+                  "completion_window": "24h",
+                  "status": "validating",
+                  "created_at": 1741312436
                 }
               }
             }
@@ -334,22 +343,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nbatch = openai.batches.create(\n    input_file_id=\"file-abc123\",\n    endpoint=\"/v1/chat/completions\",\n    completion_window=\"24h\",\n)\nprint(batch.id, batch.status)\n# Output: batch_abc123 validating"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nbatch = openai.batches.create(\n    input_file_id=\"file-abc123\",\n    endpoint=\"/v1/chat/completions\",\n    completion_window=\"24h\",\n)\nprint(batch.id, batch.status)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nbatch = openai.batches.create(\n    input_file_id=\"file-abc123\",\n    endpoint=\"/v1/chat/completions\",\n    completion_window=\"24h\",\n)\nprint(batch.id, batch.status)\n# Output: batch_abc123 validating"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nbatch = openai.batches.create(\n    input_file_id=\"file-abc123\",\n    endpoint=\"/v1/chat/completions\",\n    completion_window=\"24h\",\n)\nprint(batch.id, batch.status)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input_file_id\": \"file-abc123\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input_file_id\": \"file-abc123\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input_file_id\": \"file-abc123\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"input_file_id\": \"file-abc123\", \"endpoint\": \"/v1/chat/completions\", \"completion_window\": \"24h\"}'"
           },
           {
             "lang": "csharp",
@@ -370,6 +379,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.batches.create({\n    input_file_id: \"file-abc123\",\n    endpoint: \"/v1/chat/completions\",\n    completion_window: \"24h\",\n});\nconsole.log(batch.id, batch.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.batches().create(\n    \"file-abc123\", \"/v1/chat/completions\", \"24h\");\n\nSystem.out.println(batch.getId() + \" \" + batch.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.batches().create(\n    \"file-abc123\", \"/v1/chat/completions\", \"24h\");\n\nSystem.out.println(batch.getId() + \" \" + batch.getStatus());"
           }
         ]
       },
@@ -437,6 +456,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListBatchesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "batch_abc123def456",
+                      "object": "batch",
+                      "endpoint": "/v1/chat/completions",
+                      "input_file_id": "file-abc123def456",
+                      "completion_window": "24h",
+                      "status": "completed",
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "batch_abc123def456",
+                  "last_id": "batch_abc123def456"
                 }
               }
             }
@@ -513,12 +549,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/batches\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar batchClient = client.OpenAI.GetBatchClient();\nvar batches = batchClient.GetBatches();\n\nforeach (var b in batches)\n    Console.WriteLine($\"{b.Id} {b.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar batchClient = client.OpenAI.GetBatchClient();\nvar batches = batchClient.GetBatches();\n\nforeach (var b in batches)\n    Console.WriteLine($\"{b.Id} {b.Status}\");"
           },
           {
             "lang": "javascript",
@@ -529,6 +575,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batches = await openai.batches.list();\nfor await (const b of batches) {\n    console.log(b.id, b.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batches = openai.batches().list();\n\nfor (var b : batches) {\n    System.out.println(b.getId() + \" \" + b.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batches = openai.batches().list();\n\nfor (var b : batches) {\n    System.out.println(b.getId() + \" \" + b.getStatus());\n}"
           }
         ]
       }
@@ -719,6 +775,22 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "batch_abc123def456",
+                  "object": "batch",
+                  "endpoint": "/v1/chat/completions",
+                  "input_file_id": "file-abc123def456",
+                  "completion_window": "24h",
+                  "status": "completed",
+                  "created_at": 1741312436,
+                  "completed_at": 1741315036,
+                  "output_file_id": "file-xyz789ghi012",
+                  "request_counts": {
+                    "total": 100,
+                    "completed": 95,
+                    "failed": 5
+                  }
                 }
               }
             }
@@ -795,12 +867,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/batches/batch_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/batches/batch_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/batches/batch_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/batches/batch_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar batchClient = client.OpenAI.GetBatchClient();\nvar batch = await batchClient.GetBatchAsync(\"batch_abc123\");\n\nConsole.WriteLine($\"{batch.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar batchClient = client.OpenAI.GetBatchClient();\nvar batch = await batchClient.GetBatchAsync(\"batch_abc123\");\n\nConsole.WriteLine($\"{batch.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.batches.retrieve(\"batch_abc123\");\nconsole.log(batch.status, batch.request_counts);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.batches.retrieve(\"batch_abc123\");\nconsole.log(batch.status, batch.request_counts);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.batches().retrieve(\"batch_abc123\");\n\nSystem.out.println(batch.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.batches().retrieve(\"batch_abc123\");\n\nSystem.out.println(batch.getStatus());"
           }
         ]
       }
@@ -991,6 +1093,15 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "batch_abc123def456",
+                  "object": "batch",
+                  "endpoint": "/v1/chat/completions",
+                  "input_file_id": "file-abc123def456",
+                  "completion_window": "24h",
+                  "status": "cancelling",
+                  "created_at": 1741312436
                 }
               }
             }
@@ -1067,12 +1178,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/batches/batch_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/batches/batch_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/batches/batch_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/batches/batch_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar batchClient = client.OpenAI.GetBatchClient();\nawait batchClient.CancelBatchAsync(\"batch_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar batchClient = client.OpenAI.GetBatchClient();\nawait batchClient.CancelBatchAsync(\"batch_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.batches.cancel(\"batch_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.batches.cancel(\"batch_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.batches().cancel(\"batch_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.batches().cancel(\"batch_abc123\");"
           }
         ]
       }
@@ -1242,6 +1383,27 @@
                       }
                     }
                   ]
+                },
+                "example": {
+                  "id": "chatcmpl-abc123def456",
+                  "object": "chat.completion",
+                  "created": 1741312436,
+                  "model": "gpt-4o-2024-11-20",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": "Hello! How can I help you today?"
+                      },
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 9,
+                    "completion_tokens": 9,
+                    "total_tokens": 18
+                  }
                 }
               }
             }
@@ -1675,22 +1837,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.chat.completions.create(\n    model=\"gpt-4o\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n# Output: \"Hello! How can I help you today?\""
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.chat.completions.create(\n    model=\"gpt-4o\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.chat.completions.create(\n    model=\"gpt-4o\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n# Output: \"Hello! How can I help you today?\""
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.chat.completions.create(\n    model=\"gpt-4o\",\n    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n)\nprint(response.choices[0].message.content)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/chat/completions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/chat/completions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/chat/completions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/chat/completions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}]}'"
           },
           {
             "lang": "csharp",
@@ -1711,6 +1873,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.chat.completions.create({\n    model: \"gpt-4o\",\n    messages: [{ role: \"user\", content: \"Hello!\" }],\n});\nconsole.log(response.choices[0].message.content);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.chat().completions().create(\n    \"gpt-4o\",\n    List.of(Map.of(\"role\", \"user\", \"content\", \"Hello!\")));\n\nSystem.out.println(\n    response.getChoices().get(0).getMessage().getContent());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.chat().completions().create(\n    \"gpt-4o\",\n    List.of(Map.of(\"role\", \"user\", \"content\", \"Hello!\")));\n\nSystem.out.println(\n    response.getChoices().get(0).getMessage().getContent());"
           }
         ]
       }
@@ -1796,6 +1968,24 @@
                         "$ref": "#/components/schemas/AzureContentFilterResultForPrompt"
                       }
                     }
+                  }
+                },
+                "example": {
+                  "id": "cmpl-abc123def456",
+                  "object": "text_completion",
+                  "created": 1741312436,
+                  "model": "gpt-3.5-turbo-instruct",
+                  "choices": [
+                    {
+                      "text": " world! This is a test.",
+                      "index": 0,
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 7,
+                    "total_tokens": 12
                   }
                 }
               }
@@ -2095,12 +2285,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/completions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"prompt\": \"Say hello\", \"max_tokens\": 100}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/completions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"prompt\": \"Say hello\", \"max_tokens\": 100}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/completions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"prompt\": \"Say hello\", \"max_tokens\": 100}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/completions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"prompt\": \"Say hello\", \"max_tokens\": 100}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar chatClient = client.OpenAI\n    .GetProjectChatClientForModel(\"gpt-4o\");\n\nvar response = await chatClient.CompleteChatAsync(\n    new ChatMessage[] {\n        new UserChatMessage(\"Say hello\"),\n    });\n\nConsole.WriteLine(response.Value.Content[0].Text);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar chatClient = client.OpenAI\n    .GetProjectChatClientForModel(\"gpt-4o\");\n\nvar response = await chatClient.CompleteChatAsync(\n    new ChatMessage[] {\n        new UserChatMessage(\"Say hello\"),\n    });\n\nConsole.WriteLine(response.Value.Content[0].Text);"
           },
           {
             "lang": "javascript",
@@ -2111,6 +2311,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.completions.create({\n    model: \"gpt-4o\",\n    prompt: \"Say hello\",\n    max_tokens: 100,\n});\nconsole.log(response.choices[0].text);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.completions().create(\n    \"gpt-4o\", \"Say hello\", 100);\n\nSystem.out.println(response.getChoices().get(0).getText());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.completions().create(\n    \"gpt-4o\", \"Say hello\", 100);\n\nSystem.out.println(response.getChoices().get(0).getText());"
           }
         ]
       }
@@ -2192,6 +2402,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerListResource"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "container_abc123def456",
+                      "object": "container",
+                      "name": "my-training-data",
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "container_abc123def456",
+                  "last_id": "container_abc123def456"
                 }
               }
             }
@@ -2268,12 +2492,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar containers = containerClient.GetContainers();\n\nforeach (var c in containers)\n    Console.WriteLine($\"{c.Id} {c.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar containers = containerClient.GetContainers();\n\nforeach (var c in containers)\n    Console.WriteLine($\"{c.Id} {c.Name}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst containers = await openai.containers.list();\nfor await (const c of containers) {\n    console.log(c.id, c.name);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst containers = await openai.containers.list();\nfor await (const c of containers) {\n    console.log(c.id, c.name);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar containers = openai.containers().list();\n\nfor (var c : containers) {\n    System.out.println(c.getId() + \" \" + c.getName());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar containers = openai.containers().list();\n\nfor (var c : containers) {\n    System.out.println(c.getId() + \" \" + c.getName());\n}"
           }
         ]
       },
@@ -2307,6 +2561,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerResource"
+                },
+                "example": {
+                  "id": "container_abc123def456",
+                  "object": "container",
+                  "name": "my-training-data",
+                  "created_at": 1741312436,
+                  "expires_after": null
                 }
               }
             }
@@ -2393,12 +2654,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-container\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-container\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-container\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/containers\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-container\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar container = await containerClient\n    .CreateContainerAsync(\"my-container\");\n\nConsole.WriteLine(container.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar container = await containerClient\n    .CreateContainerAsync(\"my-container\");\n\nConsole.WriteLine(container.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst container = await openai.containers.create({\n    name: \"my-container\",\n});\nconsole.log(container.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst container = await openai.containers.create({\n    name: \"my-container\",\n});\nconsole.log(container.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar container = openai.containers()\n    .create(\"my-container\");\n\nSystem.out.println(container.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar container = openai.containers()\n    .create(\"my-container\");\n\nSystem.out.println(container.getId());"
           }
         ]
       }
@@ -2443,6 +2734,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerResource"
+                },
+                "example": {
+                  "id": "container_abc123def456",
+                  "object": "container",
+                  "name": "my-training-data",
+                  "created_at": 1741312436,
+                  "expires_after": null
                 }
               }
             }
@@ -2519,12 +2817,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar container = await containerClient\n    .GetContainerAsync(\"container_abc123\");\n\nConsole.WriteLine(container.Value.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar container = await containerClient\n    .GetContainerAsync(\"container_abc123\");\n\nConsole.WriteLine(container.Value.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst container = await openai.containers.retrieve(\"container_abc123\");\nconsole.log(container.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst container = await openai.containers.retrieve(\"container_abc123\");\nconsole.log(container.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar container = openai.containers()\n    .retrieve(\"container_abc123\");\n\nSystem.out.println(container.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar container = openai.containers()\n    .retrieve(\"container_abc123\");\n\nSystem.out.println(container.getName());"
           }
         ]
       },
@@ -2560,6 +2888,15 @@
                 "description": "A request ID used for troubleshooting purposes.",
                 "schema": {
                   "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "container_abc123",
+                  "object": "container.deleted",
+                  "deleted": true
                 }
               }
             }
@@ -2636,12 +2973,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nawait containerClient.DeleteContainerAsync(\"container_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nawait containerClient.DeleteContainerAsync(\"container_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.containers.delete(\"container_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.containers.delete(\"container_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.containers().delete(\"container_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.containers().delete(\"container_abc123\");"
           }
         ]
       }
@@ -2732,6 +3099,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerFileListResource"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "container_file_abc123",
+                      "object": "container.file",
+                      "container_id": "container_abc123def456",
+                      "path": "/data/training.jsonl",
+                      "created_at": 1741312436,
+                      "bytes": 2048
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "container_file_abc123",
+                  "last_id": "container_file_abc123"
                 }
               }
             }
@@ -2808,12 +3191,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar files = containerClient\n    .GetContainerFiles(\"container_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Path}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar files = containerClient\n    .GetContainerFiles(\"container_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Path}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.containers.files.list(\"container_abc123\");\nfor await (const f of files) {\n    console.log(f.id, f.path);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.containers.files.list(\"container_abc123\");\nfor await (const f of files) {\n    console.log(f.id, f.path);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.containers().files()\n    .list(\"container_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getPath());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.containers().files()\n    .list(\"container_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getPath());\n}"
           }
         ]
       },
@@ -2856,6 +3269,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerFileResource"
+                },
+                "example": {
+                  "id": "container_file_abc123",
+                  "object": "container.file",
+                  "container_id": "container_abc123def456",
+                  "path": "/data/training.jsonl",
+                  "created_at": 1741312436,
+                  "bytes": 2048,
+                  "source": "user"
                 }
               }
             }
@@ -2942,12 +3364,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F file=\"@data.txt\" \\\n  -F file_path=\"data.txt\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F file=\"@data.txt\" \\\n  -F file_path=\"data.txt\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F file=\"@data.txt\" \\\n  -F file_path=\"data.txt\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/containers/container_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F file=\"@data.txt\" \\\n  -F file_path=\"data.txt\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar file = await containerClient.CreateContainerFileAsync(\n    \"container_abc123\",\n    File.OpenRead(\"data.txt\"), \"data.txt\");\n\nConsole.WriteLine(file.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar file = await containerClient.CreateContainerFileAsync(\n    \"container_abc123\",\n    File.OpenRead(\"data.txt\"), \"data.txt\");\n\nConsole.WriteLine(file.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.containers.files.create(\"container_abc123\", {\n    file: fs.createReadStream(\"data.txt\"),\n    file_path: \"data.txt\",\n});\nconsole.log(file.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.containers.files.create(\"container_abc123\", {\n    file: fs.createReadStream(\"data.txt\"),\n    file_path: \"data.txt\",\n});\nconsole.log(file.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.containers().files()\n    .create(\"container_abc123\",\n        Path.of(\"data.txt\"), \"data.txt\");\n\nSystem.out.println(file.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.containers().files()\n    .create(\"container_abc123\",\n        Path.of(\"data.txt\"), \"data.txt\");\n\nSystem.out.println(file.getId());"
           }
         ]
       }
@@ -3001,6 +3453,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ContainerFileResource"
+                },
+                "example": {
+                  "id": "container_file_abc123",
+                  "object": "container.file",
+                  "container_id": "container_abc123def456",
+                  "path": "/data/training.jsonl",
+                  "created_at": 1741312436,
+                  "bytes": 2048,
+                  "source": "user"
                 }
               }
             }
@@ -3077,12 +3538,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar file = await containerClient.GetContainerFileAsync(\n    \"container_abc123\", \"file_abc123\");\n\nConsole.WriteLine(file.Value.Path);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar file = await containerClient.GetContainerFileAsync(\n    \"container_abc123\", \"file_abc123\");\n\nConsole.WriteLine(file.Value.Path);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.containers.files.retrieve(\n    \"container_abc123\", \"file_abc123\"\n);\nconsole.log(file.path);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.containers.files.retrieve(\n    \"container_abc123\", \"file_abc123\"\n);\nconsole.log(file.path);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.containers().files()\n    .retrieve(\"container_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getPath());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.containers().files()\n    .retrieve(\"container_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getPath());"
           }
         ]
       },
@@ -3127,6 +3618,15 @@
                 "description": "A request ID used for troubleshooting purposes.",
                 "schema": {
                   "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "file_abc123",
+                  "object": "container.file.deleted",
+                  "deleted": true
                 }
               }
             }
@@ -3203,12 +3703,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nawait containerClient.DeleteContainerFileAsync(\n    \"container_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nawait containerClient.DeleteContainerFileAsync(\n    \"container_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.containers.files.delete(\n    \"container_abc123\", \"file_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.containers.files.delete(\n    \"container_abc123\", \"file_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.containers().files()\n    .delete(\"container_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.containers().files()\n    .delete(\"container_abc123\", \"file_abc123\");"
           }
         ]
       }
@@ -3338,12 +3868,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/containers/container_abc123/files/file_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar content = await containerClient\n    .GetContainerFileContentAsync(\n        \"container_abc123\", \"file_abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar containerClient = client.OpenAI.GetContainerClient();\nvar content = await containerClient\n    .GetContainerFileContentAsync(\n        \"container_abc123\", \"file_abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.containers.files.content(\n    \"container_abc123\", \"file_abc123\"\n);\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.containers.files.content(\n    \"container_abc123\", \"file_abc123\"\n);\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.containers().files()\n    .content(\"container_abc123\", \"file_abc123\");\n\nSystem.out.println(new String(content));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.containers().files()\n    .content(\"container_abc123\", \"file_abc123\");\n\nSystem.out.println(new String(content));"
           }
         ]
       }
@@ -3379,6 +3939,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationResource"
+                },
+                "example": {
+                  "id": "conv_abc123def456",
+                  "object": "conversation",
+                  "created_at": 1741312436,
+                  "metadata": {}
                 }
               }
             }
@@ -3455,22 +4021,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nconversation = openai.conversations.create(\n    items=[{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}],\n)\nprint(conversation.id)\n# Output: conv_abc123def456"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nconversation = openai.conversations.create(\n    items=[{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}],\n)\nprint(conversation.id)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nconversation = openai.conversations.create(\n    items=[{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}],\n)\nprint(conversation.id)\n# Output: conv_abc123def456"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nconversation = openai.conversations.create(\n    items=[{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}],\n)\nprint(conversation.id)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/conversations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/conversations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Hello\"}]}'"
           },
           {
             "lang": "csharp",
@@ -3491,6 +4057,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst conversation = await openai.conversations.create({\n    items: [{ type: \"message\", role: \"user\", content: \"Hello\" }],\n});\nconsole.log(conversation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations().create(\n    List.of(Map.of(\"type\", \"message\", \"role\", \"user\",\n        \"content\", \"Hello\")));\n\nSystem.out.println(conversation.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations().create(\n    List.of(Map.of(\"type\", \"message\", \"role\", \"user\",\n        \"content\", \"Hello\")));\n\nSystem.out.println(conversation.getId());"
           }
         ]
       }
@@ -3535,6 +4111,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationResource"
+                },
+                "example": {
+                  "id": "conv_abc123def456",
+                  "object": "conversation",
+                  "created_at": 1741312436,
+                  "metadata": {}
                 }
               }
             }
@@ -3611,12 +4193,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar conversation = client.OpenAI.Conversations\n    .GetConversation(\"conv_abc123\");\n\nConsole.WriteLine(conversation.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar conversation = client.OpenAI.Conversations\n    .GetConversation(\"conv_abc123\");\n\nConsole.WriteLine(conversation.Id);"
           },
           {
             "lang": "javascript",
@@ -3627,6 +4219,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst conversation = await openai.conversations.retrieve(\"conv_abc123\");\nconsole.log(conversation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations()\n    .retrieve(\"conv_abc123\");\n\nSystem.out.println(conversation.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations()\n    .retrieve(\"conv_abc123\");\n\nSystem.out.println(conversation.getId());"
           }
         ]
       },
@@ -3669,6 +4271,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationResource"
+                },
+                "example": {
+                  "id": "conv_abc123def456",
+                  "object": "conversation",
+                  "created_at": 1741312436,
+                  "metadata": {
+                    "topic": "customer-support"
+                  }
                 }
               }
             }
@@ -3755,12 +4365,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"geography\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"geography\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"geography\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"geography\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar conversation = client.OpenAI.Conversations\n    .UpdateConversation(\"conv_abc123\",\n        new { metadata = new { topic = \"geography\" } });\n\nConsole.WriteLine(conversation.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar conversation = client.OpenAI.Conversations\n    .UpdateConversation(\"conv_abc123\",\n        new { metadata = new { topic = \"geography\" } });\n\nConsole.WriteLine(conversation.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst conversation = await openai.conversations.update(\"conv_abc123\", {\n    metadata: { topic: \"geography\" },\n});\nconsole.log(conversation.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst conversation = await openai.conversations.update(\"conv_abc123\", {\n    metadata: { topic: \"geography\" },\n});\nconsole.log(conversation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations()\n    .update(\"conv_abc123\",\n        Map.of(\"metadata\", Map.of(\"topic\", \"geography\")));\n\nSystem.out.println(conversation.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar conversation = openai.conversations()\n    .update(\"conv_abc123\",\n        Map.of(\"metadata\", Map.of(\"topic\", \"geography\")));\n\nSystem.out.println(conversation.getId());"
           }
         ]
       },
@@ -3803,6 +4443,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeletedConversationResource"
+                },
+                "example": {
+                  "id": "conv_abc123def456",
+                  "object": "conversation",
+                  "deleted": true
                 }
               }
             }
@@ -3879,12 +4524,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.OpenAI.Conversations\n    .DeleteConversation(\"conv_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.OpenAI.Conversations\n    .DeleteConversation(\"conv_abc123\");"
           },
           {
             "lang": "javascript",
@@ -3895,6 +4550,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.conversations.delete(\"conv_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().delete(\"conv_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().delete(\"conv_abc123\");"
           }
         ]
       }
@@ -3988,6 +4653,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationItemList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "convitem_abc123",
+                      "object": "conversation.item",
+                      "conversation_id": "conv_abc123def456",
+                      "role": "user",
+                      "type": "message",
+                      "content": [
+                        {
+                          "type": "input_text",
+                          "text": "Hello!"
+                        }
+                      ],
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "convitem_abc123",
+                  "last_id": "convitem_abc123"
                 }
               }
             }
@@ -4064,12 +4751,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar items = client.OpenAI.Conversations\n    .GetConversationItems(\"conv_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine($\"{item.Type} {item.Id}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar items = client.OpenAI.Conversations\n    .GetConversationItems(\"conv_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine($\"{item.Type} {item.Id}\");"
           },
           {
             "lang": "javascript",
@@ -4080,6 +4777,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.conversations.items.list(\"conv_abc123\");\nfor await (const item of items) {\n    console.log(item.type, item.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.conversations().items()\n    .list(\"conv_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getType() + \" \" + item.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.conversations().items()\n    .list(\"conv_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getType() + \" \" + item.getId());\n}"
           }
         ]
       },
@@ -4135,6 +4842,25 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationItemList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "convitem_abc123",
+                      "object": "conversation.item",
+                      "conversation_id": "conv_abc123def456",
+                      "role": "user",
+                      "type": "message",
+                      "content": [
+                        {
+                          "type": "input_text",
+                          "text": "Hello!"
+                        }
+                      ],
+                      "created_at": 1741312436
+                    }
+                  ]
                 }
               }
             }
@@ -4221,12 +4947,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Follow-up\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Follow-up\"}]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Follow-up\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/conversations/conv_abc123/items\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"items\": [{\"type\": \"message\", \"role\": \"user\", \"content\": \"Follow-up\"}]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.OpenAI.Conversations\n    .CreateConversationItems(\"conv_abc123\",\n        new { items = new[] {\n            new { type = \"message\", role = \"user\", content = \"Follow-up\" }\n        }});"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.OpenAI.Conversations\n    .CreateConversationItems(\"conv_abc123\",\n        new { items = new[] {\n            new { type = \"message\", role = \"user\", content = \"Follow-up\" }\n        }});"
           },
           {
             "lang": "javascript",
@@ -4237,6 +4973,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.conversations.items.create(\"conv_abc123\", {\n    items: [{ type: \"message\", role: \"user\", content: \"Follow-up\" }],\n});"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().items().create(\"conv_abc123\",\n    List.of(Map.of(\"type\", \"message\", \"role\", \"user\",\n        \"content\", \"Follow-up\")));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().items().create(\"conv_abc123\",\n    List.of(Map.of(\"type\", \"message\", \"role\", \"user\",\n        \"content\", \"Follow-up\")));"
           }
         ]
       }
@@ -4303,6 +5049,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationItem"
+                },
+                "example": {
+                  "id": "convitem_abc123",
+                  "object": "conversation.item",
+                  "conversation_id": "conv_abc123def456",
+                  "role": "user",
+                  "type": "message",
+                  "content": [
+                    {
+                      "type": "input_text",
+                      "text": "Hello!"
+                    }
+                  ],
+                  "created_at": 1741312436
                 }
               }
             }
@@ -4379,12 +5139,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar item = client.OpenAI.Conversations\n    .GetConversationItem(\"conv_abc123\", \"item_abc123\");\n\nConsole.WriteLine(item.Type);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar item = client.OpenAI.Conversations\n    .GetConversationItem(\"conv_abc123\", \"item_abc123\");\n\nConsole.WriteLine(item.Type);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst item = await openai.conversations.items.retrieve(\n    \"conv_abc123\", \"item_abc123\"\n);\nconsole.log(item.type);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst item = await openai.conversations.items.retrieve(\n    \"conv_abc123\", \"item_abc123\"\n);\nconsole.log(item.type);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar item = openai.conversations().items()\n    .retrieve(\"conv_abc123\", \"item_abc123\");\n\nSystem.out.println(item.getType());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar item = openai.conversations().items()\n    .retrieve(\"conv_abc123\", \"item_abc123\");\n\nSystem.out.println(item.getType());"
           }
         ]
       },
@@ -4436,6 +5226,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ConversationResource"
+                },
+                "example": {
+                  "id": "convitem_abc123",
+                  "object": "conversation.item",
+                  "deleted": true
                 }
               }
             }
@@ -4512,12 +5307,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/conversations/conv_abc123/items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.OpenAI.Conversations\n    .DeleteConversationItem(\"conv_abc123\", \"item_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.OpenAI.Conversations\n    .DeleteConversationItem(\"conv_abc123\", \"item_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.conversations.items.delete(\n    \"conv_abc123\", \"item_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.conversations.items.delete(\n    \"conv_abc123\", \"item_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().items()\n    .delete(\"conv_abc123\", \"item_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.conversations().items()\n    .delete(\"conv_abc123\", \"item_abc123\");"
           }
         ]
       }
@@ -4554,6 +5379,27 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.CreateEmbeddingResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "object": "embedding",
+                      "embedding": [
+                        -0.0128,
+                        -0.0074,
+                        -0.0176,
+                        -0.0283,
+                        -0.0187
+                      ],
+                      "index": 0
+                    }
+                  ],
+                  "model": "text-embedding-3-large",
+                  "usage": {
+                    "prompt_tokens": 5,
+                    "total_tokens": 5
+                  }
                 }
               }
             }
@@ -6198,22 +7044,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.embeddings.create(\n    model=\"text-embedding-3-large\",\n    input=\"Sample text to embed\",\n)\nprint(response.data[0].embedding[:5])\n# Output: [-0.0128, -0.0074, -0.0176, -0.0283, -0.0187]"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.embeddings.create(\n    model=\"text-embedding-3-large\",\n    input=\"Sample text to embed\",\n)\nprint(response.data[0].embedding[:5])\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.embeddings.create(\n    model=\"text-embedding-3-large\",\n    input=\"Sample text to embed\",\n)\nprint(response.data[0].embedding[:5])\n# Output: [-0.0128, -0.0074, -0.0176, -0.0283, -0.0187]"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.embeddings.create(\n    model=\"text-embedding-3-large\",\n    input=\"Sample text to embed\",\n)\nprint(response.data[0].embedding[:5])\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/embeddings\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"text-embedding-3-large\", \"input\": \"Sample text\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/embeddings\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"text-embedding-3-large\", \"input\": \"Sample text\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/embeddings\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"text-embedding-3-large\", \"input\": \"Sample text\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/embeddings\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"text-embedding-3-large\", \"input\": \"Sample text\"}'"
           },
           {
             "lang": "csharp",
@@ -6234,6 +7080,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.embeddings.create({\n    model: \"text-embedding-3-large\",\n    input: \"Sample text to embed\",\n});\nconsole.log(response.data[0].embedding.slice(0, 5));"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.embeddings().create(\n    \"text-embedding-3-large\", \"Sample text to embed\");\n\nSystem.out.println(\n    response.getData().get(0).getEmbedding().size());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.embeddings().create(\n    \"text-embedding-3-large\", \"Sample text to embed\");\n\nSystem.out.println(\n    response.getData().get(0).getEmbedding().size());"
           }
         ]
       }
@@ -6322,6 +7178,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "eval_abc123def456",
+                      "object": "eval",
+                      "name": "My Evaluation",
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "eval_abc123def456",
+                  "last_id": "eval_abc123def456"
                 }
               }
             }
@@ -6398,12 +7268,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evals = evalClient.GetEvals();\n\nforeach (var e in evals)\n    Console.WriteLine($\"{e.Id} {e.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evals = evalClient.GetEvals();\n\nforeach (var e in evals)\n    Console.WriteLine($\"{e.Id} {e.Name}\");"
           },
           {
             "lang": "javascript",
@@ -6414,6 +7294,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evals = await openai.evals.list();\nfor await (const e of evals) {\n    console.log(e.id, e.name);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evals = openai.evals().list();\n\nfor (var e : evals) {\n    System.out.println(e.getId() + \" \" + e.getName());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evals = openai.evals().list();\n\nfor (var e : evals) {\n    System.out.println(e.getId() + \" \" + e.getName());\n}"
           }
         ]
       },
@@ -6448,6 +7338,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.Eval"
+                },
+                "example": {
+                  "id": "eval_abc123def456",
+                  "object": "eval",
+                  "name": "My Evaluation",
+                  "created_at": 1741312436,
+                  "data_source_config": {
+                    "type": "custom",
+                    "item_schema": {}
+                  },
+                  "testing_criteria": [],
+                  "metadata": {}
                 }
               }
             }
@@ -6601,12 +7503,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-eval\", \"data_source_config\": {\"type\": \"custom\", \"item_schema\": {}}, \"testing_criteria\": []}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-eval\", \"data_source_config\": {\"type\": \"custom\", \"item_schema\": {}}, \"testing_criteria\": []}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-eval\", \"data_source_config\": {\"type\": \"custom\", \"item_schema\": {}}, \"testing_criteria\": []}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-eval\", \"data_source_config\": {\"type\": \"custom\", \"item_schema\": {}}, \"testing_criteria\": []}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.CreateEvalAsync(\n    \"my-eval\",\n    new { type = \"custom\", item_schema = new { } },\n    new object[] { });\n\nConsole.WriteLine(evaluation.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.CreateEvalAsync(\n    \"my-eval\",\n    new { type = \"custom\", item_schema = new { } },\n    new object[] { });\n\nConsole.WriteLine(evaluation.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.create({\n    name: \"my-eval\",\n    data_source_config: { type: \"custom\", item_schema: {} },\n    testing_criteria: [],\n});\nconsole.log(evaluation.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.create({\n    name: \"my-eval\",\n    data_source_config: { type: \"custom\", item_schema: {} },\n    testing_criteria: [],\n});\nconsole.log(evaluation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals().create(\n    \"my-eval\",\n    Map.of(\"type\", \"custom\", \"item_schema\", Map.of()),\n    List.of());\n\nSystem.out.println(evaluation.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals().create(\n    \"my-eval\",\n    Map.of(\"type\", \"custom\", \"item_schema\", Map.of()),\n    List.of());\n\nSystem.out.println(evaluation.getId());"
           }
         ]
       }
@@ -6652,6 +7584,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.Eval"
+                },
+                "example": {
+                  "id": "eval_abc123def456",
+                  "object": "eval",
+                  "name": "My Evaluation",
+                  "created_at": 1741312436,
+                  "data_source_config": {
+                    "type": "custom",
+                    "item_schema": {}
+                  },
+                  "testing_criteria": [],
+                  "metadata": {}
                 }
               }
             }
@@ -6728,12 +7672,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.GetEvalAsync(\"eval_abc123\");\n\nConsole.WriteLine($\"{evaluation.Value.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.GetEvalAsync(\"eval_abc123\");\n\nConsole.WriteLine($\"{evaluation.Value.Name}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.retrieve(\"eval_abc123\");\nconsole.log(evaluation.name, evaluation.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.retrieve(\"eval_abc123\");\nconsole.log(evaluation.name, evaluation.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals()\n    .retrieve(\"eval_abc123\");\n\nSystem.out.println(evaluation.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals()\n    .retrieve(\"eval_abc123\");\n\nSystem.out.println(evaluation.getName());"
           }
         ]
       },
@@ -6776,6 +7750,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.Eval"
+                },
+                "example": {
+                  "id": "eval_abc123def456",
+                  "object": "eval",
+                  "name": "Updated Evaluation",
+                  "created_at": 1741312436,
+                  "data_source_config": {
+                    "type": "custom",
+                    "item_schema": {}
+                  },
+                  "testing_criteria": [],
+                  "metadata": {}
                 }
               }
             }
@@ -6870,12 +7856,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.UpdateEvalAsync(\n    \"eval_abc123\", name: \"updated-name\");\n\nConsole.WriteLine(evaluation.Value.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar evaluation = await evalClient.UpdateEvalAsync(\n    \"eval_abc123\", name: \"updated-name\");\n\nConsole.WriteLine(evaluation.Value.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.update(\"eval_abc123\", {\n    name: \"updated-name\",\n});\nconsole.log(evaluation.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst evaluation = await openai.evals.update(\"eval_abc123\", {\n    name: \"updated-name\",\n});\nconsole.log(evaluation.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals()\n    .update(\"eval_abc123\", Map.of(\"name\", \"updated-name\"));\n\nSystem.out.println(evaluation.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar evaluation = openai.evals()\n    .update(\"eval_abc123\", Map.of(\"name\", \"updated-name\"));\n\nSystem.out.println(evaluation.getName());"
           }
         ]
       },
@@ -6937,6 +7953,11 @@
                       "type": "string"
                     }
                   }
+                },
+                "example": {
+                  "id": "eval_abc123def456",
+                  "object": "eval",
+                  "deleted": true
                 }
               }
             }
@@ -7013,12 +8034,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.DeleteEvalAsync(\"eval_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.DeleteEvalAsync(\"eval_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.delete(\"eval_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.delete(\"eval_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().delete(\"eval_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().delete(\"eval_abc123\");"
           }
         ]
       }
@@ -7114,6 +8165,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRunList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "evalrun_abc123def456",
+                      "object": "eval.run",
+                      "eval_id": "eval_abc123def456",
+                      "status": "completed",
+                      "created_at": 1741312436,
+                      "model": "gpt-4o-2024-11-20",
+                      "result_counts": {
+                        "total": 50,
+                        "passed": 45,
+                        "failed": 3,
+                        "errored": 2
+                      }
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "evalrun_abc123def456",
+                  "last_id": "evalrun_abc123def456"
                 }
               }
             }
@@ -7190,12 +8263,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar runs = evalClient.GetEvalRuns(\"eval_abc123\");\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Id} {run.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar runs = evalClient.GetEvalRuns(\"eval_abc123\");\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Id} {run.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst runs = await openai.evals.runs.list(\"eval_abc123\");\nfor await (const run of runs) {\n    console.log(run.id, run.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst runs = await openai.evals.runs.list(\"eval_abc123\");\nfor await (const run of runs) {\n    console.log(run.id, run.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar runs = openai.evals().runs().list(\"eval_abc123\");\n\nfor (var run : runs) {\n    System.out.println(run.getId() + \" \" + run.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar runs = openai.evals().runs().list(\"eval_abc123\");\n\nfor (var run : runs) {\n    System.out.println(run.getId() + \" \" + run.getStatus());\n}"
           }
         ]
       },
@@ -7238,6 +8341,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRun"
+                },
+                "example": {
+                  "id": "evalrun_abc123def456",
+                  "object": "eval.run",
+                  "eval_id": "eval_abc123def456",
+                  "status": "queued",
+                  "created_at": 1741312436,
+                  "model": "gpt-4o-2024-11-20",
+                  "result_counts": {
+                    "total": 0,
+                    "passed": 0,
+                    "failed": 0,
+                    "errored": 0
+                  }
                 }
               }
             }
@@ -7324,12 +8441,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"data_source\": {\"type\": \"completions\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"data_source\": {\"type\": \"completions\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"data_source\": {\"type\": \"completions\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"data_source\": {\"type\": \"completions\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar run = await evalClient.CreateEvalRunAsync(\n    \"eval_abc123\", \"gpt-4o\",\n    new { type = \"completions\" });\n\nConsole.WriteLine(run.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar run = await evalClient.CreateEvalRunAsync(\n    \"eval_abc123\", \"gpt-4o\",\n    new { type = \"completions\" });\n\nConsole.WriteLine(run.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.evals.runs.create(\"eval_abc123\", {\n    model: \"gpt-4o\",\n    data_source: { type: \"completions\" },\n});\nconsole.log(run.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.evals.runs.create(\"eval_abc123\", {\n    model: \"gpt-4o\",\n    data_source: { type: \"completions\" },\n});\nconsole.log(run.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.evals().runs().create(\n    \"eval_abc123\", \"gpt-4o\",\n    Map.of(\"type\", \"completions\"));\n\nSystem.out.println(run.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.evals().runs().create(\n    \"eval_abc123\", \"gpt-4o\",\n    Map.of(\"type\", \"completions\"));\n\nSystem.out.println(run.getId());"
           }
         ]
       }
@@ -7382,6 +8529,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRun"
+                },
+                "example": {
+                  "id": "evalrun_abc123def456",
+                  "object": "eval.run",
+                  "eval_id": "eval_abc123def456",
+                  "status": "completed",
+                  "created_at": 1741312436,
+                  "model": "gpt-4o-2024-11-20",
+                  "result_counts": {
+                    "total": 50,
+                    "passed": 45,
+                    "failed": 3,
+                    "errored": 2
+                  }
                 }
               }
             }
@@ -7458,12 +8619,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar run = await evalClient.GetEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar run = await evalClient.GetEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.evals.runs.retrieve(\n    \"eval_abc123\", \"run_abc123\"\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.evals.runs.retrieve(\n    \"eval_abc123\", \"run_abc123\"\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.evals().runs()\n    .retrieve(\"eval_abc123\", \"run_abc123\");\n\nSystem.out.println(run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.evals().runs()\n    .retrieve(\"eval_abc123\", \"run_abc123\");\n\nSystem.out.println(run.getStatus());"
           }
         ]
       },
@@ -7514,6 +8705,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRun"
+                },
+                "example": {
+                  "id": "evalrun_abc123def456",
+                  "object": "eval.run",
+                  "eval_id": "eval_abc123def456",
+                  "status": "canceled",
+                  "created_at": 1741312436,
+                  "model": "gpt-4o-2024-11-20"
                 }
               }
             }
@@ -7590,12 +8789,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.CancelEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.CancelEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.runs.cancel(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.runs.cancel(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().runs()\n    .cancel(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().runs()\n    .cancel(\"eval_abc123\", \"run_abc123\");"
           }
         ]
       },
@@ -7665,6 +8894,11 @@
                       "type": "string"
                     }
                   }
+                },
+                "example": {
+                  "id": "evalrun_abc123def456",
+                  "object": "eval.run",
+                  "deleted": true
                 }
               }
             }
@@ -7741,12 +8975,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.DeleteEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nawait evalClient.DeleteEvalRunAsync(\n    \"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.runs.delete(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.evals.runs.delete(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().runs()\n    .delete(\"eval_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.evals().runs()\n    .delete(\"eval_abc123\", \"run_abc123\");"
           }
         ]
       }
@@ -7846,6 +9110,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRunOutputItemList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "evalrunitem_abc123",
+                      "object": "eval.run.output_item",
+                      "eval_run_id": "evalrun_abc123def456",
+                      "status": "pass",
+                      "created_at": 1741312436
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "evalrunitem_abc123",
+                  "last_id": "evalrunitem_abc123"
                 }
               }
             }
@@ -7922,12 +9201,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar items = evalClient.GetEvalRunOutputItems(\n    \"eval_abc123\", \"run_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine(item.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar items = evalClient.GetEvalRunOutputItems(\n    \"eval_abc123\", \"run_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine(item.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.evals.runs.outputItems\n    .list(\"eval_abc123\", \"run_abc123\");\nfor await (const item of items) {\n    console.log(item.id);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.evals.runs.outputItems\n    .list(\"eval_abc123\", \"run_abc123\");\nfor await (const item of items) {\n    console.log(item.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.evals().runs().outputItems()\n    .list(\"eval_abc123\", \"run_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.evals().runs().outputItems()\n    .list(\"eval_abc123\", \"run_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getId());\n}"
           }
         ]
       }
@@ -7988,6 +9297,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.EvalRunOutputItem"
+                },
+                "example": {
+                  "id": "evalrunitem_abc123",
+                  "object": "eval.run.output_item",
+                  "eval_run_id": "evalrun_abc123def456",
+                  "status": "pass",
+                  "created_at": 1741312436
                 }
               }
             }
@@ -8064,12 +9380,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items/item_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/evals/eval_abc123/runs/run_abc123/output_items/item_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar item = await evalClient.GetEvalRunOutputItemAsync(\n    \"eval_abc123\", \"run_abc123\", \"item_abc123\");\n\nConsole.WriteLine(item.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar evalClient = client.OpenAI.GetEvalClient();\nvar item = await evalClient.GetEvalRunOutputItemAsync(\n    \"eval_abc123\", \"run_abc123\", \"item_abc123\");\n\nConsole.WriteLine(item.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst item = await openai.evals.runs.outputItems\n    .retrieve(\"eval_abc123\", \"run_abc123\", \"item_abc123\");\nconsole.log(item.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst item = await openai.evals.runs.outputItems\n    .retrieve(\"eval_abc123\", \"run_abc123\", \"item_abc123\");\nconsole.log(item.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar item = openai.evals().runs().outputItems()\n    .retrieve(\"eval_abc123\", \"run_abc123\",\n        \"item_abc123\");\n\nSystem.out.println(item.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar item = openai.evals().runs().outputItems()\n    .retrieve(\"eval_abc123\", \"run_abc123\",\n        \"item_abc123\");\n\nSystem.out.println(item.getId());"
           }
         ]
       }
@@ -8176,6 +9522,14 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "file-abc123def456",
+                  "object": "file",
+                  "bytes": 140,
+                  "created_at": 1741312436,
+                  "filename": "training_data.jsonl",
+                  "purpose": "fine-tune"
                 }
               }
             }
@@ -8252,22 +9606,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nfile = openai.files.create(\n    file=open(\"data.jsonl\", \"rb\"),\n    purpose=\"fine-tune\",\n)\nprint(file.id)\n# Output: file-abc123def456"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nfile = openai.files.create(\n    file=open(\"data.jsonl\", \"rb\"),\n    purpose=\"fine-tune\",\n)\nprint(file.id)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nfile = openai.files.create(\n    file=open(\"data.jsonl\", \"rb\"),\n    purpose=\"fine-tune\",\n)\nprint(file.id)\n# Output: file-abc123def456"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nfile = openai.files.create(\n    file=open(\"data.jsonl\", \"rb\"),\n    purpose=\"fine-tune\",\n)\nprint(file.id)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@data.jsonl\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@data.jsonl\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@data.jsonl\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@data.jsonl\""
           },
           {
             "lang": "csharp",
@@ -8288,6 +9642,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.files.create({\n    file: fs.createReadStream(\"data.jsonl\"),\n    purpose: \"fine-tune\",\n});\nconsole.log(file.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.files().create(\n    Path.of(\"data.jsonl\"), \"fine-tune\");\n\nSystem.out.println(file.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.files().create(\n    Path.of(\"data.jsonl\"), \"fine-tune\");\n\nSystem.out.println(file.getId());"
           }
         ]
       },
@@ -8361,6 +9725,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFilesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "file-abc123def456",
+                      "object": "file",
+                      "bytes": 140,
+                      "created_at": 1741312436,
+                      "filename": "training_data.jsonl",
+                      "purpose": "fine-tune"
+                    }
+                  ]
                 }
               }
             }
@@ -8437,12 +9814,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -8463,6 +9840,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.files.list();\nfor await (const f of files) {\n    console.log(f.id, f.filename);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.files().list();\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getFilename());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.files().list();\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getFilename());\n}"
           }
         ]
       }
@@ -8578,6 +9965,14 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "file-abc123def456",
+                  "object": "file",
+                  "bytes": 140,
+                  "created_at": 1741312436,
+                  "filename": "training_data.jsonl",
+                  "purpose": "fine-tune"
                 }
               }
             }
@@ -8654,12 +10049,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nvar file = await fileClient.GetFileAsync(\"file-abc123\");\n\nConsole.WriteLine($\"{file.Value.Filename} {file.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nvar file = await fileClient.GetFileAsync(\"file-abc123\");\n\nConsole.WriteLine($\"{file.Value.Filename} {file.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.files.retrieve(\"file-abc123\");\nconsole.log(file.filename, file.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.files.retrieve(\"file-abc123\");\nconsole.log(file.filename, file.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.files().retrieve(\"file-abc123\");\n\nSystem.out.println(file.getFilename() + \" \" + file.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.files().retrieve(\"file-abc123\");\n\nSystem.out.println(file.getFilename() + \" \" + file.getStatus());"
           }
         ]
       },
@@ -8702,6 +10127,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteFileResponse"
+                },
+                "example": {
+                  "id": "file-abc123def456",
+                  "object": "file",
+                  "deleted": true
                 }
               }
             }
@@ -8778,12 +10208,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/files/file-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nawait fileClient.DeleteFileAsync(\"file-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nawait fileClient.DeleteFileAsync(\"file-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.files.delete(\"file-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.files.delete(\"file-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.files().delete(\"file-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.files().delete(\"file-abc123\");"
           }
         ]
       }
@@ -8904,12 +10364,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/files/file-abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/files/file-abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/files/file-abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/files/file-abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nvar content = await fileClient.DownloadFileAsync(\"file-abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar fileClient = client.OpenAI.GetOpenAIFileClient();\nvar content = await fileClient.DownloadFileAsync(\"file-abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.files.content(\"file-abc123\");\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.files.content(\"file-abc123\");\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.files().content(\"file-abc123\");\n\nSystem.out.println(new String(content));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.files().content(\"file-abc123\");\n\nSystem.out.println(new String(content));"
           }
         ]
       }
@@ -8937,6 +10427,13 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunGraderResponse"
+                },
+                "example": {
+                  "result": {
+                    "score": 0.95,
+                    "passed": true,
+                    "explanation": "The response accurately answered the question."
+                  }
                 }
               }
             }
@@ -9023,12 +10520,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/run\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}, \"model_sample\": \"Hello\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/run\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}, \"model_sample\": \"Hello\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/run\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}, \"model_sample\": \"Hello\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/run\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}, \"model_sample\": \"Hello\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar result = await ftClient.RunGraderAsync(\n    new { type = \"python\", source = \"return 1.0\" },\n    \"Hello world\");\n\nConsole.WriteLine(result);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar result = await ftClient.RunGraderAsync(\n    new { type = \"python\", source = \"return 1.0\" },\n    \"Hello world\");\n\nConsole.WriteLine(result);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst result = await openai.fineTuning.alpha.graders.run({\n    grader: { type: \"python\", source: \"return 1.0\" },\n    model_sample: \"Hello world\",\n});\nconsole.log(result);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst result = await openai.fineTuning.alpha.graders.run({\n    grader: { type: \"python\", source: \"return 1.0\" },\n    model_sample: \"Hello world\",\n});\nconsole.log(result);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar result = openai.fineTuning().alpha().graders()\n    .run(Map.of(\"type\", \"python\", \"source\", \"return 1.0\"),\n        \"Hello world\");\n\nSystem.out.println(result);"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar result = openai.fineTuning().alpha().graders()\n    .run(Map.of(\"type\", \"python\", \"source\", \"return 1.0\"),\n        \"Hello world\");\n\nSystem.out.println(result);"
           }
         ]
       }
@@ -9056,6 +10583,10 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ValidateGraderResponse"
+                },
+                "example": {
+                  "valid": true,
+                  "errors": []
                 }
               }
             }
@@ -9166,12 +10697,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/validate\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/validate\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/validate\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/alpha/graders/validate\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"grader\": {\"type\": \"python\", \"source\": \"return 1.0\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar result = await ftClient.ValidateGraderAsync(\n    new { type = \"python\", source = \"return 1.0\" });\n\nConsole.WriteLine(result);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar result = await ftClient.ValidateGraderAsync(\n    new { type = \"python\", source = \"return 1.0\" });\n\nConsole.WriteLine(result);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst result = await openai.fineTuning.alpha.graders.validate({\n    grader: { type: \"python\", source: \"return 1.0\" },\n});\nconsole.log(result);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst result = await openai.fineTuning.alpha.graders.validate({\n    grader: { type: \"python\", source: \"return 1.0\" },\n});\nconsole.log(result);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar result = openai.fineTuning().alpha().graders()\n    .validate(Map.of(\"type\", \"python\",\n        \"source\", \"return 1.0\"));\n\nSystem.out.println(result);"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar result = openai.fineTuning().alpha().graders()\n    .validate(Map.of(\"type\", \"python\",\n        \"source\", \"return 1.0\"));\n\nSystem.out.println(result);"
           }
         ]
       }
@@ -9264,6 +10825,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFineTuningCheckpointPermissionResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "ftckptperm-abc123",
+                      "object": "fine_tuning.job.checkpoint.permission",
+                      "created_at": 1741312436,
+                      "project_id": "proj-abc123"
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "ftckptperm-abc123",
+                  "last_id": "ftckptperm-abc123"
                 }
               }
             }
@@ -9340,12 +10915,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar permissions = ftClient.GetCheckpointPermissions(\n    \"ft:gpt-4o:org:suffix:id\");\n\nforeach (var p in permissions)\n    Console.WriteLine(p.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar permissions = ftClient.GetCheckpointPermissions(\n    \"ft:gpt-4o:org:suffix:id\");\n\nforeach (var p in permissions)\n    Console.WriteLine(p.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst permissions = await openai.fineTuning.checkpoints\n    .permissions.list(\"ft:gpt-4o:org:suffix:id\");\nfor await (const p of permissions) {\n    console.log(p.id);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst permissions = await openai.fineTuning.checkpoints\n    .permissions.list(\"ft:gpt-4o:org:suffix:id\");\nfor await (const p of permissions) {\n    console.log(p.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar permissions = openai.fineTuning().checkpoints()\n    .permissions().list(\"ft:gpt-4o:org:suffix:id\");\n\nfor (var p : permissions) {\n    System.out.println(p.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar permissions = openai.fineTuning().checkpoints()\n    .permissions().list(\"ft:gpt-4o:org:suffix:id\");\n\nfor (var p : permissions) {\n    System.out.println(p.getId());\n}"
           }
         ]
       },
@@ -9389,6 +10994,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFineTuningCheckpointPermissionResponse"
+                },
+                "example": {
+                  "id": "ftckptperm-abc123",
+                  "object": "fine_tuning.job.checkpoint.permission",
+                  "created_at": 1741312436,
+                  "project_id": "proj-abc123"
                 }
               }
             }
@@ -9475,12 +11086,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"project_ids\": [\"proj_abc123\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"project_ids\": [\"proj_abc123\"]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"project_ids\": [\"proj_abc123\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"project_ids\": [\"proj_abc123\"]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CreateCheckpointPermissionAsync(\n    \"ft:gpt-4o:org:suffix:id\",\n    new[] { \"proj_abc123\" });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CreateCheckpointPermissionAsync(\n    \"ft:gpt-4o:org:suffix:id\",\n    new[] { \"proj_abc123\" });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.checkpoints.permissions.create(\n    \"ft:gpt-4o:org:suffix:id\",\n    { project_ids: [\"proj_abc123\"] }\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.checkpoints.permissions.create(\n    \"ft:gpt-4o:org:suffix:id\",\n    { project_ids: [\"proj_abc123\"] }\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().checkpoints().permissions()\n    .create(\"ft:gpt-4o:org:suffix:id\",\n        List.of(\"proj_abc123\"));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().checkpoints().permissions()\n    .create(\"ft:gpt-4o:org:suffix:id\",\n        List.of(\"proj_abc123\"));"
           }
         ]
       }
@@ -9535,6 +11176,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteFineTuningCheckpointPermissionResponse"
+                },
+                "example": {
+                  "id": "ftckptperm-abc123",
+                  "object": "fine_tuning.job.checkpoint.permission",
+                  "deleted": true
                 }
               }
             }
@@ -9611,12 +11257,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions/perm_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions/perm_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions/perm_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/fine_tuning/checkpoints/ft:gpt-4o:org:suffix:id/permissions/perm_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.DeleteCheckpointPermissionAsync(\n    \"ft:gpt-4o:org:suffix:id\", \"perm_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.DeleteCheckpointPermissionAsync(\n    \"ft:gpt-4o:org:suffix:id\", \"perm_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.checkpoints.permissions.delete(\n    \"ft:gpt-4o:org:suffix:id\", \"perm_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.checkpoints.permissions.delete(\n    \"ft:gpt-4o:org:suffix:id\", \"perm_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().checkpoints().permissions()\n    .delete(\"ft:gpt-4o:org:suffix:id\", \"perm_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().checkpoints().permissions()\n    .delete(\"ft:gpt-4o:org:suffix:id\", \"perm_abc123\");"
           }
         ]
       }
@@ -9653,6 +11329,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "status": "validating_files",
+                  "training_file": "file-abc123def456",
+                  "hyperparameters": {
+                    "n_epochs": "auto",
+                    "batch_size": "auto",
+                    "learning_rate_multiplier": "auto"
+                  },
+                  "organization_id": "org-abc123"
                 }
               }
             }
@@ -9729,22 +11419,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\njob = openai.fine_tuning.jobs.create(\n    model=\"gpt-4o-mini-2024-07-18\",\n    training_file=\"file-abc123\",\n)\nprint(job.id, job.status)\n# Output: ftjob-abc123 validating_files"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\njob = openai.fine_tuning.jobs.create(\n    model=\"gpt-4o-mini-2024-07-18\",\n    training_file=\"file-abc123\",\n)\nprint(job.id, job.status)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\njob = openai.fine_tuning.jobs.create(\n    model=\"gpt-4o-mini-2024-07-18\",\n    training_file=\"file-abc123\",\n)\nprint(job.id, job.status)\n# Output: ftjob-abc123 validating_files"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\njob = openai.fine_tuning.jobs.create(\n    model=\"gpt-4o-mini-2024-07-18\",\n    training_file=\"file-abc123\",\n)\nprint(job.id, job.status)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-mini-2024-07-18\", \"training_file\": \"file-abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-mini-2024-07-18\", \"training_file\": \"file-abc123\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-mini-2024-07-18\", \"training_file\": \"file-abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-mini-2024-07-18\", \"training_file\": \"file-abc123\"}'"
           },
           {
             "lang": "csharp",
@@ -9765,6 +11455,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.fineTuning.jobs.create({\n    model: \"gpt-4o-mini-2024-07-18\",\n    training_file: \"file-abc123\",\n});\nconsole.log(job.id, job.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.fineTuning().jobs().create(\n    \"gpt-4o-mini-2024-07-18\", \"file-abc123\");\n\nSystem.out.println(job.getId() + \" \" + job.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.fineTuning().jobs().create(\n    \"gpt-4o-mini-2024-07-18\", \"file-abc123\");\n\nSystem.out.println(job.getId() + \" \" + job.getStatus());"
           }
         ]
       },
@@ -9821,6 +11521,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListPaginatedFineTuningJobsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "ftjob-abc123def456",
+                      "object": "fine_tuning.job",
+                      "model": "gpt-4o-mini-2024-07-18",
+                      "created_at": 1741312436,
+                      "status": "succeeded",
+                      "training_file": "file-abc123def456",
+                      "fine_tuned_model": "ft:gpt-4o-mini:my-org:custom-suffix:abc123"
+                    }
+                  ],
+                  "has_more": false
                 }
               }
             }
@@ -9897,12 +11612,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar jobs = ftClient.GetJobs();\n\nforeach (var job in jobs)\n    Console.WriteLine($\"{job.Id} {job.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar jobs = ftClient.GetJobs();\n\nforeach (var job in jobs)\n    Console.WriteLine($\"{job.Id} {job.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst jobs = await openai.fineTuning.jobs.list();\nfor await (const job of jobs) {\n    console.log(job.id, job.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst jobs = await openai.fineTuning.jobs.list();\nfor await (const job of jobs) {\n    console.log(job.id, job.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar jobs = openai.fineTuning().jobs().list();\n\nfor (var job : jobs) {\n    System.out.println(job.getId() + \" \" + job.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar jobs = openai.fineTuning().jobs().list();\n\nfor (var job : jobs) {\n    System.out.println(job.getId() + \" \" + job.getStatus());\n}"
           }
         ]
       }
@@ -9948,6 +11693,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "finished_at": 1741315036,
+                  "status": "succeeded",
+                  "training_file": "file-abc123def456",
+                  "fine_tuned_model": "ft:gpt-4o-mini:my-org:custom-suffix:abc123",
+                  "trained_tokens": 52814,
+                  "result_files": [
+                    "file-result123"
+                  ]
                 }
               }
             }
@@ -10024,12 +11783,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar job = await ftClient.GetJobAsync(\"ftjob-abc123\");\n\nConsole.WriteLine($\"{job.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar job = await ftClient.GetJobAsync(\"ftjob-abc123\");\n\nConsole.WriteLine($\"{job.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.fineTuning.jobs.retrieve(\"ftjob-abc123\");\nconsole.log(job.status, job.trained_tokens);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst job = await openai.fineTuning.jobs.retrieve(\"ftjob-abc123\");\nconsole.log(job.status, job.trained_tokens);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.fineTuning().jobs()\n    .retrieve(\"ftjob-abc123\");\n\nSystem.out.println(job.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar job = openai.fineTuning().jobs()\n    .retrieve(\"ftjob-abc123\");\n\nSystem.out.println(job.getStatus());"
           }
         ]
       }
@@ -10075,6 +11864,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "status": "cancelled",
+                  "training_file": "file-abc123def456"
                 }
               }
             }
@@ -10151,12 +11948,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CancelJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CancelJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.cancel(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.cancel(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().cancel(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().cancel(\"ftjob-abc123\");"
           }
         ]
       }
@@ -10224,6 +12051,27 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFineTuningJobCheckpointsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "ftckpt-abc123def456",
+                      "object": "fine_tuning.job.checkpoint",
+                      "created_at": 1741313436,
+                      "fine_tuning_job_id": "ftjob-abc123def456",
+                      "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+                      "step_number": 100,
+                      "metrics": {
+                        "step": 100,
+                        "train_loss": 0.234,
+                        "train_mean_token_accuracy": 0.891
+                      }
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "ftckpt-abc123def456",
+                  "last_id": "ftckpt-abc123def456"
                 }
               }
             }
@@ -10300,12 +12148,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar checkpoints = ftClient.GetJobCheckpoints(\"ftjob-abc123\");\n\nforeach (var cp in checkpoints)\n    Console.WriteLine($\"{cp.Id} step {cp.StepNumber}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar checkpoints = ftClient.GetJobCheckpoints(\"ftjob-abc123\");\n\nforeach (var cp in checkpoints)\n    Console.WriteLine($\"{cp.Id} step {cp.StepNumber}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst checkpoints = await openai.fineTuning.jobs.checkpoints\n    .list(\"ftjob-abc123\");\nfor await (const cp of checkpoints) {\n    console.log(cp.id, cp.step_number);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst checkpoints = await openai.fineTuning.jobs.checkpoints\n    .list(\"ftjob-abc123\");\nfor await (const cp of checkpoints) {\n    console.log(cp.id, cp.step_number);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar checkpoints = openai.fineTuning().jobs()\n    .checkpoints().list(\"ftjob-abc123\");\n\nfor (var cp : checkpoints) {\n    System.out.println(cp.getId() + \" step \" + cp.getStepNumber());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar checkpoints = openai.fineTuning().jobs()\n    .checkpoints().list(\"ftjob-abc123\");\n\nfor (var cp : checkpoints) {\n    System.out.println(cp.getId() + \" step \" + cp.getStepNumber());\n}"
           }
         ]
       }
@@ -10381,6 +12259,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CopyModelResponse"
+                },
+                "example": {
+                  "id": "ftckpt-copy123",
+                  "object": "fine_tuning.job.checkpoint",
+                  "created_at": 1741312436,
+                  "fine_tuning_job_id": "ftjob-abc123def456",
+                  "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+                  "step_number": 100,
+                  "metrics": {
+                    "step": 100,
+                    "train_loss": 0.234
+                  }
                 }
               }
             }
@@ -10467,12 +12357,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CopyCheckpointAsync(\n    \"ftjob-abc123\", \"ftckpt-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.CopyCheckpointAsync(\n    \"ftjob-abc123\", \"ftckpt-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.checkpoints.copy(\n    \"ftjob-abc123\", \"ftckpt-abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.checkpoints.copy(\n    \"ftjob-abc123\", \"ftckpt-abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().checkpoints()\n    .copy(\"ftjob-abc123\", \"ftckpt-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().checkpoints()\n    .copy(\"ftjob-abc123\", \"ftckpt-abc123\");"
           }
         ]
       },
@@ -10546,6 +12466,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CopyModelResponse"
+                },
+                "example": {
+                  "id": "ftckpt-abc123def456",
+                  "object": "fine_tuning.job.checkpoint",
+                  "created_at": 1741313436,
+                  "fine_tuning_job_id": "ftjob-abc123def456",
+                  "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+                  "step_number": 100,
+                  "metrics": {
+                    "step": 100,
+                    "train_loss": 0.234,
+                    "train_mean_token_accuracy": 0.891
+                  }
                 }
               }
             }
@@ -10622,12 +12555,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/checkpoints/ftckpt-abc123/copy\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar checkpoint = await ftClient.GetCheckpointAsync(\n    \"ftjob-abc123\", \"ftckpt-abc123\");\n\nConsole.WriteLine(checkpoint.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar checkpoint = await ftClient.GetCheckpointAsync(\n    \"ftjob-abc123\", \"ftckpt-abc123\");\n\nConsole.WriteLine(checkpoint.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst checkpoint = await openai.fineTuning.jobs.checkpoints\n    .retrieve(\"ftjob-abc123\", \"ftckpt-abc123\");\nconsole.log(checkpoint.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst checkpoint = await openai.fineTuning.jobs.checkpoints\n    .retrieve(\"ftjob-abc123\", \"ftckpt-abc123\");\nconsole.log(checkpoint.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar checkpoint = openai.fineTuning().jobs()\n    .checkpoints().retrieve(\"ftjob-abc123\", \"ftckpt-abc123\");\n\nSystem.out.println(checkpoint.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar checkpoint = openai.fineTuning().jobs()\n    .checkpoints().retrieve(\"ftjob-abc123\", \"ftckpt-abc123\");\n\nSystem.out.println(checkpoint.getId());"
           }
         ]
       }
@@ -10695,6 +12658,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListFineTuningJobEventsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "ftevent-abc123",
+                      "object": "fine_tuning.job.event",
+                      "created_at": 1741312436,
+                      "level": "info",
+                      "message": "Training started"
+                    }
+                  ],
+                  "has_more": false
                 }
               }
             }
@@ -10771,12 +12747,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/events\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/events\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/events\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/events\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar events = ftClient.GetJobEvents(\"ftjob-abc123\");\n\nforeach (var evt in events)\n    Console.WriteLine(evt.Message);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nvar events = ftClient.GetJobEvents(\"ftjob-abc123\");\n\nforeach (var evt in events)\n    Console.WriteLine(evt.Message);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst events = await openai.fineTuning.jobs.listEvents(\"ftjob-abc123\");\nfor await (const event of events) {\n    console.log(event.message);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst events = await openai.fineTuning.jobs.listEvents(\"ftjob-abc123\");\nfor await (const event of events) {\n    console.log(event.message);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar events = openai.fineTuning().jobs()\n    .listEvents(\"ftjob-abc123\");\n\nfor (var event : events) {\n    System.out.println(event.getMessage());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar events = openai.fineTuning().jobs()\n    .listEvents(\"ftjob-abc123\");\n\nfor (var event : events) {\n    System.out.println(event.getMessage());\n}"
           }
         ]
       }
@@ -10822,6 +12828,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "status": "paused",
+                  "training_file": "file-abc123def456"
                 }
               }
             }
@@ -10898,12 +12912,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/pause\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/pause\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/pause\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/pause\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.PauseJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.PauseJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.pause(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.pause(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().pause(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().pause(\"ftjob-abc123\");"
           }
         ]
       }
@@ -10949,6 +12993,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.FineTuningJob"
+                },
+                "example": {
+                  "id": "ftjob-abc123def456",
+                  "object": "fine_tuning.job",
+                  "model": "gpt-4o-mini-2024-07-18",
+                  "created_at": 1741312436,
+                  "status": "running",
+                  "training_file": "file-abc123def456"
                 }
               }
             }
@@ -11025,12 +13077,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/resume\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/resume\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/resume\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/fine_tuning/jobs/ftjob-abc123/resume\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.ResumeJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar ftClient = client.OpenAI.GetFineTuningClient();\nawait ftClient.ResumeJobAsync(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.resume(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.fineTuning.jobs.resume(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().resume(\"ftjob-abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.fineTuning().jobs().resume(\"ftjob-abc123\");"
           }
         ]
       }
@@ -11067,6 +13149,29 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListModelsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "gpt-4o",
+                      "object": "model",
+                      "created": 1715367049,
+                      "owned_by": "system"
+                    },
+                    {
+                      "id": "gpt-4o-mini",
+                      "object": "model",
+                      "created": 1721172741,
+                      "owned_by": "system"
+                    },
+                    {
+                      "id": "text-embedding-3-large",
+                      "object": "model",
+                      "created": 1705953180,
+                      "owned_by": "system"
+                    }
+                  ]
                 }
               }
             }
@@ -11133,22 +13238,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nmodels = openai.models.list()\nfor model in models:\n    print(model.id)\n# Output:\n# gpt-4o\n# gpt-4o-mini\n# text-embedding-3-large"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nmodels = openai.models.list()\nfor model in models:\n    print(model.id)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nmodels = openai.models.list()\nfor model in models:\n    print(model.id)\n# Output:\n# gpt-4o\n# gpt-4o-mini\n# text-embedding-3-large"
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nmodels = openai.models.list()\nfor model in models:\n    print(model.id)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/models\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/models\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/models\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/models\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -11169,6 +13274,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst models = await openai.models.list();\nfor await (const model of models) {\n    console.log(model.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar models = openai.models().list();\n\nfor (var model : models) {\n    System.out.println(model.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar models = openai.models().list();\n\nfor (var model : models) {\n    System.out.println(model.getId());\n}"
           }
         ]
       }
@@ -11214,6 +13329,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.Model"
+                },
+                "example": {
+                  "id": "gpt-4o",
+                  "object": "model",
+                  "created": 1715367049,
+                  "owned_by": "system"
                 }
               }
             }
@@ -11290,12 +13411,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/models/gpt-4o\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/models/gpt-4o\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/models/gpt-4o\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/models/gpt-4o\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar model = client.OpenAI.GetOpenAIModelClient()\n    .GetModel(\"gpt-4o\");\n\nConsole.WriteLine($\"{model.Value.Id} {model.Value.OwnedBy}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar model = client.OpenAI.GetOpenAIModelClient()\n    .GetModel(\"gpt-4o\");\n\nConsole.WriteLine($\"{model.Value.Id} {model.Value.OwnedBy}\");"
           },
           {
             "lang": "javascript",
@@ -11306,6 +13437,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst model = await openai.models.retrieve(\"gpt-4o\");\nconsole.log(model.id, model.owned_by);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar model = openai.models().retrieve(\"gpt-4o\");\n\nSystem.out.println(model.getId() + \" \" + model.getOwnedBy());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar model = openai.models().retrieve(\"gpt-4o\");\n\nSystem.out.println(model.getId() + \" \" + model.getOwnedBy());"
           }
         ]
       },
@@ -11349,6 +13490,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteModelResponse"
+                },
+                "example": {
+                  "id": "ft:gpt-4o-mini:my-org:custom-suffix:abc123",
+                  "object": "model",
+                  "deleted": true
                 }
               }
             }
@@ -11425,12 +13571,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/models/ft:gpt-4o:org:suffix:id\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/models/ft:gpt-4o:org:suffix:id\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/models/ft:gpt-4o:org:suffix:id\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/models/ft:gpt-4o:org:suffix:id\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.OpenAI.GetOpenAIModelClient()\n    .DeleteModel(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.OpenAI.GetOpenAIModelClient()\n    .DeleteModel(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.models.delete(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.models.delete(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.models()\n    .delete(\"ft:gpt-4o:your-org:custom-suffix:id\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.models()\n    .delete(\"ft:gpt-4o:your-org:custom-suffix:id\");"
           }
         ]
       }
@@ -11558,12 +13734,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\", \"sdp\": \"YOUR_SDP_OFFER\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\", \"sdp\": \"YOUR_SDP_OFFER\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\", \"sdp\": \"YOUR_SDP_OFFER\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\", \"sdp\": \"YOUR_SDP_OFFER\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar call = await realtimeClient.CreateCallAsync(\n    \"gpt-4o-realtime-preview\", \"YOUR_SDP_OFFER\");\n\nConsole.WriteLine(call.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar call = await realtimeClient.CreateCallAsync(\n    \"gpt-4o-realtime-preview\", \"YOUR_SDP_OFFER\");\n\nConsole.WriteLine(call.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst call = await openai.realtime.calls.create({\n    model: \"gpt-4o-realtime-preview\",\n    sdp: \"YOUR_SDP_OFFER\",\n});\nconsole.log(call.id, call.sdp);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst call = await openai.realtime.calls.create({\n    model: \"gpt-4o-realtime-preview\",\n    sdp: \"YOUR_SDP_OFFER\",\n});\nconsole.log(call.id, call.sdp);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar call = openai.realtime().calls().create(\n    \"gpt-4o-realtime-preview\", \"YOUR_SDP_OFFER\");\n\nSystem.out.println(call.getId() + \" \" + call.getSdp());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar call = openai.realtime().calls().create(\n    \"gpt-4o-realtime-preview\", \"YOUR_SDP_OFFER\");\n\nSystem.out.println(call.getId() + \" \" + call.getSdp());"
           }
         ]
       }
@@ -11595,7 +13801,17 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded."
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "call_abc123",
+                  "object": "realtime.call",
+                  "sdp": "v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\n",
+                  "status": "accepted"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -11680,12 +13896,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/accept\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/accept\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/accept\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/accept\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.AcceptCallAsync(\n    \"call_abc123\", \"gpt-4o-realtime-preview\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.AcceptCallAsync(\n    \"call_abc123\", \"gpt-4o-realtime-preview\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.accept(\"call_abc123\", {\n    model: \"gpt-4o-realtime-preview\",\n});"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.accept(\"call_abc123\", {\n    model: \"gpt-4o-realtime-preview\",\n});"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .accept(\"call_abc123\", \"gpt-4o-realtime-preview\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .accept(\"call_abc123\", \"gpt-4o-realtime-preview\");"
           }
         ]
       }
@@ -11717,7 +13963,16 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded."
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "call_abc123",
+                  "object": "realtime.call",
+                  "status": "ended"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -11791,12 +14046,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/hangup\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/hangup\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/hangup\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/hangup\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.HangupCallAsync(\"call_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.HangupCallAsync(\"call_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.hangup(\"call_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.hangup(\"call_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls().hangup(\"call_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls().hangup(\"call_abc123\");"
           }
         ]
       }
@@ -11828,7 +14113,16 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded."
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "call_abc123",
+                  "object": "realtime.call",
+                  "status": "referred"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -11913,12 +14207,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/refer\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"refer_to\": \"sip:dest@example.com\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/refer\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"refer_to\": \"sip:dest@example.com\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/refer\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"refer_to\": \"sip:dest@example.com\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/refer\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"refer_to\": \"sip:dest@example.com\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.ReferCallAsync(\n    \"call_abc123\", \"sip:destination@example.com\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.ReferCallAsync(\n    \"call_abc123\", \"sip:destination@example.com\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.refer(\"call_abc123\", {\n    refer_to: \"sip:destination@example.com\",\n});"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.refer(\"call_abc123\", {\n    refer_to: \"sip:destination@example.com\",\n});"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .refer(\"call_abc123\", \"sip:destination@example.com\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .refer(\"call_abc123\", \"sip:destination@example.com\");"
           }
         ]
       }
@@ -11950,7 +14274,16 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded."
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "id": "call_abc123",
+                  "object": "realtime.call",
+                  "status": "rejected"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -12035,12 +14368,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/reject\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"reason\": \"busy\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/reject\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"reason\": \"busy\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/reject\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"reason\": \"busy\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/calls/call_abc123/reject\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"reason\": \"busy\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.RejectCallAsync(\n    \"call_abc123\", \"busy\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nawait realtimeClient.RejectCallAsync(\n    \"call_abc123\", \"busy\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.reject(\"call_abc123\", {\n    reason: \"busy\",\n});"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.realtime.calls.reject(\"call_abc123\", {\n    reason: \"busy\",\n});"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .reject(\"call_abc123\", \"busy\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.realtime().calls()\n    .reject(\"call_abc123\", \"busy\");"
           }
         ]
       }
@@ -12077,6 +14440,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RealtimeCreateClientSecretResponse"
+                },
+                "example": {
+                  "id": "sess_abc123def456",
+                  "object": "realtime.session",
+                  "client_secret": {
+                    "value": "ek_abc123def456ghi789",
+                    "expires_at": 1741316036
+                  }
                 }
               }
             }
@@ -12164,12 +14535,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/client_secrets\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/client_secrets\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/client_secrets\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/client_secrets\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar secret = await realtimeClient.CreateClientSecretAsync(\n    \"gpt-4o-realtime-preview\");\n\nConsole.WriteLine(secret.Value.ClientSecret.Value);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar secret = await realtimeClient.CreateClientSecretAsync(\n    \"gpt-4o-realtime-preview\");\n\nConsole.WriteLine(secret.Value.ClientSecret.Value);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst secret = await openai.realtime.clientSecrets.create({\n    model: \"gpt-4o-realtime-preview\",\n});\nconsole.log(secret.client_secret.value);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst secret = await openai.realtime.clientSecrets.create({\n    model: \"gpt-4o-realtime-preview\",\n});\nconsole.log(secret.client_secret.value);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar secret = openai.realtime().clientSecrets()\n    .create(\"gpt-4o-realtime-preview\");\n\nSystem.out.println(secret.getClientSecret().getValue());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar secret = openai.realtime().clientSecrets()\n    .create(\"gpt-4o-realtime-preview\");\n\nSystem.out.println(secret.getClientSecret().getValue());"
           }
         ]
       }
@@ -12206,6 +14607,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RealtimeSessionCreateResponse"
+                },
+                "example": {
+                  "id": "sess_abc123def456",
+                  "object": "realtime.session",
+                  "model": "gpt-4o-realtime-preview",
+                  "modalities": [
+                    "text",
+                    "audio"
+                  ],
+                  "voice": "alloy",
+                  "input_audio_format": "pcm16",
+                  "output_audio_format": "pcm16",
+                  "turn_detection": {
+                    "type": "server_vad"
+                  }
                 }
               }
             }
@@ -12293,12 +14709,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/sessions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/sessions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/sessions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/sessions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-realtime-preview\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar session = await realtimeClient.CreateSessionAsync(\n    \"gpt-4o-realtime-preview\");\n\nConsole.WriteLine(session.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar session = await realtimeClient.CreateSessionAsync(\n    \"gpt-4o-realtime-preview\");\n\nConsole.WriteLine(session.Value.Id);"
           },
           {
             "lang": "javascript",
@@ -12309,6 +14735,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst session = await openai.realtime.sessions.create({\n    model: \"gpt-4o-realtime-preview\",\n});\nconsole.log(session.id, session.client_secret.value);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar session = openai.realtime().sessions()\n    .create(\"gpt-4o-realtime-preview\");\n\nSystem.out.println(session.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar session = openai.realtime().sessions()\n    .create(\"gpt-4o-realtime-preview\");\n\nSystem.out.println(session.getId());"
           }
         ]
       }
@@ -12345,6 +14781,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RealtimeTranscriptionSessionCreateResponse"
+                },
+                "example": {
+                  "id": "sess_trans_abc123",
+                  "object": "realtime.transcription_session",
+                  "model": "gpt-4o-transcribe",
+                  "input_audio_format": "pcm16"
                 }
               }
             }
@@ -12432,12 +14874,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/transcription_sessions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-transcribe\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/transcription_sessions\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-transcribe\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/realtime/transcription_sessions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-transcribe\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/realtime/transcription_sessions\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o-transcribe\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar session = await realtimeClient\n    .CreateTranscriptionSessionAsync(\"gpt-4o-transcribe\");\n\nConsole.WriteLine(session.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar realtimeClient = client.OpenAI.GetRealtimeClient();\nvar session = await realtimeClient\n    .CreateTranscriptionSessionAsync(\"gpt-4o-transcribe\");\n\nConsole.WriteLine(session.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst session = await openai.realtime.transcriptionSessions\n    .create({ model: \"gpt-4o-transcribe\" });\nconsole.log(session.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst session = await openai.realtime.transcriptionSessions\n    .create({ model: \"gpt-4o-transcribe\" });\nconsole.log(session.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar session = openai.realtime().transcriptionSessions()\n    .create(\"gpt-4o-transcribe\");\n\nSystem.out.println(session.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar session = openai.realtime().transcriptionSessions()\n    .create(\"gpt-4o-transcribe\");\n\nSystem.out.println(session.getId());"
           }
         ]
       }
@@ -12758,6 +15230,32 @@
                       "description": "The content filter results from RAI."
                     }
                   }
+                },
+                "example": {
+                  "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+                  "object": "response",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "output": [
+                    {
+                      "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                      "type": "message",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "The capital of France is Paris.",
+                          "annotations": []
+                        }
+                      ]
+                    }
+                  ],
+                  "model": "gpt-4o-2024-11-20",
+                  "usage": {
+                    "input_tokens": 13,
+                    "output_tokens": 8,
+                    "total_tokens": 21
+                  }
                 }
               },
               "text/event-stream": {}
@@ -12835,22 +15333,22 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.create(\n    model=\"gpt-4o\",\n    input=\"What is the capital of France?\",\n)\nprint(response.output_text)\n# Output: \"The capital of France is Paris.\""
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.create(\n    model=\"gpt-4o\",\n    input=\"What is the capital of France?\",\n)\nprint(response.output_text)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.create(\n    model=\"gpt-4o\",\n    input=\"What is the capital of France?\",\n)\nprint(response.output_text)\n# Output: \"The capital of France is Paris.\""
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.create(\n    model=\"gpt-4o\",\n    input=\"What is the capital of France?\",\n)\nprint(response.output_text)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/responses\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"input\": \"What is the capital of France?\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/responses\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"input\": \"What is the capital of France?\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/responses\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"input\": \"What is the capital of France?\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/responses\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\": \"gpt-4o\", \"input\": \"What is the capital of France?\"}'"
           },
           {
             "lang": "csharp",
@@ -12871,6 +15369,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.responses.create({\n    model: \"gpt-4o\",\n    input: \"What is the capital of France?\",\n});\nconsole.log(response.output_text);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.responses()\n    .create(\"gpt-4o\", \"What is the capital of France?\");\n\nSystem.out.println(response.getOutputText());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.responses()\n    .create(\"gpt-4o\", \"What is the capital of France?\");\n\nSystem.out.println(response.getOutputText());"
           }
         ]
       }
@@ -13244,6 +15752,32 @@
                       "description": "The content filter results from RAI."
                     }
                   }
+                },
+                "example": {
+                  "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+                  "object": "response",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "output": [
+                    {
+                      "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                      "type": "message",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "output_text",
+                          "text": "The capital of France is Paris.",
+                          "annotations": []
+                        }
+                      ]
+                    }
+                  ],
+                  "model": "gpt-4o-2024-11-20",
+                  "usage": {
+                    "input_tokens": 13,
+                    "output_tokens": 8,
+                    "total_tokens": 21
+                  }
                 }
               }
             }
@@ -13310,22 +15844,52 @@
           {
             "lang": "python",
             "label": "Entra ID",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.retrieve(\"resp_abc123\")\nprint(response.status, response.output_text)\n# Output: completed The capital of France is Paris."
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.identity import DefaultAzureCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=DefaultAzureCredential(),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.retrieve(\"resp_abc123\")\nprint(response.status, response.output_text)\n"
           },
           {
             "lang": "python",
             "label": "API Key",
-            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.retrieve(\"resp_abc123\")\nprint(response.status, response.output_text)\n# Output: completed The capital of France is Paris."
+            "source": "from azure.ai.projects import AIProjectClient\nfrom azure.core.credentials import AzureKeyCredential\n\nproject = AIProjectClient(\n    endpoint=\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    credential=AzureKeyCredential(\"YOUR_API_KEY\"),\n)\nopenai = project.get_openai_client()\n\nresponse = openai.responses.retrieve(\"resp_abc123\")\nprint(response.status, response.output_text)\n"
           },
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nvar response = await responsesClient\n    .GetResponseAsync(\"resp_abc123\");\n\nConsole.WriteLine(response.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nvar response = await responsesClient\n    .GetResponseAsync(\"resp_abc123\");\n\nConsole.WriteLine(response.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.responses.retrieve(\"resp_abc123\");\nconsole.log(response.status, response.output_text);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst response = await openai.responses.retrieve(\"resp_abc123\");\nconsole.log(response.status, response.output_text);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.responses().retrieve(\"resp_abc123\");\n\nSystem.out.println(response.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar response = openai.responses().retrieve(\"resp_abc123\");\n\nSystem.out.println(response.getStatus());"
           }
         ]
       },
@@ -13390,6 +15954,11 @@
                       ]
                     }
                   }
+                },
+                "example": {
+                  "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+                  "object": "response",
+                  "deleted": true
                 }
               }
             }
@@ -13466,12 +16035,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/responses/resp_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nawait responsesClient.DeleteResponseAsync(\"resp_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nawait responsesClient.DeleteResponseAsync(\"resp_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.responses.delete(\"resp_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.responses.delete(\"resp_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.responses().delete(\"resp_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.responses().delete(\"resp_abc123\");"
           }
         ]
       }
@@ -13800,6 +16399,19 @@
                       "description": "The content filter results from RAI."
                     }
                   }
+                },
+                "example": {
+                  "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+                  "object": "response",
+                  "created_at": 1741312436,
+                  "status": "cancelled",
+                  "output": [],
+                  "model": "gpt-4o-2024-11-20",
+                  "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0
+                  }
                 }
               }
             }
@@ -13876,12 +16488,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/responses/resp_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/responses/resp_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/responses/resp_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/responses/resp_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nawait responsesClient.CancelResponseAsync(\"resp_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nawait responsesClient.CancelResponseAsync(\"resp_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.responses.cancel(\"resp_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.responses.cancel(\"resp_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.responses().cancel(\"resp_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.responses().cancel(\"resp_abc123\");"
           }
         ]
       }
@@ -13972,6 +16614,25 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ResponseItemList"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                      "type": "message",
+                      "role": "user",
+                      "content": [
+                        {
+                          "type": "input_text",
+                          "text": "What is the capital of France?"
+                        }
+                      ]
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                  "last_id": "msg_67cb71b5c1988190b5fba3b237c63581"
                 }
               }
             }
@@ -14048,12 +16709,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/responses/resp_abc123/input_items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/responses/resp_abc123/input_items\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/responses/resp_abc123/input_items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/responses/resp_abc123/input_items\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nvar items = responsesClient.GetResponseInputItems(\"resp_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine(item.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel(\"gpt-4o\");\n\nvar items = responsesClient.GetResponseInputItems(\"resp_abc123\");\n\nforeach (var item in items)\n    Console.WriteLine(item.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.responses.inputItems.list(\"resp_abc123\");\nfor await (const item of items) {\n    console.log(item.type, item.id);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst items = await openai.responses.inputItems.list(\"resp_abc123\");\nfor await (const item of items) {\n    console.log(item.type, item.id);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.responses().inputItems()\n    .list(\"resp_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getType() + \" \" + item.getId());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar items = openai.responses().inputItems()\n    .list(\"resp_abc123\");\n\nfor (var item : items) {\n    System.out.println(item.getType() + \" \" + item.getId());\n}"
           }
         ]
       }
@@ -14089,6 +16780,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ThreadObject"
+                },
+                "example": {
+                  "id": "thread_abc123def456",
+                  "object": "thread",
+                  "created_at": 1741312436,
+                  "metadata": {}
                 }
               }
             }
@@ -14175,12 +16872,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar thread = await threadClient.CreateThreadAsync();\n\nConsole.WriteLine(thread.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar thread = await threadClient.CreateThreadAsync();\n\nConsole.WriteLine(thread.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.create();\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.create();\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar thread = openai.beta().threads().create();\n\nSystem.out.println(thread.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar thread = openai.beta().threads().create();\n\nSystem.out.println(thread.getId());"
           }
         ]
       }
@@ -14207,6 +16934,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_xyz789ghi012",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "queued",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -14293,12 +17029,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\", \"thread\": {\"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\", \"thread\": {\"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\", \"thread\": {\"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\", \"thread\": {\"messages\": [{\"role\": \"user\", \"content\": \"Hello\"}]}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.CreateThreadAndRunAsync(\n    \"asst_abc123\",\n    new ThreadCreationOptions\n    {\n        InitialMessages = { new ThreadInitializationMessage(\n            MessageRole.User, new[] { MessageContent.FromText(\"Hello\") }) },\n    });\n\nConsole.WriteLine(run.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.CreateThreadAndRunAsync(\n    \"asst_abc123\",\n    new ThreadCreationOptions\n    {\n        InitialMessages = { new ThreadInitializationMessage(\n            MessageRole.User, new[] { MessageContent.FromText(\"Hello\") }) },\n    });\n\nConsole.WriteLine(run.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.createAndRun({\n    assistant_id: \"asst_abc123\",\n    thread: { messages: [{ role: \"user\", content: \"Hello\" }] },\n});\nconsole.log(run.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.createAndRun({\n    assistant_id: \"asst_abc123\",\n    thread: { messages: [{ role: \"user\", content: \"Hello\" }] },\n});\nconsole.log(run.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().createAndRun(\n    \"asst_abc123\",\n    Map.of(\"messages\", List.of(\n        Map.of(\"role\", \"user\", \"content\", \"Hello\"))));\n\nSystem.out.println(run.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().createAndRun(\n    \"asst_abc123\",\n    Map.of(\"messages\", List.of(\n        Map.of(\"role\", \"user\", \"content\", \"Hello\"))));\n\nSystem.out.println(run.getId());"
           }
         ]
       }
@@ -14342,6 +17108,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteThreadResponse"
+                },
+                "example": {
+                  "id": "thread_abc123def456",
+                  "object": "thread",
+                  "deleted": true
                 }
               }
             }
@@ -14418,12 +17189,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.DeleteThreadAsync(\"thread_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.DeleteThreadAsync(\"thread_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.delete(\"thread_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.delete(\"thread_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().delete(\"thread_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().delete(\"thread_abc123\");"
           }
         ]
       },
@@ -14465,6 +17266,12 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ThreadObject"
+                },
+                "example": {
+                  "id": "thread_abc123def456",
+                  "object": "thread",
+                  "created_at": 1741312436,
+                  "metadata": {}
                 }
               }
             }
@@ -14541,12 +17348,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar thread = await threadClient.GetThreadAsync(\"thread_abc123\");\n\nConsole.WriteLine(thread.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar thread = await threadClient.GetThreadAsync(\"thread_abc123\");\n\nConsole.WriteLine(thread.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.retrieve(\"thread_abc123\");\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.retrieve(\"thread_abc123\");\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar thread = openai.beta().threads()\n    .retrieve(\"thread_abc123\");\n\nSystem.out.println(thread.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar thread = openai.beta().threads()\n    .retrieve(\"thread_abc123\");\n\nSystem.out.println(thread.getId());"
           }
         ]
       },
@@ -14588,6 +17425,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ThreadObject"
+                },
+                "example": {
+                  "id": "thread_abc123def456",
+                  "object": "thread",
+                  "created_at": 1741312436,
+                  "metadata": {
+                    "project": "my-project"
+                  }
                 }
               }
             }
@@ -14674,12 +17519,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"science\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"science\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"science\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"topic\": \"science\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyThreadAsync(\"thread_abc123\",\n    new ThreadModificationOptions\n    {\n        Metadata = { [\"topic\"] = \"science\" },\n    });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyThreadAsync(\"thread_abc123\",\n    new ThreadModificationOptions\n    {\n        Metadata = { [\"topic\"] = \"science\" },\n    });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.update(\"thread_abc123\", {\n    metadata: { topic: \"science\" },\n});\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst thread = await openai.beta.threads.update(\"thread_abc123\", {\n    metadata: { topic: \"science\" },\n});\nconsole.log(thread.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().update(\"thread_abc123\",\n    Map.of(\"metadata\", Map.of(\"topic\", \"science\")));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().update(\"thread_abc123\",\n    Map.of(\"metadata\", Map.of(\"topic\", \"science\")));"
           }
         ]
       }
@@ -14774,6 +17649,31 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListMessagesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "msg_abc123def456",
+                      "object": "thread.message",
+                      "created_at": 1741312436,
+                      "thread_id": "thread_abc123def456",
+                      "role": "assistant",
+                      "content": [
+                        {
+                          "type": "text",
+                          "text": {
+                            "value": "Hello! How can I help you?",
+                            "annotations": []
+                          }
+                        }
+                      ],
+                      "status": "completed"
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "msg_abc123def456",
+                  "last_id": "msg_abc123def456"
                 }
               }
             }
@@ -14850,12 +17750,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar messages = threadClient.GetMessages(\"thread_abc123\");\n\nforeach (var msg in messages)\n    Console.WriteLine($\"{msg.Role} {msg.Content[0].Text}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar messages = threadClient.GetMessages(\"thread_abc123\");\n\nforeach (var msg in messages)\n    Console.WriteLine($\"{msg.Role} {msg.Content[0].Text}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst messages = await openai.beta.threads.messages.list(\"thread_abc123\");\nfor await (const msg of messages) {\n    console.log(msg.role, msg.content[0].text.value);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst messages = await openai.beta.threads.messages.list(\"thread_abc123\");\nfor await (const msg of messages) {\n    console.log(msg.role, msg.content[0].text.value);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar messages = openai.beta().threads().messages()\n    .list(\"thread_abc123\");\n\nfor (var msg : messages) {\n    System.out.println(msg.getRole() + \" \"\n        + msg.getContent().get(0).getText().getValue());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar messages = openai.beta().threads().messages()\n    .list(\"thread_abc123\");\n\nfor (var msg : messages) {\n    System.out.println(msg.getRole() + \" \"\n        + msg.getContent().get(0).getText().getValue());\n}"
           }
         ]
       },
@@ -14897,6 +17827,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.MessageObject"
+                },
+                "example": {
+                  "id": "msg_abc123def456",
+                  "object": "thread.message",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "value": "What is the weather today?",
+                        "annotations": []
+                      }
+                    }
+                  ],
+                  "status": "completed"
                 }
               }
             }
@@ -14983,12 +17930,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"role\": \"user\", \"content\": \"What is the capital of France?\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"role\": \"user\", \"content\": \"What is the capital of France?\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"role\": \"user\", \"content\": \"What is the capital of France?\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"role\": \"user\", \"content\": \"What is the capital of France?\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar message = await threadClient.CreateMessageAsync(\n    \"thread_abc123\", MessageRole.User,\n    new[] { MessageContent.FromText(\"What is the capital of France?\") });\n\nConsole.WriteLine(message.Value.Id);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar message = await threadClient.CreateMessageAsync(\n    \"thread_abc123\", MessageRole.User,\n    new[] { MessageContent.FromText(\"What is the capital of France?\") });\n\nConsole.WriteLine(message.Value.Id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst message = await openai.beta.threads.messages.create(\n    \"thread_abc123\",\n    { role: \"user\", content: \"What is the capital of France?\" }\n);\nconsole.log(message.id);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst message = await openai.beta.threads.messages.create(\n    \"thread_abc123\",\n    { role: \"user\", content: \"What is the capital of France?\" }\n);\nconsole.log(message.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar message = openai.beta().threads().messages()\n    .create(\"thread_abc123\", \"user\",\n        \"What is the capital of France?\");\n\nSystem.out.println(message.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar message = openai.beta().threads().messages()\n    .create(\"thread_abc123\", \"user\",\n        \"What is the capital of France?\");\n\nSystem.out.println(message.getId());"
           }
         ]
       }
@@ -15040,6 +18017,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteMessageResponse"
+                },
+                "example": {
+                  "id": "msg_abc123def456",
+                  "object": "thread.message",
+                  "deleted": true
                 }
               }
             }
@@ -15116,12 +18098,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.DeleteMessageAsync(\n    \"thread_abc123\", \"msg_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.DeleteMessageAsync(\n    \"thread_abc123\", \"msg_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.messages.delete(\n    \"thread_abc123\", \"msg_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.messages.delete(\n    \"thread_abc123\", \"msg_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().messages()\n    .delete(\"thread_abc123\", \"msg_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().messages()\n    .delete(\"thread_abc123\", \"msg_abc123\");"
           }
         ]
       },
@@ -15171,6 +18183,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.MessageObject"
+                },
+                "example": {
+                  "id": "msg_abc123def456",
+                  "object": "thread.message",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "value": "What is the weather today?",
+                        "annotations": []
+                      }
+                    }
+                  ],
+                  "status": "completed"
                 }
               }
             }
@@ -15247,12 +18276,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar message = await threadClient.GetMessageAsync(\n    \"thread_abc123\", \"msg_abc123\");\n\nConsole.WriteLine(message.Value.Content[0].Text);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar message = await threadClient.GetMessageAsync(\n    \"thread_abc123\", \"msg_abc123\");\n\nConsole.WriteLine(message.Value.Content[0].Text);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst message = await openai.beta.threads.messages.retrieve(\n    \"thread_abc123\", \"msg_abc123\"\n);\nconsole.log(message.content[0].text.value);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst message = await openai.beta.threads.messages.retrieve(\n    \"thread_abc123\", \"msg_abc123\"\n);\nconsole.log(message.content[0].text.value);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar message = openai.beta().threads().messages()\n    .retrieve(\"thread_abc123\", \"msg_abc123\");\n\nSystem.out.println(\n    message.getContent().get(0).getText().getValue());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar message = openai.beta().threads().messages()\n    .retrieve(\"thread_abc123\", \"msg_abc123\");\n\nSystem.out.println(\n    message.getContent().get(0).getText().getValue());"
           }
         ]
       },
@@ -15302,6 +18361,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.MessageObject"
+                },
+                "example": {
+                  "id": "msg_abc123def456",
+                  "object": "thread.message",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "role": "user",
+                  "content": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "value": "What is the weather today?",
+                        "annotations": []
+                      }
+                    }
+                  ],
+                  "status": "completed",
+                  "metadata": {
+                    "priority": "high"
+                  }
                 }
               }
             }
@@ -15388,12 +18467,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"reviewed\": \"true\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"reviewed\": \"true\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"reviewed\": \"true\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/messages/msg_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"reviewed\": \"true\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyMessageAsync(\n    \"thread_abc123\", \"msg_abc123\",\n    new MessageModificationOptions\n    {\n        Metadata = { [\"reviewed\"] = \"true\" },\n    });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyMessageAsync(\n    \"thread_abc123\", \"msg_abc123\",\n    new MessageModificationOptions\n    {\n        Metadata = { [\"reviewed\"] = \"true\" },\n    });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.messages.update(\n    \"thread_abc123\", \"msg_abc123\",\n    { metadata: { reviewed: \"true\" } }\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.messages.update(\n    \"thread_abc123\", \"msg_abc123\",\n    { metadata: { reviewed: \"true\" } }\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().messages()\n    .update(\"thread_abc123\", \"msg_abc123\",\n        Map.of(\"metadata\", Map.of(\"reviewed\", \"true\")));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().messages()\n    .update(\"thread_abc123\", \"msg_abc123\",\n        Map.of(\"metadata\", Map.of(\"reviewed\", \"true\")));"
           }
         ]
       }
@@ -15428,6 +18537,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "queued",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -15514,12 +18632,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"assistant_id\": \"asst_abc123\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.CreateRunAsync(\n    \"thread_abc123\", \"asst_abc123\");\n\nConsole.WriteLine($\"{run.Value.Id} {run.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.CreateRunAsync(\n    \"thread_abc123\", \"asst_abc123\");\n\nConsole.WriteLine($\"{run.Value.Id} {run.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.create(\"thread_abc123\", {\n    assistant_id: \"asst_abc123\",\n});\nconsole.log(run.id, run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.create(\"thread_abc123\", {\n    assistant_id: \"asst_abc123\",\n});\nconsole.log(run.id, run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .create(\"thread_abc123\", \"asst_abc123\");\n\nSystem.out.println(run.getId() + \" \" + run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .create(\"thread_abc123\", \"asst_abc123\");\n\nSystem.out.println(run.getId() + \" \" + run.getStatus());"
           }
         ]
       },
@@ -15594,6 +18742,23 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListRunsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "run_abc123def456",
+                      "object": "thread.run",
+                      "created_at": 1741312436,
+                      "thread_id": "thread_abc123def456",
+                      "assistant_id": "asst_abc123def456",
+                      "status": "completed",
+                      "model": "gpt-4o"
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "run_abc123def456",
+                  "last_id": "run_abc123def456"
                 }
               }
             }
@@ -15670,12 +18835,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar runs = threadClient.GetRuns(\"thread_abc123\");\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Id} {run.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar runs = threadClient.GetRuns(\"thread_abc123\");\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Id} {run.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst runs = await openai.beta.threads.runs.list(\"thread_abc123\");\nfor await (const run of runs) {\n    console.log(run.id, run.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst runs = await openai.beta.threads.runs.list(\"thread_abc123\");\nfor await (const run of runs) {\n    console.log(run.id, run.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar runs = openai.beta().threads().runs()\n    .list(\"thread_abc123\");\n\nfor (var run : runs) {\n    System.out.println(run.getId() + \" \" + run.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar runs = openai.beta().threads().runs()\n    .list(\"thread_abc123\");\n\nfor (var run : runs) {\n    System.out.println(run.getId() + \" \" + run.getStatus());\n}"
           }
         ]
       }
@@ -15718,6 +18913,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "completed",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -15794,12 +18998,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.GetRunAsync(\n    \"thread_abc123\", \"run_abc123\");\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.GetRunAsync(\n    \"thread_abc123\", \"run_abc123\");\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.retrieve(\n    \"thread_abc123\", \"run_abc123\"\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.retrieve(\n    \"thread_abc123\", \"run_abc123\"\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .retrieve(\"thread_abc123\", \"run_abc123\");\n\nSystem.out.println(run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .retrieve(\"thread_abc123\", \"run_abc123\");\n\nSystem.out.println(run.getStatus());"
           }
         ]
       },
@@ -15840,6 +19074,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "completed",
+                  "model": "gpt-4o",
+                  "metadata": {
+                    "run_type": "evaluation"
+                  }
                 }
               }
             }
@@ -15926,12 +19172,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"priority\": \"high\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"priority\": \"high\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"priority\": \"high\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"metadata\": {\"priority\": \"high\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyRunAsync(\n    \"thread_abc123\", \"run_abc123\",\n    new RunModificationOptions\n    {\n        Metadata = { [\"priority\"] = \"high\" },\n    });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.ModifyRunAsync(\n    \"thread_abc123\", \"run_abc123\",\n    new RunModificationOptions\n    {\n        Metadata = { [\"priority\"] = \"high\" },\n    });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.runs.update(\n    \"thread_abc123\", \"run_abc123\",\n    { metadata: { priority: \"high\" } }\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.runs.update(\n    \"thread_abc123\", \"run_abc123\",\n    { metadata: { priority: \"high\" } }\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().runs()\n    .update(\"thread_abc123\", \"run_abc123\",\n        Map.of(\"metadata\", Map.of(\"priority\", \"high\")));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().runs()\n    .update(\"thread_abc123\", \"run_abc123\",\n        Map.of(\"metadata\", Map.of(\"priority\", \"high\")));"
           }
         ]
       }
@@ -15974,6 +19250,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "cancelling",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -16050,12 +19335,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.CancelRunAsync(\n    \"thread_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nawait threadClient.CancelRunAsync(\n    \"thread_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.runs.cancel(\n    \"thread_abc123\", \"run_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.beta.threads.runs.cancel(\n    \"thread_abc123\", \"run_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().runs()\n    .cancel(\"thread_abc123\", \"run_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.beta().threads().runs()\n    .cancel(\"thread_abc123\", \"run_abc123\");"
           }
         ]
       }
@@ -16140,6 +19455,30 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListRunStepsResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "step_abc123def456",
+                      "object": "thread.run.step",
+                      "created_at": 1741312436,
+                      "run_id": "run_abc123def456",
+                      "assistant_id": "asst_abc123def456",
+                      "thread_id": "thread_abc123def456",
+                      "type": "message_creation",
+                      "status": "completed",
+                      "step_details": {
+                        "type": "message_creation",
+                        "message_creation": {
+                          "message_id": "msg_abc123def456"
+                        }
+                      }
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "step_abc123def456",
+                  "last_id": "step_abc123def456"
                 }
               }
             }
@@ -16216,12 +19555,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar steps = threadClient.GetRunSteps(\n    \"thread_abc123\", \"run_abc123\");\n\nforeach (var step in steps)\n    Console.WriteLine($\"{step.Id} {step.Type}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar steps = threadClient.GetRunSteps(\n    \"thread_abc123\", \"run_abc123\");\n\nforeach (var step in steps)\n    Console.WriteLine($\"{step.Id} {step.Type}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst steps = await openai.beta.threads.runs.steps.list(\n    \"thread_abc123\", \"run_abc123\"\n);\nfor await (const step of steps) {\n    console.log(step.id, step.type);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst steps = await openai.beta.threads.runs.steps.list(\n    \"thread_abc123\", \"run_abc123\"\n);\nfor await (const step of steps) {\n    console.log(step.id, step.type);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar steps = openai.beta().threads().runs().steps()\n    .list(\"thread_abc123\", \"run_abc123\");\n\nfor (var step : steps) {\n    System.out.println(step.getId() + \" \" + step.getType());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar steps = openai.beta().threads().runs().steps()\n    .list(\"thread_abc123\", \"run_abc123\");\n\nfor (var step : steps) {\n    System.out.println(step.getId() + \" \" + step.getType());\n}"
           }
         ]
       }
@@ -16272,6 +19641,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunStepObject"
+                },
+                "example": {
+                  "id": "step_abc123def456",
+                  "object": "thread.run.step",
+                  "created_at": 1741312436,
+                  "run_id": "run_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "thread_id": "thread_abc123def456",
+                  "type": "message_creation",
+                  "status": "completed",
+                  "step_details": {
+                    "type": "message_creation",
+                    "message_creation": {
+                      "message_id": "msg_abc123def456"
+                    }
+                  }
                 }
               }
             }
@@ -16348,12 +19733,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/steps/step_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar step = await threadClient.GetRunStepAsync(\n    \"thread_abc123\", \"run_abc123\", \"step_abc123\");\n\nConsole.WriteLine($\"{step.Value.Type} {step.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar step = await threadClient.GetRunStepAsync(\n    \"thread_abc123\", \"run_abc123\", \"step_abc123\");\n\nConsole.WriteLine($\"{step.Value.Type} {step.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst step = await openai.beta.threads.runs.steps.retrieve(\n    \"thread_abc123\", \"run_abc123\", \"step_abc123\"\n);\nconsole.log(step.type, step.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst step = await openai.beta.threads.runs.steps.retrieve(\n    \"thread_abc123\", \"run_abc123\", \"step_abc123\"\n);\nconsole.log(step.type, step.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar step = openai.beta().threads().runs().steps()\n    .retrieve(\"thread_abc123\", \"run_abc123\",\n        \"step_abc123\");\n\nSystem.out.println(step.getType() + \" \" + step.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar step = openai.beta().threads().runs().steps()\n    .retrieve(\"thread_abc123\", \"run_abc123\",\n        \"step_abc123\");\n\nSystem.out.println(step.getType() + \" \" + step.getStatus());"
           }
         ]
       }
@@ -16396,6 +19811,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.RunObject"
+                },
+                "example": {
+                  "id": "run_abc123def456",
+                  "object": "thread.run",
+                  "created_at": 1741312436,
+                  "thread_id": "thread_abc123def456",
+                  "assistant_id": "asst_abc123def456",
+                  "status": "queued",
+                  "model": "gpt-4o"
                 }
               }
             }
@@ -16482,12 +19906,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"tool_outputs\": [{\"tool_call_id\": \"call_abc123\", \"output\": \"result\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"tool_outputs\": [{\"tool_call_id\": \"call_abc123\", \"output\": \"result\"}]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"tool_outputs\": [{\"tool_call_id\": \"call_abc123\", \"output\": \"result\"}]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/threads/thread_abc123/runs/run_abc123/submit_tool_outputs\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"tool_outputs\": [{\"tool_call_id\": \"call_abc123\", \"output\": \"result\"}]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.SubmitToolOutputsToRunAsync(\n    \"thread_abc123\", \"run_abc123\",\n    new[] { new ToolOutput(\"call_abc123\", \"result\") });\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar threadClient = client.OpenAI.GetAssistantClient();\nvar run = await threadClient.SubmitToolOutputsToRunAsync(\n    \"thread_abc123\", \"run_abc123\",\n    new[] { new ToolOutput(\"call_abc123\", \"result\") });\n\nConsole.WriteLine(run.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.submitToolOutputs(\n    \"thread_abc123\", \"run_abc123\",\n    { tool_outputs: [{ tool_call_id: \"call_abc123\", output: \"result\" }] }\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst run = await openai.beta.threads.runs.submitToolOutputs(\n    \"thread_abc123\", \"run_abc123\",\n    { tool_outputs: [{ tool_call_id: \"call_abc123\", output: \"result\" }] }\n);\nconsole.log(run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .submitToolOutputs(\"thread_abc123\", \"run_abc123\",\n        List.of(Map.of(\"tool_call_id\", \"call_abc123\",\n            \"output\", \"result\")));\n\nSystem.out.println(run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar run = openai.beta().threads().runs()\n    .submitToolOutputs(\"thread_abc123\", \"run_abc123\",\n        List.of(Map.of(\"tool_call_id\", \"call_abc123\",\n            \"output\", \"result\")));\n\nSystem.out.println(run.getStatus());"
           }
         ]
       }
@@ -16570,6 +20024,29 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListVectorStoresResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "vs_abc123def456",
+                      "object": "vector_store",
+                      "name": "Product Knowledge Base",
+                      "created_at": 1741312436,
+                      "status": "completed",
+                      "usage_bytes": 123456,
+                      "file_counts": {
+                        "in_progress": 0,
+                        "completed": 3,
+                        "failed": 0,
+                        "cancelled": 0,
+                        "total": 3
+                      }
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "vs_abc123def456",
+                  "last_id": "vs_abc123def456"
                 }
               }
             }
@@ -16646,12 +20123,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar stores = vsClient.GetVectorStores();\n\nforeach (var store in stores)\n    Console.WriteLine($\"{store.Id} {store.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar stores = vsClient.GetVectorStores();\n\nforeach (var store in stores)\n    Console.WriteLine($\"{store.Id} {store.Name}\");"
           },
           {
             "lang": "javascript",
@@ -16662,6 +20149,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst stores = await openai.vectorStores.list();\nfor await (const store of stores) {\n    console.log(store.id, store.name);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar stores = openai.vectorStores().list();\n\nfor (var store : stores) {\n    System.out.println(store.getId() + \" \" + store.getName());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar stores = openai.vectorStores().list();\n\nfor (var store : stores) {\n    System.out.println(store.getId() + \" \" + store.getName());\n}"
           }
         ]
       },
@@ -16696,6 +20193,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreObject"
+                },
+                "example": {
+                  "id": "vs_abc123def456",
+                  "object": "vector_store",
+                  "name": "Product Knowledge Base",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 0,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 0,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 0
+                  }
                 }
               }
             }
@@ -16782,12 +20294,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-vector-store\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-vector-store\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-vector-store\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"my-vector-store\"}'"
           },
           {
             "lang": "csharp",
@@ -16808,6 +20320,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.create({\n    name: \"my-vector-store\",\n});\nconsole.log(store.id);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar store = openai.vectorStores()\n    .create(\"my-vector-store\");\n\nSystem.out.println(store.getId());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar store = openai.vectorStores()\n    .create(\"my-vector-store\");\n\nSystem.out.println(store.getId());"
           }
         ]
       }
@@ -16853,6 +20375,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreObject"
+                },
+                "example": {
+                  "id": "vs_abc123def456",
+                  "object": "vector_store",
+                  "name": "Product Knowledge Base",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 123456,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -16929,12 +20466,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar store = await vsClient.GetVectorStoreAsync(\"vs_abc123\");\n\nConsole.WriteLine($\"{store.Value.Name}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar store = await vsClient.GetVectorStoreAsync(\"vs_abc123\");\n\nConsole.WriteLine($\"{store.Value.Name}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.retrieve(\"vs_abc123\");\nconsole.log(store.name, store.file_counts);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.retrieve(\"vs_abc123\");\nconsole.log(store.name, store.file_counts);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar store = openai.vectorStores()\n    .retrieve(\"vs_abc123\");\n\nSystem.out.println(store.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar store = openai.vectorStores()\n    .retrieve(\"vs_abc123\");\n\nSystem.out.println(store.getName());"
           }
         ]
       },
@@ -16978,6 +20545,21 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreObject"
+                },
+                "example": {
+                  "id": "vs_abc123def456",
+                  "object": "vector_store",
+                  "name": "Updated Knowledge Base",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 123456,
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -17064,12 +20646,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"name\": \"updated-name\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.ModifyVectorStoreAsync(\"vs_abc123\",\n    new VectorStoreModificationOptions { Name = \"updated-name\" });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.ModifyVectorStoreAsync(\"vs_abc123\",\n    new VectorStoreModificationOptions { Name = \"updated-name\" });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.update(\"vs_abc123\", {\n    name: \"updated-name\",\n});\nconsole.log(store.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst store = await openai.vectorStores.update(\"vs_abc123\", {\n    name: \"updated-name\",\n});\nconsole.log(store.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().update(\"vs_abc123\",\n    Map.of(\"name\", \"updated-name\"));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().update(\"vs_abc123\",\n    Map.of(\"name\", \"updated-name\"));"
           }
         ]
       },
@@ -17113,6 +20725,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteVectorStoreResponse"
+                },
+                "example": {
+                  "id": "vs_abc123def456",
+                  "object": "vector_store",
+                  "deleted": true
                 }
               }
             }
@@ -17189,12 +20806,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.DeleteVectorStoreAsync(\"vs_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.DeleteVectorStoreAsync(\"vs_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.delete(\"vs_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.delete(\"vs_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().delete(\"vs_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().delete(\"vs_abc123\");"
           }
         ]
       }
@@ -17240,6 +20887,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileBatchObject"
+                },
+                "example": {
+                  "id": "vsfb_abc123def456",
+                  "object": "vector_store.file_batch",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "in_progress",
+                  "file_counts": {
+                    "in_progress": 3,
+                    "completed": 0,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -17326,12 +20987,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_ids\": [\"file_abc123\", \"file_def456\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_ids\": [\"file_abc123\", \"file_def456\"]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_ids\": [\"file_abc123\", \"file_def456\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_ids\": [\"file_abc123\", \"file_def456\"]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar batch = await vsClient.CreateBatchFileJobAsync(\n    \"vs_abc123\",\n    new[] { \"file_abc123\", \"file_def456\" });\n\nConsole.WriteLine($\"{batch.Value.BatchId} {batch.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar batch = await vsClient.CreateBatchFileJobAsync(\n    \"vs_abc123\",\n    new[] { \"file_abc123\", \"file_def456\" });\n\nConsole.WriteLine($\"{batch.Value.BatchId} {batch.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.vectorStores.fileBatches.create(\n    \"vs_abc123\",\n    { file_ids: [\"file_abc123\", \"file_def456\"] }\n);\nconsole.log(batch.id, batch.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.vectorStores.fileBatches.create(\n    \"vs_abc123\",\n    { file_ids: [\"file_abc123\", \"file_def456\"] }\n);\nconsole.log(batch.id, batch.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.vectorStores().fileBatches()\n    .create(\"vs_abc123\",\n        List.of(\"file_abc123\", \"file_def456\"));\n\nSystem.out.println(batch.getId() + \" \" + batch.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.vectorStores().fileBatches()\n    .create(\"vs_abc123\",\n        List.of(\"file_abc123\", \"file_def456\"));\n\nSystem.out.println(batch.getId() + \" \" + batch.getStatus());"
           }
         ]
       }
@@ -17386,6 +21077,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileBatchObject"
+                },
+                "example": {
+                  "id": "vsfb_abc123def456",
+                  "object": "vector_store.file_batch",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "file_counts": {
+                    "in_progress": 0,
+                    "completed": 3,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -17462,12 +21167,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar batch = await vsClient.GetBatchFileJobAsync(\n    \"vs_abc123\", \"vsfb_abc123\");\n\nConsole.WriteLine(batch.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar batch = await vsClient.GetBatchFileJobAsync(\n    \"vs_abc123\", \"vsfb_abc123\");\n\nConsole.WriteLine(batch.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.vectorStores.fileBatches.retrieve(\n    \"vs_abc123\", \"vsfb_abc123\"\n);\nconsole.log(batch.status, batch.file_counts);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst batch = await openai.vectorStores.fileBatches.retrieve(\n    \"vs_abc123\", \"vsfb_abc123\"\n);\nconsole.log(batch.status, batch.file_counts);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.vectorStores().fileBatches()\n    .retrieve(\"vs_abc123\", \"vsfb_abc123\");\n\nSystem.out.println(batch.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar batch = openai.vectorStores().fileBatches()\n    .retrieve(\"vs_abc123\", \"vsfb_abc123\");\n\nSystem.out.println(batch.getStatus());"
           }
         ]
       }
@@ -17522,6 +21257,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileBatchObject"
+                },
+                "example": {
+                  "id": "vsfb_abc123def456",
+                  "object": "vector_store.file_batch",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "cancelling",
+                  "file_counts": {
+                    "in_progress": 1,
+                    "completed": 2,
+                    "failed": 0,
+                    "cancelled": 0,
+                    "total": 3
+                  }
                 }
               }
             }
@@ -17598,12 +21347,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.CancelBatchFileJobAsync(\n    \"vs_abc123\", \"vsfb_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.CancelBatchFileJobAsync(\n    \"vs_abc123\", \"vsfb_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.fileBatches.cancel(\n    \"vs_abc123\", \"vsfb_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.fileBatches.cancel(\n    \"vs_abc123\", \"vsfb_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().fileBatches()\n    .cancel(\"vs_abc123\", \"vsfb_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().fileBatches()\n    .cancel(\"vs_abc123\", \"vsfb_abc123\");"
           }
         ]
       }
@@ -17720,6 +21499,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListVectorStoreFilesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "file-vs-abc123",
+                      "object": "vector_store.file",
+                      "vector_store_id": "vs_abc123def456",
+                      "created_at": 1741312436,
+                      "status": "completed",
+                      "usage_bytes": 12345
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "file-vs-abc123",
+                  "last_id": "file-vs-abc123"
                 }
               }
             }
@@ -17796,12 +21591,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/file_batches/vsfb_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar files = vsClient.GetFileAssociations(\n    \"vs_abc123\", \"vsfb_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar files = vsClient.GetFileAssociations(\n    \"vs_abc123\", \"vsfb_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.vectorStores.fileBatches.listFiles(\n    \"vs_abc123\", \"vsfb_abc123\"\n);\nfor await (const f of files) {\n    console.log(f.id, f.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.vectorStores.fileBatches.listFiles(\n    \"vs_abc123\", \"vsfb_abc123\"\n);\nfor await (const f of files) {\n    console.log(f.id, f.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.vectorStores().fileBatches()\n    .listFiles(\"vs_abc123\", \"vsfb_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.vectorStores().fileBatches()\n    .listFiles(\"vs_abc123\", \"vsfb_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getStatus());\n}"
           }
         ]
       }
@@ -17909,6 +21734,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.ListVectorStoreFilesResponse"
+                },
+                "example": {
+                  "object": "list",
+                  "data": [
+                    {
+                      "id": "file-vs-abc123",
+                      "object": "vector_store.file",
+                      "vector_store_id": "vs_abc123def456",
+                      "created_at": 1741312436,
+                      "status": "completed",
+                      "usage_bytes": 12345
+                    }
+                  ],
+                  "has_more": false,
+                  "first_id": "file-vs-abc123",
+                  "last_id": "file-vs-abc123"
                 }
               }
             }
@@ -17985,12 +21826,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar files = vsClient.GetVectorStoreFiles(\"vs_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar files = vsClient.GetVectorStoreFiles(\"vs_abc123\");\n\nforeach (var f in files)\n    Console.WriteLine($\"{f.Id} {f.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.vectorStores.files.list(\"vs_abc123\");\nfor await (const f of files) {\n    console.log(f.id, f.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst files = await openai.vectorStores.files.list(\"vs_abc123\");\nfor await (const f of files) {\n    console.log(f.id, f.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.vectorStores().files()\n    .list(\"vs_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar files = openai.vectorStores().files()\n    .list(\"vs_abc123\");\n\nfor (var f : files) {\n    System.out.println(f.getId() + \" \" + f.getStatus());\n}"
           }
         ]
       },
@@ -18034,6 +21905,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileObject"
+                },
+                "example": {
+                  "id": "file-vs-abc123",
+                  "object": "vector_store.file",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "in_progress",
+                  "usage_bytes": 0
                 }
               }
             }
@@ -18120,12 +21999,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_id\": \"file_abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_id\": \"file_abc123\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_id\": \"file_abc123\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"file_id\": \"file_abc123\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar file = await vsClient.AddFileToVectorStoreAsync(\n    \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine($\"{file.Value.Id} {file.Value.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar file = await vsClient.AddFileToVectorStoreAsync(\n    \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine($\"{file.Value.Id} {file.Value.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.vectorStores.files.create(\"vs_abc123\", {\n    file_id: \"file_abc123\",\n});\nconsole.log(file.id, file.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.vectorStores.files.create(\"vs_abc123\", {\n    file_id: \"file_abc123\",\n});\nconsole.log(file.id, file.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.vectorStores().files()\n    .create(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getId() + \" \" + file.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.vectorStores().files()\n    .create(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getId() + \" \" + file.getStatus());"
           }
         ]
       }
@@ -18180,6 +22089,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileObject"
+                },
+                "example": {
+                  "id": "file-vs-abc123",
+                  "object": "vector_store.file",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 12345
                 }
               }
             }
@@ -18256,12 +22173,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar file = await vsClient.GetVectorStoreFileAsync(\n    \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine(file.Value.Status);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar file = await vsClient.GetVectorStoreFileAsync(\n    \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine(file.Value.Status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.vectorStores.files.retrieve(\n    \"vs_abc123\", \"file_abc123\"\n);\nconsole.log(file.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst file = await openai.vectorStores.files.retrieve(\n    \"vs_abc123\", \"file_abc123\"\n);\nconsole.log(file.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.vectorStores().files()\n    .retrieve(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar file = openai.vectorStores().files()\n    .retrieve(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(file.getStatus());"
           }
         ]
       },
@@ -18311,6 +22258,17 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreFileObject"
+                },
+                "example": {
+                  "id": "file-vs-abc123",
+                  "object": "vector_store.file",
+                  "vector_store_id": "vs_abc123def456",
+                  "created_at": 1741312436,
+                  "status": "completed",
+                  "usage_bytes": 12345,
+                  "attributes": {
+                    "category": "product-docs"
+                  }
                 }
               }
             }
@@ -18397,12 +22355,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"attributes\": {\"key\": \"value\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"attributes\": {\"key\": \"value\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"attributes\": {\"key\": \"value\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"attributes\": {\"key\": \"value\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.UpdateVectorStoreFileAttributesAsync(\n    \"vs_abc123\", \"file_abc123\",\n    new { key = \"value\" });"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.UpdateVectorStoreFileAttributesAsync(\n    \"vs_abc123\", \"file_abc123\",\n    new { key = \"value\" });"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.files.update(\n    \"vs_abc123\", \"file_abc123\",\n    { attributes: { key: \"value\" } }\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.files.update(\n    \"vs_abc123\", \"file_abc123\",\n    { attributes: { key: \"value\" } }\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().files().update(\n    \"vs_abc123\", \"file_abc123\",\n    Map.of(\"key\", \"value\"));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().files().update(\n    \"vs_abc123\", \"file_abc123\",\n    Map.of(\"key\", \"value\"));"
           }
         ]
       },
@@ -18455,6 +22443,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.DeleteVectorStoreFileResponse"
+                },
+                "example": {
+                  "id": "file-vs-abc123",
+                  "object": "vector_store.file",
+                  "deleted": true
                 }
               }
             }
@@ -18531,12 +22524,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.RemoveFileFromVectorStoreAsync(\n    \"vs_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nawait vsClient.RemoveFileFromVectorStoreAsync(\n    \"vs_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.files.delete(\n    \"vs_abc123\", \"file_abc123\"\n);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nawait openai.vectorStores.files.delete(\n    \"vs_abc123\", \"file_abc123\"\n);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().files()\n    .delete(\"vs_abc123\", \"file_abc123\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nopenai.vectorStores().files()\n    .delete(\"vs_abc123\", \"file_abc123\");"
           }
         ]
       }
@@ -18591,6 +22614,9 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreSearchResultsPage"
+                },
+                "example": {
+                  "content": "This is the content of the file stored in the vector store."
                 }
               }
             }
@@ -18667,12 +22693,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123/content\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/files/file_abc123/content\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar content = await vsClient\n    .GetVectorStoreFileContentAsync(\n        \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar content = await vsClient\n    .GetVectorStoreFileContentAsync(\n        \"vs_abc123\", \"file_abc123\");\n\nConsole.WriteLine(content.Value.ToString());"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.vectorStores.files.content(\n    \"vs_abc123\", \"file_abc123\"\n);\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst content = await openai.vectorStores.files.content(\n    \"vs_abc123\", \"file_abc123\"\n);\nconsole.log(await content.text());"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.vectorStores().files()\n    .content(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(new String(content));"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar content = openai.vectorStores().files()\n    .content(\"vs_abc123\", \"file_abc123\");\n\nSystem.out.println(new String(content));"
           }
         ]
       }
@@ -18718,6 +22774,24 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OpenAI.VectorStoreSearchResultsPage"
+                },
+                "example": {
+                  "object": "vector_store.search_results.page",
+                  "data": [
+                    {
+                      "file_id": "file-vs-abc123",
+                      "filename": "product-docs.pdf",
+                      "score": 0.92,
+                      "content": [
+                        {
+                          "type": "text",
+                          "text": "Our product supports both REST API and SDK integrations."
+                        }
+                      ],
+                      "attributes": {}
+                    }
+                  ],
+                  "has_more": false
                 }
               }
             }
@@ -18804,12 +22878,22 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/search\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"query\": \"search query\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/search\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"query\": \"search query\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/search\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"query\": \"search query\"}'"
+            "source": "curl -X POST \"$ENDPOINT/openai/v1/vector_stores/vs_abc123/search\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"query\": \"search query\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar results = vsClient.SearchVectorStore(\n    \"vs_abc123\", \"search query\");\n\nforeach (var result in results)\n    Console.WriteLine($\"{result.Score} {result.Content}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure.AI.Projects.OpenAI;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar vsClient = client.OpenAI.GetVectorStoreClient();\nvar results = vsClient.SearchVectorStore(\n    \"vs_abc123\", \"search query\");\n\nforeach (var result in results)\n    Console.WriteLine($\"{result.Score} {result.Content}\");"
           },
           {
             "lang": "javascript",
@@ -18820,6 +22904,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst project = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\nconst openai = await project.getOpenAIClient();\n\nconst results = await openai.vectorStores.search(\"vs_abc123\", {\n    query: \"search query\",\n});\nfor await (const result of results) {\n    console.log(result.score, result.content);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar results = openai.vectorStores()\n    .search(\"vs_abc123\", \"search query\");\n\nfor (var result : results) {\n    System.out.println(result.getScore()\n        + \" \" + result.getContent());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient project = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nvar openai = project.getOpenAIClient();\n\nvar results = openai.vectorStores()\n    .search(\"vs_abc123\", \"search query\");\n\nfor (var result : results) {\n    System.out.println(result.getScore()\n        + \" \" + result.getContent());\n}"
           }
         ]
       }

--- a/docs-vnext/openapi/projects-preview.json
+++ b/docs-vnext/openapi/projects-preview.json
@@ -126,6 +126,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedConnection"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-aoai-connection",
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+                      "type": "AzureOpenAI",
+                      "properties": {
+                        "category": "AzureOpenAI",
+                        "target": "https://my-aoai.openai.azure.com/",
+                        "authType": "ApiKey"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -166,12 +180,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/connections?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/connections?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/connections?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/connections?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -192,6 +206,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst connections = await client.connections.list();\nfor await (const conn of connections) {\n    console.log(conn.name, conn.type);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Connection> connections = client.getConnections();\n\nfor (Connection conn : connections) {\n    System.out.printf(\"%s %s%n\", conn.getName(), conn.getConnectionType());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Connection> connections = client.getConnections();\n\nfor (Connection conn : connections) {\n    System.out.printf(\"%s %s%n\", conn.getName(), conn.getConnectionType());\n}"
           }
         ]
       }
@@ -233,6 +257,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Connection"
+                },
+                "example": {
+                  "name": "my-aoai-connection",
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+                  "type": "AzureOpenAI",
+                  "properties": {
+                    "category": "AzureOpenAI",
+                    "target": "https://my-aoai.openai.azure.com/",
+                    "authType": "ApiKey"
+                  }
                 }
               }
             }
@@ -270,12 +304,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/connections/my-connection?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/connections/my-connection?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/connections/my-connection?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/connections/my-connection?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -296,6 +330,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst connection = await client.connections.get(\"my-connection\");\nconsole.log(connection.name, connection.type);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nConnection connection = client.getConnection(\"my-connection\");\n\nSystem.out.printf(\"%s %s%n\", connection.getName(), connection.getConnectionType());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nConnection connection = client.getConnection(\"my-connection\");\n\nSystem.out.printf(\"%s %s%n\", connection.getName(), connection.getConnectionType());"
           }
         ]
       }
@@ -337,6 +381,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Connection"
+                },
+                "example": {
+                  "name": "my-aoai-connection",
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+                  "type": "AzureOpenAI",
+                  "properties": {
+                    "category": "AzureOpenAI",
+                    "target": "https://my-aoai.openai.azure.com/",
+                    "authType": "ApiKey",
+                    "credentials": {
+                      "key": "YOUR_API_KEY"
+                    }
+                  }
                 }
               }
             }
@@ -374,12 +431,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/connections/my-connection/getConnectionWithCredentials?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/connections/my-connection/getConnectionWithCredentials?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/connections/my-connection/getConnectionWithCredentials?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/connections/my-connection/getConnectionWithCredentials?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -390,6 +447,26 @@
             "lang": "csharp",
             "label": "API Key",
             "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar connection = client.GetConnectionWithCredentials(\n    \"my-connection\");\n\nConsole.WriteLine(connection.Credentials);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst connection = await client.connections.getWithCredentials(\"my-connection\");\nconsole.log(connection.name, connection.credentials);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst connection = await client.connections.getWithCredentials(\"my-connection\");\nconsole.log(connection.name, connection.credentials);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nConnection connection = client.getConnectionWithCredentials(\n    \"my-connection\");\n\nSystem.out.println(connection.getCredentials());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nConnection connection = client.getConnectionWithCredentials(\n    \"my-connection\");\n\nSystem.out.println(connection.getCredentials());"
           }
         ]
       }
@@ -410,6 +487,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedDatasetVersion"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-dataset",
+                      "version": "1",
+                      "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/",
+                      "type": "uri_folder",
+                      "tags": {
+                        "purpose": "training"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -450,12 +540,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/datasets?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/datasets?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/datasets?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/datasets?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -476,6 +566,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst datasets = await client.datasets.list();\nfor await (const ds of datasets) {\n    console.log(ds.name, ds.version);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Dataset> datasets = client.getDatasets();\n\nfor (Dataset ds : datasets) {\n    System.out.printf(\"%s v%s%n\", ds.getName(), ds.getVersion());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Dataset> datasets = client.getDatasets();\n\nfor (Dataset ds : datasets) {\n    System.out.printf(\"%s v%s%n\", ds.getName(), ds.getVersion());\n}"
           }
         ]
       }
@@ -505,6 +605,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedDatasetVersion"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-dataset",
+                      "version": "1",
+                      "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                      "type": "uri_folder"
+                    },
+                    {
+                      "name": "my-dataset",
+                      "version": "2",
+                      "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v2/",
+                      "type": "uri_folder"
+                    }
+                  ]
                 }
               }
             }
@@ -545,12 +661,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/datasets/my-dataset/versions?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/datasets/my-dataset/versions?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/datasets/my-dataset/versions?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/datasets/my-dataset/versions?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar versions = client.GetDatasetVersions(\"my-dataset\");\n\nforeach (var v in versions)\n    Console.WriteLine($\"v{v.Version} {v.CreatedDate}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar versions = client.GetDatasetVersions(\"my-dataset\");\n\nforeach (var v in versions)\n    Console.WriteLine($\"v{v.Version} {v.CreatedDate}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst versions = await client.datasets.listVersions(\"my-dataset\");\nfor await (const v of versions) {\n    console.log(v.version, v.createdDate);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst versions = await client.datasets.listVersions(\"my-dataset\");\nfor await (const v of versions) {\n    console.log(v.version, v.createdDate);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Dataset> versions = client.getDatasetVersions(\"my-dataset\");\n\nfor (Dataset v : versions) {\n    System.out.printf(\"v%s %s%n\", v.getVersion(), v.getCreatedDate());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Dataset> versions = client.getDatasetVersions(\"my-dataset\");\n\nfor (Dataset v : versions) {\n    System.out.printf(\"v%s %s%n\", v.getVersion(), v.getCreatedDate());\n}"
           }
         ]
       }
@@ -589,6 +735,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetVersion"
+                },
+                "example": {
+                  "name": "my-dataset",
+                  "version": "1",
+                  "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                  "type": "uri_folder",
+                  "tags": {
+                    "purpose": "training"
+                  }
                 }
               }
             }
@@ -626,12 +781,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -652,6 +807,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst dataset = await client.datasets.get(\"my-dataset\", \"1\");\nconsole.log(dataset.name, dataset.version);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nDataset dataset = client.getDataset(\"my-dataset\", \"1\");\n\nSystem.out.printf(\"%s v%s%n\", dataset.getName(), dataset.getVersion());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nDataset dataset = client.getDataset(\"my-dataset\", \"1\");\n\nSystem.out.printf(\"%s v%s%n\", dataset.getName(), dataset.getVersion());"
           }
         ]
       },
@@ -699,6 +864,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetVersion"
+                },
+                "example": {
+                  "name": "my-dataset",
+                  "version": "1",
+                  "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                  "type": "uri_folder",
+                  "tags": {
+                    "purpose": "training"
+                  }
                 }
               }
             }
@@ -709,6 +883,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetVersion"
+                },
+                "example": {
+                  "name": "my-dataset",
+                  "version": "1",
+                  "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                  "type": "uri_folder",
+                  "tags": {
+                    "purpose": "training"
+                  }
                 }
               }
             }
@@ -746,12 +929,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X PATCH \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Training data\"}'"
+            "source": "curl -X PATCH \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Training data\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X PATCH \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Training data\"}'"
+            "source": "curl -X PATCH \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Training data\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar dataset = client.CreateOrUpdateDataset(\n    \"my-dataset\", \"1\",\n    new DatasetVersionOptions { Description = \"Training data\" });\n\nConsole.WriteLine(dataset.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar dataset = client.CreateOrUpdateDataset(\n    \"my-dataset\", \"1\",\n    new DatasetVersionOptions { Description = \"Training data\" });\n\nConsole.WriteLine(dataset.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst dataset = await client.datasets.createOrUpdate(\n    \"my-dataset\", \"1\",\n    { description: \"Training data\" },\n);\nconsole.log(dataset.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst dataset = await client.datasets.createOrUpdate(\n    \"my-dataset\", \"1\",\n    { description: \"Training data\" },\n);\nconsole.log(dataset.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nDataset dataset = client.createOrUpdateDataset(\n    \"my-dataset\", \"1\",\n    new DatasetVersionOptions().setDescription(\"Training data\"));\n\nSystem.out.println(dataset.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nDataset dataset = client.createOrUpdateDataset(\n    \"my-dataset\", \"1\",\n    new DatasetVersionOptions().setDescription(\"Training data\"));\n\nSystem.out.println(dataset.getName());"
           }
         ]
       },
@@ -783,7 +996,14 @@
         ],
         "responses": {
           "204": {
-            "description": "There is no content to send for this request, but the headers may be useful."
+            "description": "There is no content to send for this request, but the headers may be useful.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "status": "deleted"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -818,12 +1038,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -844,6 +1064,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nawait client.datasets.delete(\"my-dataset\", \"1\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nclient.deleteDataset(\"my-dataset\", \"1\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nclient.deleteDataset(\"my-dataset\", \"1\");"
           }
         ]
       }
@@ -882,6 +1112,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AssetCredentialResponse"
+                },
+                "example": {
+                  "credentials": {
+                    "sasUri": "https://my-storage.blob.core.windows.net/datasets/my-dataset?sv=2023-01-01&sig=YOUR_SAS_TOKEN"
+                  }
                 }
               }
             }
@@ -919,12 +1154,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/credentials?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/credentials?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/credentials?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/credentials?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar creds = client.GetDatasetCredentials(\"my-dataset\", \"1\");\n\nConsole.WriteLine(creds.CredentialType);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar creds = client.GetDatasetCredentials(\"my-dataset\", \"1\");\n\nConsole.WriteLine(creds.CredentialType);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst creds = await client.datasets.getCredentials(\"my-dataset\", \"1\");\nconsole.log(creds.credentialType);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst creds = await client.datasets.getCredentials(\"my-dataset\", \"1\");\nconsole.log(creds.credentialType);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nDatasetCredentials creds = client.getDatasetCredentials(\n    \"my-dataset\", \"1\");\n\nSystem.out.println(creds.getCredentialType());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nDatasetCredentials creds = client.getDatasetCredentials(\n    \"my-dataset\", \"1\");\n\nSystem.out.println(creds.getCredentialType());"
           }
         ]
       }
@@ -974,6 +1239,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PendingUploadResponse"
+                },
+                "example": {
+                  "blobReference": {
+                    "blobUri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                    "credential": {
+                      "sasUri": "https://my-storage.blob.core.windows.net/datasets?sv=2023-01-01&sig=YOUR_SAS_TOKEN"
+                    }
+                  }
                 }
               }
             }
@@ -1011,12 +1284,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/startPendingUpload?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"pending_upload_type\": \"temporary_sas\"}'"
+            "source": "curl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/startPendingUpload?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"pending_upload_type\": \"temporary_sas\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/startPendingUpload?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"pending_upload_type\": \"temporary_sas\"}'"
+            "source": "curl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/startPendingUpload?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"pending_upload_type\": \"temporary_sas\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar upload = client.StartPendingDatasetUpload(\n    \"my-dataset\", \"1\",\n    new PendingUploadOptions { PendingUploadType = \"temporary_sas\" });\n\nConsole.WriteLine(upload.BlobReference);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar upload = client.StartPendingDatasetUpload(\n    \"my-dataset\", \"1\",\n    new PendingUploadOptions { PendingUploadType = \"temporary_sas\" });\n\nConsole.WriteLine(upload.BlobReference);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst upload = await client.datasets.startPendingUpload(\n    \"my-dataset\", \"1\",\n    { pendingUploadType: \"temporary_sas\" },\n);\nconsole.log(upload.blobReference);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst upload = await client.datasets.startPendingUpload(\n    \"my-dataset\", \"1\",\n    { pendingUploadType: \"temporary_sas\" },\n);\nconsole.log(upload.blobReference);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPendingUpload upload = client.startPendingDatasetUpload(\n    \"my-dataset\", \"1\",\n    new PendingUploadOptions().setPendingUploadType(\"temporary_sas\"));\n\nSystem.out.println(upload.getBlobReference());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPendingUpload upload = client.startPendingDatasetUpload(\n    \"my-dataset\", \"1\",\n    new PendingUploadOptions().setPendingUploadType(\"temporary_sas\"));\n\nSystem.out.println(upload.getBlobReference());"
           }
         ]
       }
@@ -1090,6 +1393,34 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedDeployment"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "gpt-4o",
+                      "type": "Azure.OpenAI",
+                      "model": {
+                        "name": "gpt-4o",
+                        "version": "2024-11-20",
+                        "format": "OpenAI"
+                      },
+                      "properties": {
+                        "provisioningState": "Succeeded"
+                      }
+                    },
+                    {
+                      "name": "text-embedding-3-large",
+                      "type": "Azure.OpenAI",
+                      "model": {
+                        "name": "text-embedding-3-large",
+                        "version": "1",
+                        "format": "OpenAI"
+                      },
+                      "properties": {
+                        "provisioningState": "Succeeded"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -1130,12 +1461,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/deployments?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/deployments?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/deployments?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/deployments?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1156,6 +1487,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst deployments = await client.deployments.list();\nfor await (const d of deployments) {\n    console.log(d.name, d.model);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Deployment> deployments = client.getDeployments();\n\nfor (Deployment d : deployments) {\n    System.out.printf(\"%s %s%n\", d.getName(), d.getModel());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Deployment> deployments = client.getDeployments();\n\nfor (Deployment d : deployments) {\n    System.out.printf(\"%s %s%n\", d.getName(), d.getModel());\n}"
           }
         ]
       }
@@ -1197,6 +1538,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Deployment"
+                },
+                "example": {
+                  "name": "gpt-4o",
+                  "type": "Azure.OpenAI",
+                  "model": {
+                    "name": "gpt-4o",
+                    "version": "2024-11-20",
+                    "format": "OpenAI"
+                  },
+                  "properties": {
+                    "provisioningState": "Succeeded"
+                  }
                 }
               }
             }
@@ -1234,12 +1587,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/deployments/gpt-4o?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/deployments/gpt-4o?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/deployments/gpt-4o?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/deployments/gpt-4o?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1260,6 +1613,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst deployment = await client.deployments.get(\"gpt-4o\");\nconsole.log(deployment.name, deployment.model);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nDeployment deployment = client.getDeployment(\"gpt-4o\");\n\nSystem.out.printf(\"%s %s%n\", deployment.getName(), deployment.getModel());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nDeployment deployment = client.getDeployment(\"gpt-4o\");\n\nSystem.out.printf(\"%s %s%n\", deployment.getName(), deployment.getModel());"
           }
         ]
       }
@@ -1292,6 +1655,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedEvaluation"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "id": "eval-abc123def456",
+                      "displayName": "Chat Quality Evaluation",
+                      "status": "Completed",
+                      "tags": {
+                        "domain": "customer-support"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -1332,12 +1707,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/evaluations/runs?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/evaluations/runs?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/evaluations/runs?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/evaluations/runs?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar runs = client.GetEvaluations();\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Name} {run.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar runs = client.GetEvaluations();\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Name} {run.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst runs = await client.evaluations.list();\nfor await (const run of runs) {\n    console.log(run.name, run.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst runs = await client.evaluations.list();\nfor await (const run of runs) {\n    console.log(run.name, run.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<EvaluationRun> runs = client.getEvaluations();\n\nfor (EvaluationRun run : runs) {\n    System.out.printf(\"%s %s%n\", run.getName(), run.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<EvaluationRun> runs = client.getEvaluations();\n\nfor (EvaluationRun run : runs) {\n    System.out.printf(\"%s %s%n\", run.getName(), run.getStatus());\n}"
           }
         ]
       }
@@ -1379,6 +1784,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Evaluation"
+                },
+                "example": {
+                  "id": "eval-abc123def456",
+                  "displayName": "Chat Quality Evaluation",
+                  "status": "Completed",
+                  "tags": {
+                    "domain": "customer-support"
+                  }
                 }
               }
             }
@@ -1416,12 +1829,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/evaluations/runs/my-eval-run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/evaluations/runs/my-eval-run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/evaluations/runs/my-eval-run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/evaluations/runs/my-eval-run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar run = client.GetEvaluation(\"my-eval-run\");\n\nConsole.WriteLine($\"{run.Name} {run.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar run = client.GetEvaluation(\"my-eval-run\");\n\nConsole.WriteLine($\"{run.Name} {run.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst run = await client.evaluations.get(\"my-eval-run\");\nconsole.log(run.name, run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst run = await client.evaluations.get(\"my-eval-run\");\nconsole.log(run.name, run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nEvaluationRun run = client.getEvaluation(\"my-eval-run\");\n\nSystem.out.printf(\"%s %s%n\", run.getName(), run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nEvaluationRun run = client.getEvaluation(\"my-eval-run\");\n\nSystem.out.printf(\"%s %s%n\", run.getName(), run.getStatus());"
           }
         ]
       },
@@ -1491,12 +1934,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/evaluations/runs/my-eval-run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/evaluations/runs/my-eval-run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/evaluations/runs/my-eval-run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/evaluations/runs/my-eval-run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.DeleteEvaluation(\"my-eval-run\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.DeleteEvaluation(\"my-eval-run\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nawait client.evaluations.delete(\"my-eval-run\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nawait client.evaluations.delete(\"my-eval-run\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nclient.deleteEvaluation(\"my-eval-run\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nclient.deleteEvaluation(\"my-eval-run\");"
           }
         ]
       }
@@ -1568,12 +2041,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/evaluations/runs/my-eval-run:cancel?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/evaluations/runs/my-eval-run:cancel?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/evaluations/runs/my-eval-run:cancel?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/evaluations/runs/my-eval-run:cancel?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nclient.CancelEvaluation(\"my-eval-run\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nclient.CancelEvaluation(\"my-eval-run\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nawait client.evaluations.cancel(\"my-eval-run\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nawait client.evaluations.cancel(\"my-eval-run\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nclient.cancelEvaluation(\"my-eval-run\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nclient.cancelEvaluation(\"my-eval-run\");"
           }
         ]
       }
@@ -1605,6 +2108,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Evaluation"
+                },
+                "example": {
+                  "id": "eval-abc123def456",
+                  "displayName": "Chat Quality Evaluation",
+                  "status": "Queued",
+                  "tags": {
+                    "domain": "customer-support"
+                  }
                 }
               }
             }
@@ -1642,12 +2153,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/evaluations/runs:run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"my-eval\", \"evaluators\": {}, \"data\": {}}'"
+            "source": "curl -X POST \"$ENDPOINT/evaluations/runs:run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"my-eval\", \"evaluators\": {}, \"data\": {}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/evaluations/runs:run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"my-eval\", \"evaluators\": {}, \"data\": {}}'"
+            "source": "curl -X POST \"$ENDPOINT/evaluations/runs:run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"my-eval\", \"evaluators\": {}, \"data\": {}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar run = client.CreateEvaluation(new EvaluationOptions\n{\n    DisplayName = \"my-eval-run\",\n    Evaluators = { [\"relevance\"] = new EvaluatorConfig(\"relevance\") },\n    Data = new DatasetConfig(\"my-dataset:1\"),\n});\n\nConsole.WriteLine(run.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar run = client.CreateEvaluation(new EvaluationOptions\n{\n    DisplayName = \"my-eval-run\",\n    Evaluators = { [\"relevance\"] = new EvaluatorConfig(\"relevance\") },\n    Data = new DatasetConfig(\"my-dataset:1\"),\n});\n\nConsole.WriteLine(run.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst run = await client.evaluations.create({\n    displayName: \"my-eval-run\",\n    evaluators: { relevance: { id: \"relevance\" } },\n    data: { type: \"dataset\", id: \"my-dataset:1\" },\n});\nconsole.log(run.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst run = await client.evaluations.create({\n    displayName: \"my-eval-run\",\n    evaluators: { relevance: { id: \"relevance\" } },\n    data: { type: \"dataset\", id: \"my-dataset:1\" },\n});\nconsole.log(run.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nEvaluationRun run = client.createEvaluation(\n    new EvaluationOptions()\n        .setDisplayName(\"my-eval-run\")\n        .setEvaluators(Map.of(\"relevance\",\n            new EvaluatorConfig(\"relevance\")))\n        .setData(new DatasetConfig(\"my-dataset:1\")));\n\nSystem.out.println(run.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nEvaluationRun run = client.createEvaluation(\n    new EvaluationOptions()\n        .setDisplayName(\"my-eval-run\")\n        .setEvaluators(Map.of(\"relevance\",\n            new EvaluatorConfig(\"relevance\")))\n        .setData(new DatasetConfig(\"my-dataset:1\")));\n\nSystem.out.println(run.getName());"
           }
         ]
       }
@@ -1679,6 +2220,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AgentEvaluation"
+                },
+                "example": {
+                  "id": "agenteval-abc123",
+                  "displayName": "Agent Performance Evaluation",
+                  "status": "Queued"
                 }
               }
             }
@@ -1716,12 +2262,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/evaluations/runs:runAgent?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"agent-eval\", \"evaluators\": {}, \"target\": {\"agent_id\": \"my-agent:1\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/evaluations/runs:runAgent?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"agent-eval\", \"evaluators\": {}, \"target\": {\"agent_id\": \"my-agent:1\"}}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/evaluations/runs:runAgent?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"agent-eval\", \"evaluators\": {}, \"target\": {\"agent_id\": \"my-agent:1\"}}'"
+            "source": "curl -X POST \"$ENDPOINT/evaluations/runs:runAgent?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"agent-eval\", \"evaluators\": {}, \"target\": {\"agent_id\": \"my-agent:1\"}}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar run = client.CreateAgentEvaluation(\n    new AgentEvaluationOptions\n    {\n        DisplayName = \"agent-eval\",\n        Evaluators = { [\"relevance\"] = new EvaluatorConfig(\"relevance\") },\n        Target = new AgentTarget(\"my-agent:1\"),\n    });\n\nConsole.WriteLine(run.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar run = client.CreateAgentEvaluation(\n    new AgentEvaluationOptions\n    {\n        DisplayName = \"agent-eval\",\n        Evaluators = { [\"relevance\"] = new EvaluatorConfig(\"relevance\") },\n        Target = new AgentTarget(\"my-agent:1\"),\n    });\n\nConsole.WriteLine(run.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst run = await client.evaluations.createAgent({\n    displayName: \"agent-eval\",\n    evaluators: { relevance: { id: \"relevance\" } },\n    target: { agentId: \"my-agent:1\" },\n});\nconsole.log(run.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst run = await client.evaluations.createAgent({\n    displayName: \"agent-eval\",\n    evaluators: { relevance: { id: \"relevance\" } },\n    target: { agentId: \"my-agent:1\" },\n});\nconsole.log(run.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nEvaluationRun run = client.createAgentEvaluation(\n    new AgentEvaluationOptions()\n        .setDisplayName(\"agent-eval\")\n        .setEvaluators(Map.of(\"relevance\",\n            new EvaluatorConfig(\"relevance\")))\n        .setTarget(new AgentTarget(\"my-agent:1\")));\n\nSystem.out.println(run.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nEvaluationRun run = client.createAgentEvaluation(\n    new AgentEvaluationOptions()\n        .setDisplayName(\"agent-eval\")\n        .setEvaluators(Map.of(\"relevance\",\n            new EvaluatorConfig(\"relevance\")))\n        .setTarget(new AgentTarget(\"my-agent:1\")));\n\nSystem.out.println(run.getName());"
           }
         ]
       }
@@ -1742,6 +2318,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedIndex"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-search-index",
+                      "version": "1",
+                      "type": "AzureSearch",
+                      "tags": {
+                        "domain": "product-docs"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -1782,12 +2370,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/indexes?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/indexes?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/indexes?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/indexes?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1808,6 +2396,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst indexes = await client.indexes.list();\nfor await (const idx of indexes) {\n    console.log(idx.name, idx.version);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Index> indexes = client.getIndexes();\n\nfor (Index idx : indexes) {\n    System.out.printf(\"%s v%s%n\", idx.getName(), idx.getVersion());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Index> indexes = client.getIndexes();\n\nfor (Index idx : indexes) {\n    System.out.printf(\"%s v%s%n\", idx.getName(), idx.getVersion());\n}"
           }
         ]
       }
@@ -1837,6 +2435,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedIndex"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-search-index",
+                      "version": "1",
+                      "type": "AzureSearch"
+                    },
+                    {
+                      "name": "my-search-index",
+                      "version": "2",
+                      "type": "AzureSearch"
+                    }
+                  ]
                 }
               }
             }
@@ -1877,12 +2489,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/indexes/my-index/versions?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/indexes/my-index/versions?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/indexes/my-index/versions?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/indexes/my-index/versions?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar versions = client.GetIndexVersions(\"my-index\");\n\nforeach (var v in versions)\n    Console.WriteLine(v.Version);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar versions = client.GetIndexVersions(\"my-index\");\n\nforeach (var v in versions)\n    Console.WriteLine(v.Version);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst versions = await client.indexes.listVersions(\"my-index\");\nfor await (const v of versions) {\n    console.log(v.version);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst versions = await client.indexes.listVersions(\"my-index\");\nfor await (const v of versions) {\n    console.log(v.version);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Index> versions = client.getIndexVersions(\"my-index\");\n\nfor (Index v : versions) {\n    System.out.println(v.getVersion());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Index> versions = client.getIndexVersions(\"my-index\");\n\nfor (Index v : versions) {\n    System.out.println(v.getVersion());\n}"
           }
         ]
       }
@@ -1921,6 +2563,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Index"
+                },
+                "example": {
+                  "name": "my-search-index",
+                  "version": "1",
+                  "type": "AzureSearch",
+                  "tags": {
+                    "domain": "product-docs"
+                  }
                 }
               }
             }
@@ -1958,12 +2608,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1984,6 +2634,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst index = await client.indexes.get(\"my-index\", \"1\");\nconsole.log(index.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nIndex index = client.getIndex(\"my-index\", \"1\");\n\nSystem.out.println(index.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nIndex index = client.getIndex(\"my-index\", \"1\");\n\nSystem.out.println(index.getName());"
           }
         ]
       },
@@ -2031,6 +2691,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Index"
+                },
+                "example": {
+                  "name": "my-search-index",
+                  "version": "1",
+                  "type": "AzureSearch",
+                  "tags": {
+                    "domain": "product-docs"
+                  }
                 }
               }
             }
@@ -2041,6 +2709,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Index"
+                },
+                "example": {
+                  "name": "my-search-index",
+                  "version": "1",
+                  "type": "AzureSearch",
+                  "tags": {
+                    "domain": "product-docs"
+                  }
                 }
               }
             }
@@ -2078,12 +2754,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X PATCH \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Search index\"}'"
+            "source": "curl -X PATCH \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Search index\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X PATCH \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Search index\"}'"
+            "source": "curl -X PATCH \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Search index\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar index = client.CreateOrUpdateIndex(\n    \"my-index\", \"1\",\n    new IndexVersionOptions { Description = \"Search index\" });\n\nConsole.WriteLine(index.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar index = client.CreateOrUpdateIndex(\n    \"my-index\", \"1\",\n    new IndexVersionOptions { Description = \"Search index\" });\n\nConsole.WriteLine(index.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst index = await client.indexes.createOrUpdate(\n    \"my-index\", \"1\",\n    { description: \"Search index\" },\n);\nconsole.log(index.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst index = await client.indexes.createOrUpdate(\n    \"my-index\", \"1\",\n    { description: \"Search index\" },\n);\nconsole.log(index.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nIndex index = client.createOrUpdateIndex(\n    \"my-index\", \"1\",\n    new IndexVersionOptions().setDescription(\"Search index\"));\n\nSystem.out.println(index.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nIndex index = client.createOrUpdateIndex(\n    \"my-index\", \"1\",\n    new IndexVersionOptions().setDescription(\"Search index\"));\n\nSystem.out.println(index.getName());"
           }
         ]
       },
@@ -2115,7 +2821,14 @@
         ],
         "responses": {
           "204": {
-            "description": "There is no content to send for this request, but the headers may be useful."
+            "description": "There is no content to send for this request, but the headers may be useful.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "status": "deleted"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -2150,12 +2863,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -2176,6 +2889,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nawait client.indexes.delete(\"my-index\", \"1\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nclient.deleteIndex(\"my-index\", \"1\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nclient.deleteIndex(\"my-index\", \"1\");"
           }
         ]
       }
@@ -2208,6 +2931,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedRedTeam"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "id": "redteam-abc123def456",
+                      "displayName": "Safety Red Team",
+                      "status": "Completed"
+                    }
+                  ]
                 }
               }
             }
@@ -2248,12 +2980,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/redTeams/runs?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/redTeams/runs?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/redTeams/runs?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/redTeams/runs?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar runs = client.GetRedTeams();\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Name} {run.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar runs = client.GetRedTeams();\n\nforeach (var run in runs)\n    Console.WriteLine($\"{run.Name} {run.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst runs = await client.redTeams.list();\nfor await (const run of runs) {\n    console.log(run.name, run.status);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst runs = await client.redTeams.list();\nfor await (const run of runs) {\n    console.log(run.name, run.status);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<RedTeamRun> runs = client.getRedTeams();\n\nfor (RedTeamRun run : runs) {\n    System.out.printf(\"%s %s%n\", run.getName(), run.getStatus());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<RedTeamRun> runs = client.getRedTeams();\n\nfor (RedTeamRun run : runs) {\n    System.out.printf(\"%s %s%n\", run.getName(), run.getStatus());\n}"
           }
         ]
       }
@@ -2295,6 +3057,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RedTeam"
+                },
+                "example": {
+                  "id": "redteam-abc123def456",
+                  "displayName": "Safety Red Team",
+                  "status": "Completed"
                 }
               }
             }
@@ -2332,12 +3099,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/redTeams/runs/my-run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/redTeams/runs/my-run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/redTeams/runs/my-run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/redTeams/runs/my-run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar run = client.GetRedTeam(\"my-redteam-run\");\n\nConsole.WriteLine($\"{run.Name} {run.Status}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar run = client.GetRedTeam(\"my-redteam-run\");\n\nConsole.WriteLine($\"{run.Name} {run.Status}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst run = await client.redTeams.get(\"my-redteam-run\");\nconsole.log(run.name, run.status);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst run = await client.redTeams.get(\"my-redteam-run\");\nconsole.log(run.name, run.status);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nRedTeamRun run = client.getRedTeam(\"my-redteam-run\");\n\nSystem.out.printf(\"%s %s%n\", run.getName(), run.getStatus());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nRedTeamRun run = client.getRedTeam(\"my-redteam-run\");\n\nSystem.out.printf(\"%s %s%n\", run.getName(), run.getStatus());"
           }
         ]
       }
@@ -2369,6 +3166,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RedTeam"
+                },
+                "example": {
+                  "id": "redteam-abc123def456",
+                  "displayName": "Safety Red Team",
+                  "status": "Queued"
                 }
               }
             }
@@ -2406,12 +3208,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/redTeams/runs:run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"my-redteam\", \"target\": {\"agent_id\": \"my-agent:1\"}, \"risk_categories\": [\"violence\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/redTeams/runs:run?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"my-redteam\", \"target\": {\"agent_id\": \"my-agent:1\"}, \"risk_categories\": [\"violence\"]}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/redTeams/runs:run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"my-redteam\", \"target\": {\"agent_id\": \"my-agent:1\"}, \"risk_categories\": [\"violence\"]}'"
+            "source": "curl -X POST \"$ENDPOINT/redTeams/runs:run?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"display_name\": \"my-redteam\", \"target\": {\"agent_id\": \"my-agent:1\"}, \"risk_categories\": [\"violence\"]}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar run = client.CreateRedTeam(new RedTeamOptions\n{\n    DisplayName = \"my-redteam\",\n    Target = new AgentTarget(\"my-agent:1\"),\n    RiskCategories = { \"violence\", \"hate\" },\n});\n\nConsole.WriteLine(run.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar run = client.CreateRedTeam(new RedTeamOptions\n{\n    DisplayName = \"my-redteam\",\n    Target = new AgentTarget(\"my-agent:1\"),\n    RiskCategories = { \"violence\", \"hate\" },\n});\n\nConsole.WriteLine(run.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst run = await client.redTeams.create({\n    displayName: \"my-redteam\",\n    target: { agentId: \"my-agent:1\" },\n    riskCategories: [\"violence\", \"hate\"],\n});\nconsole.log(run.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst run = await client.redTeams.create({\n    displayName: \"my-redteam\",\n    target: { agentId: \"my-agent:1\" },\n    riskCategories: [\"violence\", \"hate\"],\n});\nconsole.log(run.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nRedTeamRun run = client.createRedTeam(\n    new RedTeamOptions()\n        .setDisplayName(\"my-redteam\")\n        .setTarget(new AgentTarget(\"my-agent:1\"))\n        .setRiskCategories(List.of(\"violence\", \"hate\")));\n\nSystem.out.println(run.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nRedTeamRun run = client.createRedTeam(\n    new RedTeamOptions()\n        .setDisplayName(\"my-redteam\")\n        .setTarget(new AgentTarget(\"my-agent:1\"))\n        .setRiskCategories(List.of(\"violence\", \"hate\")));\n\nSystem.out.println(run.getName());"
           }
         ]
       }

--- a/docs-vnext/openapi/projects-stable.json
+++ b/docs-vnext/openapi/projects-stable.json
@@ -126,6 +126,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedConnection"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-aoai-connection",
+                      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+                      "type": "AzureOpenAI",
+                      "properties": {
+                        "category": "AzureOpenAI",
+                        "target": "https://my-aoai.openai.azure.com/",
+                        "authType": "ApiKey"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -166,12 +180,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/connections?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/connections?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/connections?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/connections?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -192,6 +206,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst connections = await client.connections.list();\nfor await (const conn of connections) {\n    console.log(conn.name, conn.type);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Connection> connections = client.getConnections();\n\nfor (Connection conn : connections) {\n    System.out.printf(\"%s %s%n\", conn.getName(), conn.getConnectionType());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Connection> connections = client.getConnections();\n\nfor (Connection conn : connections) {\n    System.out.printf(\"%s %s%n\", conn.getName(), conn.getConnectionType());\n}"
           }
         ]
       }
@@ -233,6 +257,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Connection"
+                },
+                "example": {
+                  "name": "my-aoai-connection",
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+                  "type": "AzureOpenAI",
+                  "properties": {
+                    "category": "AzureOpenAI",
+                    "target": "https://my-aoai.openai.azure.com/",
+                    "authType": "ApiKey"
+                  }
                 }
               }
             }
@@ -270,12 +304,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/connections/my-connection?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/connections/my-connection?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/connections/my-connection?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/connections/my-connection?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -296,6 +330,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst connection = await client.connections.get(\"my-connection\");\nconsole.log(connection.name, connection.type);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nConnection connection = client.getConnection(\"my-connection\");\n\nSystem.out.printf(\"%s %s%n\", connection.getName(), connection.getConnectionType());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nConnection connection = client.getConnection(\"my-connection\");\n\nSystem.out.printf(\"%s %s%n\", connection.getName(), connection.getConnectionType());"
           }
         ]
       }
@@ -337,6 +381,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Connection"
+                },
+                "example": {
+                  "name": "my-aoai-connection",
+                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+                  "type": "AzureOpenAI",
+                  "properties": {
+                    "category": "AzureOpenAI",
+                    "target": "https://my-aoai.openai.azure.com/",
+                    "authType": "ApiKey",
+                    "credentials": {
+                      "key": "YOUR_API_KEY"
+                    }
+                  }
                 }
               }
             }
@@ -374,12 +431,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/connections/my-connection/getConnectionWithCredentials?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/connections/my-connection/getConnectionWithCredentials?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/connections/my-connection/getConnectionWithCredentials?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/connections/my-connection/getConnectionWithCredentials?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -390,6 +447,26 @@
             "lang": "csharp",
             "label": "API Key",
             "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar connection = client.GetConnectionWithCredentials(\n    \"my-connection\");\n\nConsole.WriteLine(connection.Credentials);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst connection = await client.connections.getWithCredentials(\"my-connection\");\nconsole.log(connection.name, connection.credentials);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst connection = await client.connections.getWithCredentials(\"my-connection\");\nconsole.log(connection.name, connection.credentials);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nConnection connection = client.getConnectionWithCredentials(\n    \"my-connection\");\n\nSystem.out.println(connection.getCredentials());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nConnection connection = client.getConnectionWithCredentials(\n    \"my-connection\");\n\nSystem.out.println(connection.getCredentials());"
           }
         ]
       }
@@ -410,6 +487,19 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedDatasetVersion"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-dataset",
+                      "version": "1",
+                      "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/",
+                      "type": "uri_folder",
+                      "tags": {
+                        "purpose": "training"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -450,12 +540,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/datasets?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/datasets?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/datasets?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/datasets?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -476,6 +566,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst datasets = await client.datasets.list();\nfor await (const ds of datasets) {\n    console.log(ds.name, ds.version);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Dataset> datasets = client.getDatasets();\n\nfor (Dataset ds : datasets) {\n    System.out.printf(\"%s v%s%n\", ds.getName(), ds.getVersion());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Dataset> datasets = client.getDatasets();\n\nfor (Dataset ds : datasets) {\n    System.out.printf(\"%s v%s%n\", ds.getName(), ds.getVersion());\n}"
           }
         ]
       }
@@ -505,6 +605,22 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedDatasetVersion"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-dataset",
+                      "version": "1",
+                      "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                      "type": "uri_folder"
+                    },
+                    {
+                      "name": "my-dataset",
+                      "version": "2",
+                      "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v2/",
+                      "type": "uri_folder"
+                    }
+                  ]
                 }
               }
             }
@@ -545,12 +661,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/datasets/my-dataset/versions?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/datasets/my-dataset/versions?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/datasets/my-dataset/versions?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/datasets/my-dataset/versions?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar versions = client.GetDatasetVersions(\"my-dataset\");\n\nforeach (var v in versions)\n    Console.WriteLine($\"v{v.Version} {v.CreatedDate}\");"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar versions = client.GetDatasetVersions(\"my-dataset\");\n\nforeach (var v in versions)\n    Console.WriteLine($\"v{v.Version} {v.CreatedDate}\");"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst versions = await client.datasets.listVersions(\"my-dataset\");\nfor await (const v of versions) {\n    console.log(v.version, v.createdDate);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst versions = await client.datasets.listVersions(\"my-dataset\");\nfor await (const v of versions) {\n    console.log(v.version, v.createdDate);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Dataset> versions = client.getDatasetVersions(\"my-dataset\");\n\nfor (Dataset v : versions) {\n    System.out.printf(\"v%s %s%n\", v.getVersion(), v.getCreatedDate());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Dataset> versions = client.getDatasetVersions(\"my-dataset\");\n\nfor (Dataset v : versions) {\n    System.out.printf(\"v%s %s%n\", v.getVersion(), v.getCreatedDate());\n}"
           }
         ]
       }
@@ -589,6 +735,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetVersion"
+                },
+                "example": {
+                  "name": "my-dataset",
+                  "version": "1",
+                  "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                  "type": "uri_folder",
+                  "tags": {
+                    "purpose": "training"
+                  }
                 }
               }
             }
@@ -626,12 +781,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -652,6 +807,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst dataset = await client.datasets.get(\"my-dataset\", \"1\");\nconsole.log(dataset.name, dataset.version);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nDataset dataset = client.getDataset(\"my-dataset\", \"1\");\n\nSystem.out.printf(\"%s v%s%n\", dataset.getName(), dataset.getVersion());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nDataset dataset = client.getDataset(\"my-dataset\", \"1\");\n\nSystem.out.printf(\"%s v%s%n\", dataset.getName(), dataset.getVersion());"
           }
         ]
       },
@@ -699,6 +864,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetVersion"
+                },
+                "example": {
+                  "name": "my-dataset",
+                  "version": "1",
+                  "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                  "type": "uri_folder",
+                  "tags": {
+                    "purpose": "training"
+                  }
                 }
               }
             }
@@ -709,6 +883,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DatasetVersion"
+                },
+                "example": {
+                  "name": "my-dataset",
+                  "version": "1",
+                  "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                  "type": "uri_folder",
+                  "tags": {
+                    "purpose": "training"
+                  }
                 }
               }
             }
@@ -746,12 +929,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X PATCH \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Training data\"}'"
+            "source": "curl -X PATCH \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Training data\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X PATCH \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Training data\"}'"
+            "source": "curl -X PATCH \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Training data\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar dataset = client.CreateOrUpdateDataset(\n    \"my-dataset\", \"1\",\n    new DatasetVersionOptions { Description = \"Training data\" });\n\nConsole.WriteLine(dataset.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar dataset = client.CreateOrUpdateDataset(\n    \"my-dataset\", \"1\",\n    new DatasetVersionOptions { Description = \"Training data\" });\n\nConsole.WriteLine(dataset.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst dataset = await client.datasets.createOrUpdate(\n    \"my-dataset\", \"1\",\n    { description: \"Training data\" },\n);\nconsole.log(dataset.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst dataset = await client.datasets.createOrUpdate(\n    \"my-dataset\", \"1\",\n    { description: \"Training data\" },\n);\nconsole.log(dataset.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nDataset dataset = client.createOrUpdateDataset(\n    \"my-dataset\", \"1\",\n    new DatasetVersionOptions().setDescription(\"Training data\"));\n\nSystem.out.println(dataset.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nDataset dataset = client.createOrUpdateDataset(\n    \"my-dataset\", \"1\",\n    new DatasetVersionOptions().setDescription(\"Training data\"));\n\nSystem.out.println(dataset.getName());"
           }
         ]
       },
@@ -783,7 +996,14 @@
         ],
         "responses": {
           "204": {
-            "description": "There is no content to send for this request, but the headers may be useful."
+            "description": "There is no content to send for this request, but the headers may be useful.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "status": "deleted"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -818,12 +1038,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/datasets/my-dataset/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -844,6 +1064,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nawait client.datasets.delete(\"my-dataset\", \"1\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nclient.deleteDataset(\"my-dataset\", \"1\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nclient.deleteDataset(\"my-dataset\", \"1\");"
           }
         ]
       }
@@ -882,6 +1112,11 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AssetCredentialResponse"
+                },
+                "example": {
+                  "credentials": {
+                    "sasUri": "https://my-storage.blob.core.windows.net/datasets/my-dataset?sv=2023-01-01&sig=YOUR_SAS_TOKEN"
+                  }
                 }
               }
             }
@@ -919,12 +1154,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/credentials?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/credentials?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/credentials?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/credentials?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar creds = client.GetDatasetCredentials(\"my-dataset\", \"1\");\n\nConsole.WriteLine(creds.CredentialType);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar creds = client.GetDatasetCredentials(\"my-dataset\", \"1\");\n\nConsole.WriteLine(creds.CredentialType);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst creds = await client.datasets.getCredentials(\"my-dataset\", \"1\");\nconsole.log(creds.credentialType);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst creds = await client.datasets.getCredentials(\"my-dataset\", \"1\");\nconsole.log(creds.credentialType);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nDatasetCredentials creds = client.getDatasetCredentials(\n    \"my-dataset\", \"1\");\n\nSystem.out.println(creds.getCredentialType());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nDatasetCredentials creds = client.getDatasetCredentials(\n    \"my-dataset\", \"1\");\n\nSystem.out.println(creds.getCredentialType());"
           }
         ]
       }
@@ -974,6 +1239,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PendingUploadResponse"
+                },
+                "example": {
+                  "blobReference": {
+                    "blobUri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                    "credential": {
+                      "sasUri": "https://my-storage.blob.core.windows.net/datasets?sv=2023-01-01&sig=YOUR_SAS_TOKEN"
+                    }
+                  }
                 }
               }
             }
@@ -1011,12 +1284,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/startPendingUpload?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"pending_upload_type\": \"temporary_sas\"}'"
+            "source": "curl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/startPendingUpload?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"pending_upload_type\": \"temporary_sas\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/startPendingUpload?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"pending_upload_type\": \"temporary_sas\"}'"
+            "source": "curl -X POST \"$ENDPOINT/datasets/my-dataset/versions/1/startPendingUpload?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"pending_upload_type\": \"temporary_sas\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar upload = client.StartPendingDatasetUpload(\n    \"my-dataset\", \"1\",\n    new PendingUploadOptions { PendingUploadType = \"temporary_sas\" });\n\nConsole.WriteLine(upload.BlobReference);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar upload = client.StartPendingDatasetUpload(\n    \"my-dataset\", \"1\",\n    new PendingUploadOptions { PendingUploadType = \"temporary_sas\" });\n\nConsole.WriteLine(upload.BlobReference);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst upload = await client.datasets.startPendingUpload(\n    \"my-dataset\", \"1\",\n    { pendingUploadType: \"temporary_sas\" },\n);\nconsole.log(upload.blobReference);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst upload = await client.datasets.startPendingUpload(\n    \"my-dataset\", \"1\",\n    { pendingUploadType: \"temporary_sas\" },\n);\nconsole.log(upload.blobReference);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPendingUpload upload = client.startPendingDatasetUpload(\n    \"my-dataset\", \"1\",\n    new PendingUploadOptions().setPendingUploadType(\"temporary_sas\"));\n\nSystem.out.println(upload.getBlobReference());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPendingUpload upload = client.startPendingDatasetUpload(\n    \"my-dataset\", \"1\",\n    new PendingUploadOptions().setPendingUploadType(\"temporary_sas\"));\n\nSystem.out.println(upload.getBlobReference());"
           }
         ]
       }
@@ -1090,6 +1393,34 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedDeployment"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "gpt-4o",
+                      "type": "Azure.OpenAI",
+                      "model": {
+                        "name": "gpt-4o",
+                        "version": "2024-11-20",
+                        "format": "OpenAI"
+                      },
+                      "properties": {
+                        "provisioningState": "Succeeded"
+                      }
+                    },
+                    {
+                      "name": "text-embedding-3-large",
+                      "type": "Azure.OpenAI",
+                      "model": {
+                        "name": "text-embedding-3-large",
+                        "version": "1",
+                        "format": "OpenAI"
+                      },
+                      "properties": {
+                        "provisioningState": "Succeeded"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -1130,12 +1461,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/deployments?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/deployments?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/deployments?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/deployments?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1156,6 +1487,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst deployments = await client.deployments.list();\nfor await (const d of deployments) {\n    console.log(d.name, d.model);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Deployment> deployments = client.getDeployments();\n\nfor (Deployment d : deployments) {\n    System.out.printf(\"%s %s%n\", d.getName(), d.getModel());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Deployment> deployments = client.getDeployments();\n\nfor (Deployment d : deployments) {\n    System.out.printf(\"%s %s%n\", d.getName(), d.getModel());\n}"
           }
         ]
       }
@@ -1197,6 +1538,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Deployment"
+                },
+                "example": {
+                  "name": "gpt-4o",
+                  "type": "Azure.OpenAI",
+                  "model": {
+                    "name": "gpt-4o",
+                    "version": "2024-11-20",
+                    "format": "OpenAI"
+                  },
+                  "properties": {
+                    "provisioningState": "Succeeded"
+                  }
                 }
               }
             }
@@ -1234,12 +1587,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/deployments/gpt-4o?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/deployments/gpt-4o?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/deployments/gpt-4o?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/deployments/gpt-4o?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1260,6 +1613,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst deployment = await client.deployments.get(\"gpt-4o\");\nconsole.log(deployment.name, deployment.model);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nDeployment deployment = client.getDeployment(\"gpt-4o\");\n\nSystem.out.printf(\"%s %s%n\", deployment.getName(), deployment.getModel());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nDeployment deployment = client.getDeployment(\"gpt-4o\");\n\nSystem.out.printf(\"%s %s%n\", deployment.getName(), deployment.getModel());"
           }
         ]
       }
@@ -1280,6 +1643,18 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedIndex"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-search-index",
+                      "version": "1",
+                      "type": "AzureSearch",
+                      "tags": {
+                        "domain": "product-docs"
+                      }
+                    }
+                  ]
                 }
               }
             }
@@ -1320,12 +1695,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/indexes?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/indexes?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/indexes?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/indexes?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1346,6 +1721,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst indexes = await client.indexes.list();\nfor await (const idx of indexes) {\n    console.log(idx.name, idx.version);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Index> indexes = client.getIndexes();\n\nfor (Index idx : indexes) {\n    System.out.printf(\"%s v%s%n\", idx.getName(), idx.getVersion());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Index> indexes = client.getIndexes();\n\nfor (Index idx : indexes) {\n    System.out.printf(\"%s v%s%n\", idx.getName(), idx.getVersion());\n}"
           }
         ]
       }
@@ -1375,6 +1760,20 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PagedIndex"
+                },
+                "example": {
+                  "value": [
+                    {
+                      "name": "my-search-index",
+                      "version": "1",
+                      "type": "AzureSearch"
+                    },
+                    {
+                      "name": "my-search-index",
+                      "version": "2",
+                      "type": "AzureSearch"
+                    }
+                  ]
                 }
               }
             }
@@ -1415,12 +1814,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/indexes/my-index/versions?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/indexes/my-index/versions?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/indexes/my-index/versions?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/indexes/my-index/versions?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar versions = client.GetIndexVersions(\"my-index\");\n\nforeach (var v in versions)\n    Console.WriteLine(v.Version);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar versions = client.GetIndexVersions(\"my-index\");\n\nforeach (var v in versions)\n    Console.WriteLine(v.Version);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst versions = await client.indexes.listVersions(\"my-index\");\nfor await (const v of versions) {\n    console.log(v.version);\n}"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst versions = await client.indexes.listVersions(\"my-index\");\nfor await (const v of versions) {\n    console.log(v.version);\n}"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nPagedIterable<Index> versions = client.getIndexVersions(\"my-index\");\n\nfor (Index v : versions) {\n    System.out.println(v.getVersion());\n}"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nPagedIterable<Index> versions = client.getIndexVersions(\"my-index\");\n\nfor (Index v : versions) {\n    System.out.println(v.getVersion());\n}"
           }
         ]
       }
@@ -1459,6 +1888,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Index"
+                },
+                "example": {
+                  "name": "my-search-index",
+                  "version": "1",
+                  "type": "AzureSearch",
+                  "tags": {
+                    "domain": "product-docs"
+                  }
                 }
               }
             }
@@ -1496,12 +1933,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1522,6 +1959,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst index = await client.indexes.get(\"my-index\", \"1\");\nconsole.log(index.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nIndex index = client.getIndex(\"my-index\", \"1\");\n\nSystem.out.println(index.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nIndex index = client.getIndex(\"my-index\", \"1\");\n\nSystem.out.println(index.getName());"
           }
         ]
       },
@@ -1569,6 +2016,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Index"
+                },
+                "example": {
+                  "name": "my-search-index",
+                  "version": "1",
+                  "type": "AzureSearch",
+                  "tags": {
+                    "domain": "product-docs"
+                  }
                 }
               }
             }
@@ -1579,6 +2034,14 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Index"
+                },
+                "example": {
+                  "name": "my-search-index",
+                  "version": "1",
+                  "type": "AzureSearch",
+                  "tags": {
+                    "domain": "product-docs"
+                  }
                 }
               }
             }
@@ -1616,12 +2079,42 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X PATCH \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Search index\"}'"
+            "source": "curl -X PATCH \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Search index\"}'"
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X PATCH \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Search index\"}'"
+            "source": "curl -X PATCH \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"description\": \"Search index\"}'"
+          },
+          {
+            "lang": "csharp",
+            "label": "Entra ID",
+            "source": "using Azure.AI.Projects;\nusing Azure.Identity;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new DefaultAzureCredential());\n\nvar index = client.CreateOrUpdateIndex(\n    \"my-index\", \"1\",\n    new IndexVersionOptions { Description = \"Search index\" });\n\nConsole.WriteLine(index.Name);"
+          },
+          {
+            "lang": "csharp",
+            "label": "API Key",
+            "source": "using Azure.AI.Projects;\nusing Azure;\n\nvar client = new AIProjectClient(\n    new Uri(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\"),\n    new AzureKeyCredential(\"YOUR_API_KEY\"));\n\nvar index = client.CreateOrUpdateIndex(\n    \"my-index\", \"1\",\n    new IndexVersionOptions { Description = \"Search index\" });\n\nConsole.WriteLine(index.Name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "Entra ID",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { DefaultAzureCredential } from \"@azure/identity\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new DefaultAzureCredential(),\n);\n\nconst index = await client.indexes.createOrUpdate(\n    \"my-index\", \"1\",\n    { description: \"Search index\" },\n);\nconsole.log(index.name);"
+          },
+          {
+            "lang": "javascript",
+            "label": "API Key",
+            "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nconst index = await client.indexes.createOrUpdate(\n    \"my-index\", \"1\",\n    { description: \"Search index\" },\n);\nconsole.log(index.name);"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nIndex index = client.createOrUpdateIndex(\n    \"my-index\", \"1\",\n    new IndexVersionOptions().setDescription(\"Search index\"));\n\nSystem.out.println(index.getName());"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nIndex index = client.createOrUpdateIndex(\n    \"my-index\", \"1\",\n    new IndexVersionOptions().setDescription(\"Search index\"));\n\nSystem.out.println(index.getName());"
           }
         ]
       },
@@ -1653,7 +2146,14 @@
         ],
         "responses": {
           "204": {
-            "description": "There is no content to send for this request, but the headers may be useful."
+            "description": "There is no content to send for this request, but the headers may be useful.",
+            "content": {
+              "application/json": {
+                "example": {
+                  "status": "deleted"
+                }
+              }
+            }
           },
           "default": {
             "description": "An unexpected error response.",
@@ -1688,12 +2188,12 @@
           {
             "lang": "bash",
             "label": "Entra ID",
-            "source": "# Get a token via Azure CLI\n# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)\ncurl -X DELETE \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
+            "source": "curl -X DELETE \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"Authorization: Bearer $TOKEN\""
           },
           {
             "lang": "bash",
             "label": "API Key",
-            "source": "# Use your API key from the Azure portal\ncurl -X DELETE \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
+            "source": "curl -X DELETE \"$ENDPOINT/indexes/my-index/versions/1?api-version=v1\" \\\n  -H \"api-key: YOUR_API_KEY\""
           },
           {
             "lang": "csharp",
@@ -1714,6 +2214,16 @@
             "lang": "javascript",
             "label": "API Key",
             "source": "import { AIProjectClient } from \"@azure/ai-projects\";\nimport { AzureKeyCredential } from \"@azure/core-auth\";\n\nconst client = new AIProjectClient(\n    \"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\",\n    new AzureKeyCredential(\"YOUR_API_KEY\"),\n);\n\nawait client.indexes.delete(\"my-index\", \"1\");"
+          },
+          {
+            "lang": "java",
+            "label": "Entra ID",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.identity.DefaultAzureCredentialBuilder;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new DefaultAzureCredentialBuilder().build())\n    .buildClient();\n\nclient.deleteIndex(\"my-index\", \"1\");"
+          },
+          {
+            "lang": "java",
+            "label": "API Key",
+            "source": "import com.azure.ai.projects.AIProjectClient;\nimport com.azure.ai.projects.AIProjectClientBuilder;\nimport com.azure.core.credential.AzureKeyCredential;\n\nAIProjectClient client = new AIProjectClientBuilder()\n    .endpoint(\"https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME\")\n    .credential(new AzureKeyCredential(\"YOUR_API_KEY\"))\n    .buildClient();\n\nclient.deleteIndex(\"my-index\", \"1\");"
           }
         ]
       }

--- a/scripts/add_response_examples.py
+++ b/scripts/add_response_examples.py
@@ -1,0 +1,1334 @@
+#!/usr/bin/env python3
+"""Add realistic example objects to OpenAPI response schemas for Mintlify rendering.
+
+Usage:
+    python scripts/add_response_examples.py <openapi-spec.json> [<openapi-spec.json> ...]
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# OpenAI-style response examples keyed by operationId
+# ---------------------------------------------------------------------------
+OPENAI_RESPONSE_EXAMPLES: dict = {
+    # ── Responses API ──────────────────────────────────────────────────────
+    "createResponse": {
+        "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+        "object": "response",
+        "created_at": 1741312436,
+        "status": "completed",
+        "output": [
+            {
+                "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "The capital of France is Paris.",
+                        "annotations": [],
+                    }
+                ],
+            }
+        ],
+        "model": "gpt-4o-2024-11-20",
+        "usage": {"input_tokens": 13, "output_tokens": 8, "total_tokens": 21},
+    },
+    "getResponse": {
+        "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+        "object": "response",
+        "created_at": 1741312436,
+        "status": "completed",
+        "output": [
+            {
+                "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "The capital of France is Paris.",
+                        "annotations": [],
+                    }
+                ],
+            }
+        ],
+        "model": "gpt-4o-2024-11-20",
+        "usage": {"input_tokens": 13, "output_tokens": 8, "total_tokens": 21},
+    },
+    "deleteResponse": {
+        "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+        "object": "response",
+        "deleted": True,
+    },
+    "cancelResponse": {
+        "id": "resp_67cb71b4e4a4819085e77aad18f06c92",
+        "object": "response",
+        "created_at": 1741312436,
+        "status": "cancelled",
+        "output": [],
+        "model": "gpt-4o-2024-11-20",
+        "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+    },
+    "listInputItems": {
+        "object": "list",
+        "data": [
+            {
+                "id": "msg_67cb71b5c1988190b5fba3b237c63581",
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "What is the capital of France?"}],
+            }
+        ],
+        "has_more": False,
+        "first_id": "msg_67cb71b5c1988190b5fba3b237c63581",
+        "last_id": "msg_67cb71b5c1988190b5fba3b237c63581",
+    },
+    # ── Chat Completions ───────────────────────────────────────────────────
+    "createChatCompletion": {
+        "id": "chatcmpl-abc123def456",
+        "object": "chat.completion",
+        "created": 1741312436,
+        "model": "gpt-4o-2024-11-20",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello! How can I help you today?"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 9, "total_tokens": 18},
+    },
+    # ── Completions (legacy) ───────────────────────────────────────────────
+    "createCompletion": {
+        "id": "cmpl-abc123def456",
+        "object": "text_completion",
+        "created": 1741312436,
+        "model": "gpt-3.5-turbo-instruct",
+        "choices": [
+            {"text": " world! This is a test.", "index": 0, "finish_reason": "stop"}
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+    },
+    # ── Embeddings ─────────────────────────────────────────────────────────
+    "createEmbedding": {
+        "object": "list",
+        "data": [
+            {
+                "object": "embedding",
+                "embedding": [-0.0128, -0.0074, -0.0176, -0.0283, -0.0187],
+                "index": 0,
+            }
+        ],
+        "model": "text-embedding-3-large",
+        "usage": {"prompt_tokens": 5, "total_tokens": 5},
+    },
+    # ── Models ─────────────────────────────────────────────────────────────
+    "listModels": {
+        "object": "list",
+        "data": [
+            {"id": "gpt-4o", "object": "model", "created": 1715367049, "owned_by": "system"},
+            {"id": "gpt-4o-mini", "object": "model", "created": 1721172741, "owned_by": "system"},
+            {
+                "id": "text-embedding-3-large",
+                "object": "model",
+                "created": 1705953180,
+                "owned_by": "system",
+            },
+        ],
+    },
+    "retrieveModel": {
+        "id": "gpt-4o",
+        "object": "model",
+        "created": 1715367049,
+        "owned_by": "system",
+    },
+    "deleteModel": {
+        "id": "ft:gpt-4o-mini:my-org:custom-suffix:abc123",
+        "object": "model",
+        "deleted": True,
+    },
+    # ── Files ──────────────────────────────────────────────────────────────
+    "createFile": {
+        "id": "file-abc123def456",
+        "object": "file",
+        "bytes": 140,
+        "created_at": 1741312436,
+        "filename": "training_data.jsonl",
+        "purpose": "fine-tune",
+    },
+    "listFiles": {
+        "object": "list",
+        "data": [
+            {
+                "id": "file-abc123def456",
+                "object": "file",
+                "bytes": 140,
+                "created_at": 1741312436,
+                "filename": "training_data.jsonl",
+                "purpose": "fine-tune",
+            }
+        ],
+    },
+    "retrieveFile": {
+        "id": "file-abc123def456",
+        "object": "file",
+        "bytes": 140,
+        "created_at": 1741312436,
+        "filename": "training_data.jsonl",
+        "purpose": "fine-tune",
+    },
+    "deleteFile": {
+        "id": "file-abc123def456",
+        "object": "file",
+        "deleted": True,
+    },
+    # ── Batches ────────────────────────────────────────────────────────────
+    "createBatch": {
+        "id": "batch_abc123def456",
+        "object": "batch",
+        "endpoint": "/v1/chat/completions",
+        "input_file_id": "file-abc123def456",
+        "completion_window": "24h",
+        "status": "validating",
+        "created_at": 1741312436,
+    },
+    "listBatches": {
+        "object": "list",
+        "data": [
+            {
+                "id": "batch_abc123def456",
+                "object": "batch",
+                "endpoint": "/v1/chat/completions",
+                "input_file_id": "file-abc123def456",
+                "completion_window": "24h",
+                "status": "completed",
+                "created_at": 1741312436,
+            }
+        ],
+        "has_more": False,
+        "first_id": "batch_abc123def456",
+        "last_id": "batch_abc123def456",
+    },
+    "retrieveBatch": {
+        "id": "batch_abc123def456",
+        "object": "batch",
+        "endpoint": "/v1/chat/completions",
+        "input_file_id": "file-abc123def456",
+        "completion_window": "24h",
+        "status": "completed",
+        "created_at": 1741312436,
+        "completed_at": 1741315036,
+        "output_file_id": "file-xyz789ghi012",
+        "request_counts": {"total": 100, "completed": 95, "failed": 5},
+    },
+    "cancelBatch": {
+        "id": "batch_abc123def456",
+        "object": "batch",
+        "endpoint": "/v1/chat/completions",
+        "input_file_id": "file-abc123def456",
+        "completion_window": "24h",
+        "status": "cancelling",
+        "created_at": 1741312436,
+    },
+    # ── Fine-tuning ────────────────────────────────────────────────────────
+    "createFineTuningJob": {
+        "id": "ftjob-abc123def456",
+        "object": "fine_tuning.job",
+        "model": "gpt-4o-mini-2024-07-18",
+        "created_at": 1741312436,
+        "status": "validating_files",
+        "training_file": "file-abc123def456",
+        "hyperparameters": {"n_epochs": "auto", "batch_size": "auto", "learning_rate_multiplier": "auto"},
+        "organization_id": "org-abc123",
+    },
+    "listPaginatedFineTuningJobs": {
+        "object": "list",
+        "data": [
+            {
+                "id": "ftjob-abc123def456",
+                "object": "fine_tuning.job",
+                "model": "gpt-4o-mini-2024-07-18",
+                "created_at": 1741312436,
+                "status": "succeeded",
+                "training_file": "file-abc123def456",
+                "fine_tuned_model": "ft:gpt-4o-mini:my-org:custom-suffix:abc123",
+            }
+        ],
+        "has_more": False,
+    },
+    "retrieveFineTuningJob": {
+        "id": "ftjob-abc123def456",
+        "object": "fine_tuning.job",
+        "model": "gpt-4o-mini-2024-07-18",
+        "created_at": 1741312436,
+        "finished_at": 1741315036,
+        "status": "succeeded",
+        "training_file": "file-abc123def456",
+        "fine_tuned_model": "ft:gpt-4o-mini:my-org:custom-suffix:abc123",
+        "trained_tokens": 52814,
+        "result_files": ["file-result123"],
+    },
+    "cancelFineTuningJob": {
+        "id": "ftjob-abc123def456",
+        "object": "fine_tuning.job",
+        "model": "gpt-4o-mini-2024-07-18",
+        "created_at": 1741312436,
+        "status": "cancelled",
+        "training_file": "file-abc123def456",
+    },
+    "pauseFineTuningJob": {
+        "id": "ftjob-abc123def456",
+        "object": "fine_tuning.job",
+        "model": "gpt-4o-mini-2024-07-18",
+        "created_at": 1741312436,
+        "status": "paused",
+        "training_file": "file-abc123def456",
+    },
+    "resumeFineTuningJob": {
+        "id": "ftjob-abc123def456",
+        "object": "fine_tuning.job",
+        "model": "gpt-4o-mini-2024-07-18",
+        "created_at": 1741312436,
+        "status": "running",
+        "training_file": "file-abc123def456",
+    },
+    "listFineTuningEvents": {
+        "object": "list",
+        "data": [
+            {
+                "id": "ftevent-abc123",
+                "object": "fine_tuning.job.event",
+                "created_at": 1741312436,
+                "level": "info",
+                "message": "Training started",
+            }
+        ],
+        "has_more": False,
+    },
+    "listFineTuningJobCheckpoints": {
+        "object": "list",
+        "data": [
+            {
+                "id": "ftckpt-abc123def456",
+                "object": "fine_tuning.job.checkpoint",
+                "created_at": 1741313436,
+                "fine_tuning_job_id": "ftjob-abc123def456",
+                "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+                "step_number": 100,
+                "metrics": {"step": 100, "train_loss": 0.234, "train_mean_token_accuracy": 0.891},
+            }
+        ],
+        "has_more": False,
+        "first_id": "ftckpt-abc123def456",
+        "last_id": "ftckpt-abc123def456",
+    },
+    "listFineTuningCheckpointPermissions": {
+        "object": "list",
+        "data": [
+            {
+                "id": "ftckptperm-abc123",
+                "object": "fine_tuning.job.checkpoint.permission",
+                "created_at": 1741312436,
+                "project_id": "proj-abc123",
+            }
+        ],
+        "has_more": False,
+        "first_id": "ftckptperm-abc123",
+        "last_id": "ftckptperm-abc123",
+    },
+    "createFineTuningCheckpointPermission": {
+        "id": "ftckptperm-abc123",
+        "object": "fine_tuning.job.checkpoint.permission",
+        "created_at": 1741312436,
+        "project_id": "proj-abc123",
+    },
+    "deleteFineTuningCheckpointPermission": {
+        "id": "ftckptperm-abc123",
+        "object": "fine_tuning.job.checkpoint.permission",
+        "deleted": True,
+    },
+    "FineTuning_CopyCheckpoint": {
+        "id": "ftckpt-copy123",
+        "object": "fine_tuning.job.checkpoint",
+        "created_at": 1741312436,
+        "fine_tuning_job_id": "ftjob-abc123def456",
+        "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+        "step_number": 100,
+        "metrics": {"step": 100, "train_loss": 0.234},
+    },
+    "FineTuning_GetCheckpoint": {
+        "id": "ftckpt-abc123def456",
+        "object": "fine_tuning.job.checkpoint",
+        "created_at": 1741313436,
+        "fine_tuning_job_id": "ftjob-abc123def456",
+        "fine_tuned_model_checkpoint": "ft:gpt-4o-mini:my-org:custom-suffix:abc123:ckpt-step-100",
+        "step_number": 100,
+        "metrics": {"step": 100, "train_loss": 0.234, "train_mean_token_accuracy": 0.891},
+    },
+    # ── Evals ──────────────────────────────────────────────────────────────
+    "createEval": {
+        "id": "eval_abc123def456",
+        "object": "eval",
+        "name": "My Evaluation",
+        "created_at": 1741312436,
+        "data_source_config": {"type": "custom", "item_schema": {}},
+        "testing_criteria": [],
+        "metadata": {},
+    },
+    "listEvals": {
+        "object": "list",
+        "data": [
+            {
+                "id": "eval_abc123def456",
+                "object": "eval",
+                "name": "My Evaluation",
+                "created_at": 1741312436,
+            }
+        ],
+        "has_more": False,
+        "first_id": "eval_abc123def456",
+        "last_id": "eval_abc123def456",
+    },
+    "getEval": {
+        "id": "eval_abc123def456",
+        "object": "eval",
+        "name": "My Evaluation",
+        "created_at": 1741312436,
+        "data_source_config": {"type": "custom", "item_schema": {}},
+        "testing_criteria": [],
+        "metadata": {},
+    },
+    "updateEval": {
+        "id": "eval_abc123def456",
+        "object": "eval",
+        "name": "Updated Evaluation",
+        "created_at": 1741312436,
+        "data_source_config": {"type": "custom", "item_schema": {}},
+        "testing_criteria": [],
+        "metadata": {},
+    },
+    "deleteEval": {
+        "id": "eval_abc123def456",
+        "object": "eval",
+        "deleted": True,
+    },
+    "createEvalRun": {
+        "id": "evalrun_abc123def456",
+        "object": "eval.run",
+        "eval_id": "eval_abc123def456",
+        "status": "queued",
+        "created_at": 1741312436,
+        "model": "gpt-4o-2024-11-20",
+        "result_counts": {"total": 0, "passed": 0, "failed": 0, "errored": 0},
+    },
+    "getEvalRuns": {
+        "object": "list",
+        "data": [
+            {
+                "id": "evalrun_abc123def456",
+                "object": "eval.run",
+                "eval_id": "eval_abc123def456",
+                "status": "completed",
+                "created_at": 1741312436,
+                "model": "gpt-4o-2024-11-20",
+                "result_counts": {"total": 50, "passed": 45, "failed": 3, "errored": 2},
+            }
+        ],
+        "has_more": False,
+        "first_id": "evalrun_abc123def456",
+        "last_id": "evalrun_abc123def456",
+    },
+    "getEvalRun": {
+        "id": "evalrun_abc123def456",
+        "object": "eval.run",
+        "eval_id": "eval_abc123def456",
+        "status": "completed",
+        "created_at": 1741312436,
+        "model": "gpt-4o-2024-11-20",
+        "result_counts": {"total": 50, "passed": 45, "failed": 3, "errored": 2},
+    },
+    "cancelEvalRun": {
+        "id": "evalrun_abc123def456",
+        "object": "eval.run",
+        "eval_id": "eval_abc123def456",
+        "status": "canceled",
+        "created_at": 1741312436,
+        "model": "gpt-4o-2024-11-20",
+    },
+    "deleteEvalRun": {
+        "id": "evalrun_abc123def456",
+        "object": "eval.run",
+        "deleted": True,
+    },
+    "getEvalRunOutputItems": {
+        "object": "list",
+        "data": [
+            {
+                "id": "evalrunitem_abc123",
+                "object": "eval.run.output_item",
+                "eval_run_id": "evalrun_abc123def456",
+                "status": "pass",
+                "created_at": 1741312436,
+            }
+        ],
+        "has_more": False,
+        "first_id": "evalrunitem_abc123",
+        "last_id": "evalrunitem_abc123",
+    },
+    "getEvalRunOutputItem": {
+        "id": "evalrunitem_abc123",
+        "object": "eval.run.output_item",
+        "eval_run_id": "evalrun_abc123def456",
+        "status": "pass",
+        "created_at": 1741312436,
+    },
+    # ── Graders ────────────────────────────────────────────────────────────
+    "runGrader": {
+        "result": {"score": 0.95, "passed": True, "explanation": "The response accurately answered the question."},
+    },
+    "validateGrader": {
+        "valid": True,
+        "errors": [],
+    },
+    # ── Containers ─────────────────────────────────────────────────────────
+    "createContainer": {
+        "id": "container_abc123def456",
+        "object": "container",
+        "name": "my-training-data",
+        "created_at": 1741312436,
+        "expires_after": None,
+    },
+    "listContainers": {
+        "object": "list",
+        "data": [
+            {
+                "id": "container_abc123def456",
+                "object": "container",
+                "name": "my-training-data",
+                "created_at": 1741312436,
+            }
+        ],
+        "has_more": False,
+        "first_id": "container_abc123def456",
+        "last_id": "container_abc123def456",
+    },
+    "retrieveContainer": {
+        "id": "container_abc123def456",
+        "object": "container",
+        "name": "my-training-data",
+        "created_at": 1741312436,
+        "expires_after": None,
+    },
+    "createContainerFile": {
+        "id": "container_file_abc123",
+        "object": "container.file",
+        "container_id": "container_abc123def456",
+        "path": "/data/training.jsonl",
+        "created_at": 1741312436,
+        "bytes": 2048,
+        "source": "user",
+    },
+    "listContainerFiles": {
+        "object": "list",
+        "data": [
+            {
+                "id": "container_file_abc123",
+                "object": "container.file",
+                "container_id": "container_abc123def456",
+                "path": "/data/training.jsonl",
+                "created_at": 1741312436,
+                "bytes": 2048,
+            }
+        ],
+        "has_more": False,
+        "first_id": "container_file_abc123",
+        "last_id": "container_file_abc123",
+    },
+    "retrieveContainerFile": {
+        "id": "container_file_abc123",
+        "object": "container.file",
+        "container_id": "container_abc123def456",
+        "path": "/data/training.jsonl",
+        "created_at": 1741312436,
+        "bytes": 2048,
+        "source": "user",
+    },
+    # ── Conversations ──────────────────────────────────────────────────────
+    "createConversation": {
+        "id": "conv_abc123def456",
+        "object": "conversation",
+        "created_at": 1741312436,
+        "metadata": {},
+    },
+    "retrieveConversation": {
+        "id": "conv_abc123def456",
+        "object": "conversation",
+        "created_at": 1741312436,
+        "metadata": {},
+    },
+    "updateConversation": {
+        "id": "conv_abc123def456",
+        "object": "conversation",
+        "created_at": 1741312436,
+        "metadata": {"topic": "customer-support"},
+    },
+    "deleteConversation": {
+        "id": "conv_abc123def456",
+        "object": "conversation",
+        "deleted": True,
+    },
+    "createConversationItems": {
+        "object": "list",
+        "data": [
+            {
+                "id": "convitem_abc123",
+                "object": "conversation.item",
+                "conversation_id": "conv_abc123def456",
+                "role": "user",
+                "type": "message",
+                "content": [{"type": "input_text", "text": "Hello!"}],
+                "created_at": 1741312436,
+            }
+        ],
+    },
+    "listConversationItems": {
+        "object": "list",
+        "data": [
+            {
+                "id": "convitem_abc123",
+                "object": "conversation.item",
+                "conversation_id": "conv_abc123def456",
+                "role": "user",
+                "type": "message",
+                "content": [{"type": "input_text", "text": "Hello!"}],
+                "created_at": 1741312436,
+            }
+        ],
+        "has_more": False,
+        "first_id": "convitem_abc123",
+        "last_id": "convitem_abc123",
+    },
+    "retrieveConversationItem": {
+        "id": "convitem_abc123",
+        "object": "conversation.item",
+        "conversation_id": "conv_abc123def456",
+        "role": "user",
+        "type": "message",
+        "content": [{"type": "input_text", "text": "Hello!"}],
+        "created_at": 1741312436,
+    },
+    "deleteConversationItem": {
+        "id": "convitem_abc123",
+        "object": "conversation.item",
+        "deleted": True,
+    },
+    # ── Vector Stores ──────────────────────────────────────────────────────
+    "createVectorStore": {
+        "id": "vs_abc123def456",
+        "object": "vector_store",
+        "name": "Product Knowledge Base",
+        "created_at": 1741312436,
+        "status": "completed",
+        "usage_bytes": 0,
+        "file_counts": {"in_progress": 0, "completed": 0, "failed": 0, "cancelled": 0, "total": 0},
+    },
+    "listVectorStores": {
+        "object": "list",
+        "data": [
+            {
+                "id": "vs_abc123def456",
+                "object": "vector_store",
+                "name": "Product Knowledge Base",
+                "created_at": 1741312436,
+                "status": "completed",
+                "usage_bytes": 123456,
+                "file_counts": {"in_progress": 0, "completed": 3, "failed": 0, "cancelled": 0, "total": 3},
+            }
+        ],
+        "has_more": False,
+        "first_id": "vs_abc123def456",
+        "last_id": "vs_abc123def456",
+    },
+    "getVectorStore": {
+        "id": "vs_abc123def456",
+        "object": "vector_store",
+        "name": "Product Knowledge Base",
+        "created_at": 1741312436,
+        "status": "completed",
+        "usage_bytes": 123456,
+        "file_counts": {"in_progress": 0, "completed": 3, "failed": 0, "cancelled": 0, "total": 3},
+    },
+    "modifyVectorStore": {
+        "id": "vs_abc123def456",
+        "object": "vector_store",
+        "name": "Updated Knowledge Base",
+        "created_at": 1741312436,
+        "status": "completed",
+        "usage_bytes": 123456,
+        "file_counts": {"in_progress": 0, "completed": 3, "failed": 0, "cancelled": 0, "total": 3},
+    },
+    "deleteVectorStore": {
+        "id": "vs_abc123def456",
+        "object": "vector_store",
+        "deleted": True,
+    },
+    "createVectorStoreFile": {
+        "id": "file-vs-abc123",
+        "object": "vector_store.file",
+        "vector_store_id": "vs_abc123def456",
+        "created_at": 1741312436,
+        "status": "in_progress",
+        "usage_bytes": 0,
+    },
+    "listVectorStoreFiles": {
+        "object": "list",
+        "data": [
+            {
+                "id": "file-vs-abc123",
+                "object": "vector_store.file",
+                "vector_store_id": "vs_abc123def456",
+                "created_at": 1741312436,
+                "status": "completed",
+                "usage_bytes": 12345,
+            }
+        ],
+        "has_more": False,
+        "first_id": "file-vs-abc123",
+        "last_id": "file-vs-abc123",
+    },
+    "getVectorStoreFile": {
+        "id": "file-vs-abc123",
+        "object": "vector_store.file",
+        "vector_store_id": "vs_abc123def456",
+        "created_at": 1741312436,
+        "status": "completed",
+        "usage_bytes": 12345,
+    },
+    "updateVectorStoreFileAttributes": {
+        "id": "file-vs-abc123",
+        "object": "vector_store.file",
+        "vector_store_id": "vs_abc123def456",
+        "created_at": 1741312436,
+        "status": "completed",
+        "usage_bytes": 12345,
+        "attributes": {"category": "product-docs"},
+    },
+    "deleteVectorStoreFile": {
+        "id": "file-vs-abc123",
+        "object": "vector_store.file",
+        "deleted": True,
+    },
+    "retrieveVectorStoreFileContent": {
+        "content": "This is the content of the file stored in the vector store.",
+    },
+    "searchVectorStore": {
+        "object": "vector_store.search_results.page",
+        "data": [
+            {
+                "file_id": "file-vs-abc123",
+                "filename": "product-docs.pdf",
+                "score": 0.92,
+                "content": [{"type": "text", "text": "Our product supports both REST API and SDK integrations."}],
+                "attributes": {},
+            }
+        ],
+        "has_more": False,
+    },
+    "createVectorStoreFileBatch": {
+        "id": "vsfb_abc123def456",
+        "object": "vector_store.file_batch",
+        "vector_store_id": "vs_abc123def456",
+        "created_at": 1741312436,
+        "status": "in_progress",
+        "file_counts": {"in_progress": 3, "completed": 0, "failed": 0, "cancelled": 0, "total": 3},
+    },
+    "getVectorStoreFileBatch": {
+        "id": "vsfb_abc123def456",
+        "object": "vector_store.file_batch",
+        "vector_store_id": "vs_abc123def456",
+        "created_at": 1741312436,
+        "status": "completed",
+        "file_counts": {"in_progress": 0, "completed": 3, "failed": 0, "cancelled": 0, "total": 3},
+    },
+    "cancelVectorStoreFileBatch": {
+        "id": "vsfb_abc123def456",
+        "object": "vector_store.file_batch",
+        "vector_store_id": "vs_abc123def456",
+        "created_at": 1741312436,
+        "status": "cancelling",
+        "file_counts": {"in_progress": 1, "completed": 2, "failed": 0, "cancelled": 0, "total": 3},
+    },
+    "listFilesInVectorStoreBatch": {
+        "object": "list",
+        "data": [
+            {
+                "id": "file-vs-abc123",
+                "object": "vector_store.file",
+                "vector_store_id": "vs_abc123def456",
+                "created_at": 1741312436,
+                "status": "completed",
+                "usage_bytes": 12345,
+            }
+        ],
+        "has_more": False,
+        "first_id": "file-vs-abc123",
+        "last_id": "file-vs-abc123",
+    },
+    # ── Threads / Assistants (legacy) ──────────────────────────────────────
+    "createThread": {
+        "id": "thread_abc123def456",
+        "object": "thread",
+        "created_at": 1741312436,
+        "metadata": {},
+    },
+    "retrieveThread": {
+        "id": "thread_abc123def456",
+        "object": "thread",
+        "created_at": 1741312436,
+        "metadata": {},
+    },
+    "modifyThread": {
+        "id": "thread_abc123def456",
+        "object": "thread",
+        "created_at": 1741312436,
+        "metadata": {"project": "my-project"},
+    },
+    "deleteThread": {
+        "id": "thread_abc123def456",
+        "object": "thread",
+        "deleted": True,
+    },
+    "createMessage": {
+        "id": "msg_abc123def456",
+        "object": "thread.message",
+        "created_at": 1741312436,
+        "thread_id": "thread_abc123def456",
+        "role": "user",
+        "content": [{"type": "text", "text": {"value": "What is the weather today?", "annotations": []}}],
+        "status": "completed",
+    },
+    "listMessages": {
+        "object": "list",
+        "data": [
+            {
+                "id": "msg_abc123def456",
+                "object": "thread.message",
+                "created_at": 1741312436,
+                "thread_id": "thread_abc123def456",
+                "role": "assistant",
+                "content": [{"type": "text", "text": {"value": "Hello! How can I help you?", "annotations": []}}],
+                "status": "completed",
+            }
+        ],
+        "has_more": False,
+        "first_id": "msg_abc123def456",
+        "last_id": "msg_abc123def456",
+    },
+    "retrieveMessage": {
+        "id": "msg_abc123def456",
+        "object": "thread.message",
+        "created_at": 1741312436,
+        "thread_id": "thread_abc123def456",
+        "role": "user",
+        "content": [{"type": "text", "text": {"value": "What is the weather today?", "annotations": []}}],
+        "status": "completed",
+    },
+    "modifyMessage": {
+        "id": "msg_abc123def456",
+        "object": "thread.message",
+        "created_at": 1741312436,
+        "thread_id": "thread_abc123def456",
+        "role": "user",
+        "content": [{"type": "text", "text": {"value": "What is the weather today?", "annotations": []}}],
+        "status": "completed",
+        "metadata": {"priority": "high"},
+    },
+    "deleteMessage": {
+        "id": "msg_abc123def456",
+        "object": "thread.message",
+        "deleted": True,
+    },
+    "createRun": {
+        "id": "run_abc123def456",
+        "object": "thread.run",
+        "created_at": 1741312436,
+        "thread_id": "thread_abc123def456",
+        "assistant_id": "asst_abc123def456",
+        "status": "queued",
+        "model": "gpt-4o",
+    },
+    "listRuns": {
+        "object": "list",
+        "data": [
+            {
+                "id": "run_abc123def456",
+                "object": "thread.run",
+                "created_at": 1741312436,
+                "thread_id": "thread_abc123def456",
+                "assistant_id": "asst_abc123def456",
+                "status": "completed",
+                "model": "gpt-4o",
+            }
+        ],
+        "has_more": False,
+        "first_id": "run_abc123def456",
+        "last_id": "run_abc123def456",
+    },
+    "retrieveRun": {
+        "id": "run_abc123def456",
+        "object": "thread.run",
+        "created_at": 1741312436,
+        "thread_id": "thread_abc123def456",
+        "assistant_id": "asst_abc123def456",
+        "status": "completed",
+        "model": "gpt-4o",
+    },
+    "modifyRun": {
+        "id": "run_abc123def456",
+        "object": "thread.run",
+        "created_at": 1741312436,
+        "thread_id": "thread_abc123def456",
+        "assistant_id": "asst_abc123def456",
+        "status": "completed",
+        "model": "gpt-4o",
+        "metadata": {"run_type": "evaluation"},
+    },
+    "cancelRun": {
+        "id": "run_abc123def456",
+        "object": "thread.run",
+        "created_at": 1741312436,
+        "thread_id": "thread_abc123def456",
+        "assistant_id": "asst_abc123def456",
+        "status": "cancelling",
+        "model": "gpt-4o",
+    },
+    "submitToolOutputsToRun": {
+        "id": "run_abc123def456",
+        "object": "thread.run",
+        "created_at": 1741312436,
+        "thread_id": "thread_abc123def456",
+        "assistant_id": "asst_abc123def456",
+        "status": "queued",
+        "model": "gpt-4o",
+    },
+    "createThreadAndRun": {
+        "id": "run_abc123def456",
+        "object": "thread.run",
+        "created_at": 1741312436,
+        "thread_id": "thread_xyz789ghi012",
+        "assistant_id": "asst_abc123def456",
+        "status": "queued",
+        "model": "gpt-4o",
+    },
+    "listRunSteps": {
+        "object": "list",
+        "data": [
+            {
+                "id": "step_abc123def456",
+                "object": "thread.run.step",
+                "created_at": 1741312436,
+                "run_id": "run_abc123def456",
+                "assistant_id": "asst_abc123def456",
+                "thread_id": "thread_abc123def456",
+                "type": "message_creation",
+                "status": "completed",
+                "step_details": {
+                    "type": "message_creation",
+                    "message_creation": {"message_id": "msg_abc123def456"},
+                },
+            }
+        ],
+        "has_more": False,
+        "first_id": "step_abc123def456",
+        "last_id": "step_abc123def456",
+    },
+    "getRunStep": {
+        "id": "step_abc123def456",
+        "object": "thread.run.step",
+        "created_at": 1741312436,
+        "run_id": "run_abc123def456",
+        "assistant_id": "asst_abc123def456",
+        "thread_id": "thread_abc123def456",
+        "type": "message_creation",
+        "status": "completed",
+        "step_details": {
+            "type": "message_creation",
+            "message_creation": {"message_id": "msg_abc123def456"},
+        },
+    },
+    # ── Realtime ───────────────────────────────────────────────────────────
+    "createRealtimeSession": {
+        "id": "sess_abc123def456",
+        "object": "realtime.session",
+        "model": "gpt-4o-realtime-preview",
+        "modalities": ["text", "audio"],
+        "voice": "alloy",
+        "input_audio_format": "pcm16",
+        "output_audio_format": "pcm16",
+        "turn_detection": {"type": "server_vad"},
+    },
+    "createRealtimeClientSecret": {
+        "id": "sess_abc123def456",
+        "object": "realtime.session",
+        "client_secret": {
+            "value": "ek_abc123def456ghi789",
+            "expires_at": 1741316036,
+        },
+    },
+    "createRealtimeTranscriptionSession": {
+        "id": "sess_trans_abc123",
+        "object": "realtime.transcription_session",
+        "model": "gpt-4o-transcribe",
+        "input_audio_format": "pcm16",
+    },
+    # ── Audio (preview only) ───────────────────────────────────────────────
+    "createTranscription": {
+        "text": "Hello, this is a transcription of the audio file.",
+    },
+    "createTranslation": {
+        "text": "Hello, this is the English translation of the audio.",
+    },
+    # ── Images (preview only) ─────────────────────────────────────────────
+    "createImage": {
+        "created": 1741312436,
+        "data": [
+            {
+                "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/generated-image.png",
+                "revised_prompt": "A beautiful sunset over the ocean with vibrant orange and purple hues.",
+            }
+        ],
+    },
+    "createImageEdit": {
+        "created": 1741312436,
+        "data": [
+            {
+                "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/edited-image.png",
+            }
+        ],
+    },
+    "createImageVariation": {
+        "created": 1741312436,
+        "data": [
+            {
+                "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/variation-image.png",
+            }
+        ],
+    },
+    # ── Videos (preview only) ─────────────────────────────────────────────
+    "Videos_Create": {
+        "id": "video_abc123def456",
+        "object": "video",
+        "status": "queued",
+        "created_at": 1741312436,
+        "model": "sora",
+        "prompt": "A serene lake surrounded by mountains at sunrise.",
+    },
+    "Videos_List": {
+        "object": "list",
+        "data": [
+            {
+                "id": "video_abc123def456",
+                "object": "video",
+                "status": "completed",
+                "created_at": 1741312436,
+                "model": "sora",
+            }
+        ],
+        "has_more": False,
+        "first_id": "video_abc123def456",
+        "last_id": "video_abc123def456",
+    },
+    "Videos_Get": {
+        "id": "video_abc123def456",
+        "object": "video",
+        "status": "completed",
+        "created_at": 1741312436,
+        "model": "sora",
+        "prompt": "A serene lake surrounded by mountains at sunrise.",
+    },
+    "Videos_Delete": {
+        "id": "video_abc123def456",
+        "object": "video",
+        "deleted": True,
+    },
+    "Videos_Remix": {
+        "id": "video_remix123",
+        "object": "video",
+        "status": "queued",
+        "created_at": 1741312436,
+        "model": "sora",
+        "prompt": "Same scene but at sunset with warm colors.",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Projects API response examples keyed by operationId
+# ---------------------------------------------------------------------------
+PROJECTS_RESPONSE_EXAMPLES: dict = {
+    # ── Connections ────────────────────────────────────────────────────────
+    "Connections_List": {
+        "value": [
+            {
+                "name": "my-aoai-connection",
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+                "type": "AzureOpenAI",
+                "properties": {
+                    "category": "AzureOpenAI",
+                    "target": "https://my-aoai.openai.azure.com/",
+                    "authType": "ApiKey",
+                },
+            }
+        ],
+    },
+    "Connections_Get": {
+        "name": "my-aoai-connection",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+        "type": "AzureOpenAI",
+        "properties": {
+            "category": "AzureOpenAI",
+            "target": "https://my-aoai.openai.azure.com/",
+            "authType": "ApiKey",
+        },
+    },
+    "Connections_GetWithCredentials": {
+        "name": "my-aoai-connection",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-project/connections/my-aoai-connection",
+        "type": "AzureOpenAI",
+        "properties": {
+            "category": "AzureOpenAI",
+            "target": "https://my-aoai.openai.azure.com/",
+            "authType": "ApiKey",
+            "credentials": {"key": "YOUR_API_KEY"},
+        },
+    },
+    # ── Datasets ───────────────────────────────────────────────────────────
+    "Datasets_ListLatest": {
+        "value": [
+            {
+                "name": "my-dataset",
+                "version": "1",
+                "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/",
+                "type": "uri_folder",
+                "tags": {"purpose": "training"},
+            }
+        ],
+    },
+    "Datasets_ListVersions": {
+        "value": [
+            {
+                "name": "my-dataset",
+                "version": "1",
+                "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+                "type": "uri_folder",
+            },
+            {
+                "name": "my-dataset",
+                "version": "2",
+                "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v2/",
+                "type": "uri_folder",
+            },
+        ],
+    },
+    "Datasets_GetVersion": {
+        "name": "my-dataset",
+        "version": "1",
+        "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+        "type": "uri_folder",
+        "tags": {"purpose": "training"},
+    },
+    "Datasets_CreateOrUpdateVersion": {
+        "name": "my-dataset",
+        "version": "1",
+        "uri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+        "type": "uri_folder",
+        "tags": {"purpose": "training"},
+    },
+    "Datasets_GetCredentials": {
+        "credentials": {
+            "sasUri": "https://my-storage.blob.core.windows.net/datasets/my-dataset?sv=2023-01-01&sig=YOUR_SAS_TOKEN",
+        },
+    },
+    "Datasets_StartPendingUploadVersion": {
+        "blobReference": {
+            "blobUri": "https://my-storage.blob.core.windows.net/datasets/my-dataset/v1/",
+            "credential": {
+                "sasUri": "https://my-storage.blob.core.windows.net/datasets?sv=2023-01-01&sig=YOUR_SAS_TOKEN",
+            },
+        },
+    },
+    # ── Deployments ────────────────────────────────────────────────────────
+    "Deployments_List": {
+        "value": [
+            {
+                "name": "gpt-4o",
+                "type": "Azure.OpenAI",
+                "model": {"name": "gpt-4o", "version": "2024-11-20", "format": "OpenAI"},
+                "properties": {"provisioningState": "Succeeded"},
+            },
+            {
+                "name": "text-embedding-3-large",
+                "type": "Azure.OpenAI",
+                "model": {"name": "text-embedding-3-large", "version": "1", "format": "OpenAI"},
+                "properties": {"provisioningState": "Succeeded"},
+            },
+        ],
+    },
+    "Deployments_Get": {
+        "name": "gpt-4o",
+        "type": "Azure.OpenAI",
+        "model": {"name": "gpt-4o", "version": "2024-11-20", "format": "OpenAI"},
+        "properties": {"provisioningState": "Succeeded"},
+    },
+    # ── Indexes ────────────────────────────────────────────────────────────
+    "Indexes_ListLatest": {
+        "value": [
+            {
+                "name": "my-search-index",
+                "version": "1",
+                "type": "AzureSearch",
+                "tags": {"domain": "product-docs"},
+            }
+        ],
+    },
+    "Indexes_ListVersions": {
+        "value": [
+            {
+                "name": "my-search-index",
+                "version": "1",
+                "type": "AzureSearch",
+            },
+            {
+                "name": "my-search-index",
+                "version": "2",
+                "type": "AzureSearch",
+            },
+        ],
+    },
+    "Indexes_GetVersion": {
+        "name": "my-search-index",
+        "version": "1",
+        "type": "AzureSearch",
+        "tags": {"domain": "product-docs"},
+    },
+    "Indexes_CreateOrUpdateVersion": {
+        "name": "my-search-index",
+        "version": "1",
+        "type": "AzureSearch",
+        "tags": {"domain": "product-docs"},
+    },
+    # ── Evaluations (preview only) ─────────────────────────────────────────
+    "Evaluations_List": {
+        "value": [
+            {
+                "id": "eval-abc123def456",
+                "displayName": "Chat Quality Evaluation",
+                "status": "Completed",
+                "tags": {"domain": "customer-support"},
+            }
+        ],
+    },
+    "Evaluations_Get": {
+        "id": "eval-abc123def456",
+        "displayName": "Chat Quality Evaluation",
+        "status": "Completed",
+        "tags": {"domain": "customer-support"},
+    },
+    "Evaluations_Create": {
+        "id": "eval-abc123def456",
+        "displayName": "Chat Quality Evaluation",
+        "status": "Queued",
+        "tags": {"domain": "customer-support"},
+    },
+    "Evaluations_CreateAgentEvaluation": {
+        "id": "agenteval-abc123",
+        "displayName": "Agent Performance Evaluation",
+        "status": "Queued",
+    },
+    # ── Red Teams (preview only) ───────────────────────────────────────────
+    "RedTeams_List": {
+        "value": [
+            {
+                "id": "redteam-abc123def456",
+                "displayName": "Safety Red Team",
+                "status": "Completed",
+            }
+        ],
+    },
+    "RedTeams_Get": {
+        "id": "redteam-abc123def456",
+        "displayName": "Safety Red Team",
+        "status": "Completed",
+    },
+    "RedTeams_Create": {
+        "id": "redteam-abc123def456",
+        "displayName": "Safety Red Team",
+        "status": "Queued",
+    },
+}
+
+
+def add_examples_to_spec(spec_path: str) -> tuple[int, int]:
+    """Add response examples to an OpenAPI spec file.
+
+    Returns (total_operations, examples_added) counts.
+    """
+    with open(spec_path) as f:
+        spec = json.load(f)
+
+    is_projects = "projects" in Path(spec_path).name.lower()
+    examples = PROJECTS_RESPONSE_EXAMPLES if is_projects else OPENAI_RESPONSE_EXAMPLES
+
+    total = 0
+    added = 0
+
+    for _path, methods in spec.get("paths", {}).items():
+        for method, details in methods.items():
+            if method not in ("get", "post", "put", "patch", "delete"):
+                continue
+
+            operation_id = details.get("operationId")
+            if not operation_id:
+                continue
+
+            for code in ("200", "201"):
+                resp = details.get("responses", {}).get(code)
+                if not resp:
+                    continue
+
+                content = resp.get("content", {}).get("application/json")
+                if not content:
+                    continue
+
+                total += 1
+
+                if "example" in content or "examples" in content:
+                    continue
+
+                example = examples.get(operation_id)
+                if example:
+                    content["example"] = example
+                    added += 1
+
+    with open(spec_path, "w") as f:
+        json.dump(spec, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    return total, added
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <spec.json> [<spec.json> ...]", file=sys.stderr)
+        sys.exit(1)
+
+    for path in sys.argv[1:]:
+        total, added = add_examples_to_spec(path)
+        remaining = total - added
+        print(f"{path}: {total} operations, {added} examples added, {remaining} without examples")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_sdk_samples.py
+++ b/scripts/generate_sdk_samples.py
@@ -75,12 +75,10 @@ OPENAI_SAMPLES = {
         '    input="What is the capital of France?",\n'
         ')\n'
         'print(response.output_text)\n'
-        '# Output: "The capital of France is Paris."'
     ),
     "getResponse": (
         'response = openai.responses.retrieve("resp_abc123")\n'
         'print(response.status, response.output_text)\n'
-        '# Output: completed The capital of France is Paris.'
     ),
     "deleteResponse": (
         'openai.responses.delete("resp_abc123")'
@@ -101,7 +99,6 @@ OPENAI_SAMPLES = {
         '    messages=[{"role": "user", "content": "Hello!"}],\n'
         ')\n'
         'print(response.choices[0].message.content)\n'
-        '# Output: "Hello! How can I help you today?"'
     ),
 
     # ── Completions (legacy) ───────────────────────────────────────────
@@ -120,7 +117,6 @@ OPENAI_SAMPLES = {
         '    items=[{"type": "message", "role": "user", "content": "Hello"}],\n'
         ')\n'
         'print(conversation.id)\n'
-        '# Output: conv_abc123def456'
     ),
     "retrieveConversation": (
         'conversation = openai.conversations.retrieve("conv_abc123")\n'
@@ -168,7 +164,6 @@ OPENAI_SAMPLES = {
         '    input="Sample text to embed",\n'
         ')\n'
         'print(response.data[0].embedding[:5])\n'
-        '# Output: [-0.0128, -0.0074, -0.0176, -0.0283, -0.0187]'
     ),
 
     # ── Models ─────────────────────────────────────────────────────────
@@ -176,10 +171,6 @@ OPENAI_SAMPLES = {
         'models = openai.models.list()\n'
         'for model in models:\n'
         '    print(model.id)\n'
-        '# Output:\n'
-        '# gpt-4o\n'
-        '# gpt-4o-mini\n'
-        '# text-embedding-3-large'
     ),
     "retrieveModel": (
         'model = openai.models.retrieve("gpt-4o")\n'
@@ -196,7 +187,6 @@ OPENAI_SAMPLES = {
         '    purpose="fine-tune",\n'
         ')\n'
         'print(file.id)\n'
-        '# Output: file-abc123def456'
     ),
     "listFiles": (
         'files = openai.files.list()\n'
@@ -223,7 +213,6 @@ OPENAI_SAMPLES = {
         '    completion_window="24h",\n'
         ')\n'
         'print(batch.id, batch.status)\n'
-        '# Output: batch_abc123 validating'
     ),
     "listBatches": (
         'batches = openai.batches.list()\n'
@@ -245,7 +234,6 @@ OPENAI_SAMPLES = {
         '    training_file="file-abc123",\n'
         ')\n'
         'print(job.id, job.status)\n'
-        '# Output: ftjob-abc123 validating_files'
     ),
     "listPaginatedFineTuningJobs": (
         'jobs = openai.fine_tuning.jobs.list()\n'
@@ -1065,6 +1053,8 @@ def main():
         CSHARP_PROJECTS_PREAMBLE_ENTRA, CSHARP_PROJECTS_PREAMBLE_APIKEY, CSHARP_PROJECTS_SAMPLES,
         JS_OPENAI_PREAMBLE_ENTRA, JS_OPENAI_PREAMBLE_APIKEY, JS_OPENAI_SAMPLES,
         JS_PROJECTS_PREAMBLE_ENTRA, JS_PROJECTS_PREAMBLE_APIKEY, JS_PROJECTS_SAMPLES,
+        JAVA_OPENAI_PREAMBLE_ENTRA, JAVA_OPENAI_PREAMBLE_APIKEY, JAVA_OPENAI_SAMPLES,
+        JAVA_PROJECTS_PREAMBLE_ENTRA, JAVA_PROJECTS_PREAMBLE_APIKEY, JAVA_PROJECTS_SAMPLES,
     )
 
     # Language configs: (lang, label, samples_dict, preamble_entra, preamble_apikey)
@@ -1074,6 +1064,7 @@ def main():
         ("bash", "cURL", CURL_OPENAI_SAMPLES, CURL_OPENAI_PREAMBLE_ENTRA, CURL_OPENAI_PREAMBLE_APIKEY),
         ("csharp", "C#", CSHARP_OPENAI_SAMPLES, CSHARP_OPENAI_PREAMBLE_ENTRA, CSHARP_OPENAI_PREAMBLE_APIKEY),
         ("javascript", "JavaScript", JS_OPENAI_SAMPLES, JS_OPENAI_PREAMBLE_ENTRA, JS_OPENAI_PREAMBLE_APIKEY),
+        ("java", "Java", JAVA_OPENAI_SAMPLES, JAVA_OPENAI_PREAMBLE_ENTRA, JAVA_OPENAI_PREAMBLE_APIKEY),
     ]
 
     # Language configs for Projects specs
@@ -1082,6 +1073,7 @@ def main():
         ("bash", "cURL", CURL_PROJECTS_SAMPLES, CURL_PROJECTS_PREAMBLE_ENTRA, CURL_PROJECTS_PREAMBLE_APIKEY),
         ("csharp", "C#", CSHARP_PROJECTS_SAMPLES, CSHARP_PROJECTS_PREAMBLE_ENTRA, CSHARP_PROJECTS_PREAMBLE_APIKEY),
         ("javascript", "JavaScript", JS_PROJECTS_SAMPLES, JS_PROJECTS_PREAMBLE_ENTRA, JS_PROJECTS_PREAMBLE_APIKEY),
+        ("java", "Java", JAVA_PROJECTS_SAMPLES, JAVA_PROJECTS_PREAMBLE_ENTRA, JAVA_PROJECTS_PREAMBLE_APIKEY),
     ]
 
     total = 0

--- a/scripts/sdk_samples_multilang.py
+++ b/scripts/sdk_samples_multilang.py
@@ -9,21 +9,15 @@ in generate_sdk_samples.py, keyed by the same operationId values.
 # ---------------------------------------------------------------------------
 
 CURL_OPENAI_PREAMBLE_ENTRA = """\
-# Get a token via Azure CLI
-# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)
 """
 
 CURL_OPENAI_PREAMBLE_APIKEY = """\
-# Use your API key from the Azure portal
 """
 
 CURL_PROJECTS_PREAMBLE_ENTRA = """\
-# Get a token via Azure CLI
-# TOKEN=$(az account get-access-token --scope https://cognitiveservices.azure.com/.default --query accessToken -o tsv)
 """
 
 CURL_PROJECTS_PREAMBLE_APIKEY = """\
-# Use your API key from the Azure portal
 """
 
 CSHARP_OPENAI_PREAMBLE_ENTRA = """\
@@ -310,16 +304,831 @@ CURL_PROJECTS_SAMPLES = {
 # ---------------------------------------------------------------------------
 
 CSHARP_OPENAI_SAMPLES = {
-    "createResponse": 'var responsesClient = client.OpenAI\n    .GetProjectResponsesClientForModel("gpt-4o");\n\nvar response = await responsesClient\n    .CreateResponseAsync("What is the capital of France?");\n\nConsole.WriteLine(response.GetOutputText());',
-    "createChatCompletion": 'var chatClient = client.OpenAI\n    .GetProjectChatClientForModel("gpt-4o");\n\nvar response = await chatClient.CompleteChatAsync(\n    new ChatMessage[] {\n        new UserChatMessage("Hello!"),\n    });\n\nConsole.WriteLine(response.Value.Content[0].Text);',
-    "createEmbedding": 'var embeddingClient = client.OpenAI\n    .GetProjectEmbeddingClientForModel("text-embedding-3-large");\n\nvar response = await embeddingClient\n    .GenerateEmbeddingAsync("Sample text to embed");\n\nConsole.WriteLine(response.Value.Vector.Length);',
-    "createConversation": 'var conversation = client.OpenAI.Conversations\n    .CreateProjectConversation();\n\nConsole.WriteLine(conversation.Id);',
-    "listModels": 'var models = client.OpenAI.GetOpenAIModelClient()\n    .GetModels();\n\nforeach (var model in models.Value)\n    Console.WriteLine(model.Id);',
-    "createFile": 'var fileClient = client.OpenAI.GetOpenAIFileClient();\n\nvar file = await fileClient.UploadFileAsync(\n    "data.jsonl", FileUploadPurpose.FineTune);\n\nConsole.WriteLine(file.Value.Id);',
-    "listFiles": 'var fileClient = client.OpenAI.GetOpenAIFileClient();\nvar files = await fileClient.GetFilesAsync();\n\nforeach (var f in files.Value)\n    Console.WriteLine($"{f.Id} {f.Filename}");',
-    "createBatch": 'var batchClient = client.OpenAI.GetBatchClient();\n\nvar batch = await batchClient.CreateBatchAsync(\n    "file-abc123", "/v1/chat/completions", "24h");\n\nConsole.WriteLine(batch.Value.Id);',
-    "createFineTuningJob": 'var ftClient = client.OpenAI.GetFineTuningClient();\n\nvar job = await ftClient.CreateJobAsync(\n    "gpt-4o-mini-2024-07-18", "file-abc123");\n\nConsole.WriteLine(job.Value.Id);',
-    "createVectorStore": 'var vsClient = client.OpenAI.GetVectorStoreClient();\n\nvar store = await vsClient.CreateVectorStoreAsync(\n    new VectorStoreCreationOptions { Name = "my-store" });\n\nConsole.WriteLine(store.Value.Id);',
+    # ── Responses ─────────────────────────────────────────────────────
+    "createResponse": (
+        'var responsesClient = client.OpenAI\n'
+        '    .GetProjectResponsesClientForModel("gpt-4o");\n'
+        '\n'
+        'var response = await responsesClient\n'
+        '    .CreateResponseAsync("What is the capital of France?");\n'
+        '\n'
+        'Console.WriteLine(response.GetOutputText());'
+    ),
+    "getResponse": (
+        'var responsesClient = client.OpenAI\n'
+        '    .GetProjectResponsesClientForModel("gpt-4o");\n'
+        '\n'
+        'var response = await responsesClient\n'
+        '    .GetResponseAsync("resp_abc123");\n'
+        '\n'
+        'Console.WriteLine(response.Value.Status);'
+    ),
+    "deleteResponse": (
+        'var responsesClient = client.OpenAI\n'
+        '    .GetProjectResponsesClientForModel("gpt-4o");\n'
+        '\n'
+        'await responsesClient.DeleteResponseAsync("resp_abc123");'
+    ),
+    "cancelResponse": (
+        'var responsesClient = client.OpenAI\n'
+        '    .GetProjectResponsesClientForModel("gpt-4o");\n'
+        '\n'
+        'await responsesClient.CancelResponseAsync("resp_abc123");'
+    ),
+    "listInputItems": (
+        'var responsesClient = client.OpenAI\n'
+        '    .GetProjectResponsesClientForModel("gpt-4o");\n'
+        '\n'
+        'var items = responsesClient.GetResponseInputItems("resp_abc123");\n'
+        '\n'
+        'foreach (var item in items)\n'
+        '    Console.WriteLine(item.Id);'
+    ),
+
+    # ── Chat ──────────────────────────────────────────────────────────
+    "createChatCompletion": (
+        'var chatClient = client.OpenAI\n'
+        '    .GetProjectChatClientForModel("gpt-4o");\n'
+        '\n'
+        'var response = await chatClient.CompleteChatAsync(\n'
+        '    new ChatMessage[] {\n'
+        '        new UserChatMessage("Hello!"),\n'
+        '    });\n'
+        '\n'
+        'Console.WriteLine(response.Value.Content[0].Text);'
+    ),
+    "createCompletion": (
+        'var chatClient = client.OpenAI\n'
+        '    .GetProjectChatClientForModel("gpt-4o");\n'
+        '\n'
+        'var response = await chatClient.CompleteChatAsync(\n'
+        '    new ChatMessage[] {\n'
+        '        new UserChatMessage("Say hello"),\n'
+        '    });\n'
+        '\n'
+        'Console.WriteLine(response.Value.Content[0].Text);'
+    ),
+
+    # ── Conversations ─────────────────────────────────────────────────
+    "createConversation": (
+        'var conversation = client.OpenAI.Conversations\n'
+        '    .CreateProjectConversation();\n'
+        '\n'
+        'Console.WriteLine(conversation.Id);'
+    ),
+    "retrieveConversation": (
+        'var conversation = client.OpenAI.Conversations\n'
+        '    .GetConversation("conv_abc123");\n'
+        '\n'
+        'Console.WriteLine(conversation.Id);'
+    ),
+    "updateConversation": (
+        'var conversation = client.OpenAI.Conversations\n'
+        '    .UpdateConversation("conv_abc123",\n'
+        '        new { metadata = new { topic = "geography" } });\n'
+        '\n'
+        'Console.WriteLine(conversation.Id);'
+    ),
+    "deleteConversation": (
+        'client.OpenAI.Conversations\n'
+        '    .DeleteConversation("conv_abc123");'
+    ),
+    "listConversationItems": (
+        'var items = client.OpenAI.Conversations\n'
+        '    .GetConversationItems("conv_abc123");\n'
+        '\n'
+        'foreach (var item in items)\n'
+        '    Console.WriteLine($"{item.Type} {item.Id}");'
+    ),
+    "createConversationItems": (
+        'client.OpenAI.Conversations\n'
+        '    .CreateConversationItems("conv_abc123",\n'
+        '        new { items = new[] {\n'
+        '            new { type = "message", role = "user", content = "Follow-up" }\n'
+        '        }});'
+    ),
+    "retrieveConversationItem": (
+        'var item = client.OpenAI.Conversations\n'
+        '    .GetConversationItem("conv_abc123", "item_abc123");\n'
+        '\n'
+        'Console.WriteLine(item.Type);'
+    ),
+    "deleteConversationItem": (
+        'client.OpenAI.Conversations\n'
+        '    .DeleteConversationItem("conv_abc123", "item_abc123");'
+    ),
+
+    # ── Embeddings ────────────────────────────────────────────────────
+    "createEmbedding": (
+        'var embeddingClient = client.OpenAI\n'
+        '    .GetProjectEmbeddingClientForModel("text-embedding-3-large");\n'
+        '\n'
+        'var response = await embeddingClient\n'
+        '    .GenerateEmbeddingAsync("Sample text to embed");\n'
+        '\n'
+        'Console.WriteLine(response.Value.Vector.Length);'
+    ),
+
+    # ── Models ────────────────────────────────────────────────────────
+    "listModels": (
+        'var models = client.OpenAI.GetOpenAIModelClient()\n'
+        '    .GetModels();\n'
+        '\n'
+        'foreach (var model in models.Value)\n'
+        '    Console.WriteLine(model.Id);'
+    ),
+    "retrieveModel": (
+        'var model = client.OpenAI.GetOpenAIModelClient()\n'
+        '    .GetModel("gpt-4o");\n'
+        '\n'
+        'Console.WriteLine($"{model.Value.Id} {model.Value.OwnedBy}");'
+    ),
+    "deleteModel": (
+        'client.OpenAI.GetOpenAIModelClient()\n'
+        '    .DeleteModel("ft:gpt-4o:your-org:custom-suffix:id");'
+    ),
+
+    # ── Files ─────────────────────────────────────────────────────────
+    "createFile": (
+        'var fileClient = client.OpenAI.GetOpenAIFileClient();\n'
+        '\n'
+        'var file = await fileClient.UploadFileAsync(\n'
+        '    "data.jsonl", FileUploadPurpose.FineTune);\n'
+        '\n'
+        'Console.WriteLine(file.Value.Id);'
+    ),
+    "listFiles": (
+        'var fileClient = client.OpenAI.GetOpenAIFileClient();\n'
+        'var files = await fileClient.GetFilesAsync();\n'
+        '\n'
+        'foreach (var f in files.Value)\n'
+        '    Console.WriteLine($"{f.Id} {f.Filename}");'
+    ),
+    "retrieveFile": (
+        'var fileClient = client.OpenAI.GetOpenAIFileClient();\n'
+        'var file = await fileClient.GetFileAsync("file-abc123");\n'
+        '\n'
+        'Console.WriteLine($"{file.Value.Filename} {file.Value.Status}");'
+    ),
+    "deleteFile": (
+        'var fileClient = client.OpenAI.GetOpenAIFileClient();\n'
+        'await fileClient.DeleteFileAsync("file-abc123");'
+    ),
+    "downloadFile": (
+        'var fileClient = client.OpenAI.GetOpenAIFileClient();\n'
+        'var content = await fileClient.DownloadFileAsync("file-abc123");\n'
+        '\n'
+        'Console.WriteLine(content.Value.ToString());'
+    ),
+
+    # ── Batch ─────────────────────────────────────────────────────────
+    "createBatch": (
+        'var batchClient = client.OpenAI.GetBatchClient();\n'
+        '\n'
+        'var batch = await batchClient.CreateBatchAsync(\n'
+        '    "file-abc123", "/v1/chat/completions", "24h");\n'
+        '\n'
+        'Console.WriteLine(batch.Value.Id);'
+    ),
+    "listBatches": (
+        'var batchClient = client.OpenAI.GetBatchClient();\n'
+        'var batches = batchClient.GetBatches();\n'
+        '\n'
+        'foreach (var b in batches)\n'
+        '    Console.WriteLine($"{b.Id} {b.Status}");'
+    ),
+    "retrieveBatch": (
+        'var batchClient = client.OpenAI.GetBatchClient();\n'
+        'var batch = await batchClient.GetBatchAsync("batch_abc123");\n'
+        '\n'
+        'Console.WriteLine($"{batch.Value.Status}");'
+    ),
+    "cancelBatch": (
+        'var batchClient = client.OpenAI.GetBatchClient();\n'
+        'await batchClient.CancelBatchAsync("batch_abc123");'
+    ),
+
+    # ── Fine-tuning ───────────────────────────────────────────────────
+    "createFineTuningJob": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        '\n'
+        'var job = await ftClient.CreateJobAsync(\n'
+        '    "gpt-4o-mini-2024-07-18", "file-abc123");\n'
+        '\n'
+        'Console.WriteLine(job.Value.Id);'
+    ),
+    "listPaginatedFineTuningJobs": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'var jobs = ftClient.GetJobs();\n'
+        '\n'
+        'foreach (var job in jobs)\n'
+        '    Console.WriteLine($"{job.Id} {job.Status}");'
+    ),
+    "retrieveFineTuningJob": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'var job = await ftClient.GetJobAsync("ftjob-abc123");\n'
+        '\n'
+        'Console.WriteLine($"{job.Value.Status}");'
+    ),
+    "cancelFineTuningJob": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'await ftClient.CancelJobAsync("ftjob-abc123");'
+    ),
+    "listFineTuningJobCheckpoints": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'var checkpoints = ftClient.GetJobCheckpoints("ftjob-abc123");\n'
+        '\n'
+        'foreach (var cp in checkpoints)\n'
+        '    Console.WriteLine($"{cp.Id} step {cp.StepNumber}");'
+    ),
+    "listFineTuningEvents": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'var events = ftClient.GetJobEvents("ftjob-abc123");\n'
+        '\n'
+        'foreach (var evt in events)\n'
+        '    Console.WriteLine(evt.Message);'
+    ),
+    "pauseFineTuningJob": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'await ftClient.PauseJobAsync("ftjob-abc123");'
+    ),
+    "resumeFineTuningJob": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'await ftClient.ResumeJobAsync("ftjob-abc123");'
+    ),
+    "FineTuning_CopyCheckpoint": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'await ftClient.CopyCheckpointAsync(\n'
+        '    "ftjob-abc123", "ftckpt-abc123");'
+    ),
+    "FineTuning_GetCheckpoint": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'var checkpoint = await ftClient.GetCheckpointAsync(\n'
+        '    "ftjob-abc123", "ftckpt-abc123");\n'
+        '\n'
+        'Console.WriteLine(checkpoint.Value.Id);'
+    ),
+    "listFineTuningCheckpointPermissions": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'var permissions = ftClient.GetCheckpointPermissions(\n'
+        '    "ft:gpt-4o:org:suffix:id");\n'
+        '\n'
+        'foreach (var p in permissions)\n'
+        '    Console.WriteLine(p.Id);'
+    ),
+    "createFineTuningCheckpointPermission": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'await ftClient.CreateCheckpointPermissionAsync(\n'
+        '    "ft:gpt-4o:org:suffix:id",\n'
+        '    new[] { "proj_abc123" });'
+    ),
+    "deleteFineTuningCheckpointPermission": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'await ftClient.DeleteCheckpointPermissionAsync(\n'
+        '    "ft:gpt-4o:org:suffix:id", "perm_abc123");'
+    ),
+    "runGrader": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'var result = await ftClient.RunGraderAsync(\n'
+        '    new { type = "python", source = "return 1.0" },\n'
+        '    "Hello world");\n'
+        '\n'
+        'Console.WriteLine(result);'
+    ),
+    "validateGrader": (
+        'var ftClient = client.OpenAI.GetFineTuningClient();\n'
+        'var result = await ftClient.ValidateGraderAsync(\n'
+        '    new { type = "python", source = "return 1.0" });\n'
+        '\n'
+        'Console.WriteLine(result);'
+    ),
+
+    # ── Evals ─────────────────────────────────────────────────────────
+    "listEvals": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var evals = evalClient.GetEvals();\n'
+        '\n'
+        'foreach (var e in evals)\n'
+        '    Console.WriteLine($"{e.Id} {e.Name}");'
+    ),
+    "createEval": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var evaluation = await evalClient.CreateEvalAsync(\n'
+        '    "my-eval",\n'
+        '    new { type = "custom", item_schema = new { } },\n'
+        '    new object[] { });\n'
+        '\n'
+        'Console.WriteLine(evaluation.Value.Id);'
+    ),
+    "getEval": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var evaluation = await evalClient.GetEvalAsync("eval_abc123");\n'
+        '\n'
+        'Console.WriteLine($"{evaluation.Value.Name}");'
+    ),
+    "updateEval": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var evaluation = await evalClient.UpdateEvalAsync(\n'
+        '    "eval_abc123", name: "updated-name");\n'
+        '\n'
+        'Console.WriteLine(evaluation.Value.Name);'
+    ),
+    "deleteEval": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'await evalClient.DeleteEvalAsync("eval_abc123");'
+    ),
+    "getEvalRuns": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var runs = evalClient.GetEvalRuns("eval_abc123");\n'
+        '\n'
+        'foreach (var run in runs)\n'
+        '    Console.WriteLine($"{run.Id} {run.Status}");'
+    ),
+    "createEvalRun": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var run = await evalClient.CreateEvalRunAsync(\n'
+        '    "eval_abc123", "gpt-4o",\n'
+        '    new { type = "completions" });\n'
+        '\n'
+        'Console.WriteLine(run.Value.Id);'
+    ),
+    "getEvalRun": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var run = await evalClient.GetEvalRunAsync(\n'
+        '    "eval_abc123", "run_abc123");\n'
+        '\n'
+        'Console.WriteLine(run.Value.Status);'
+    ),
+    "cancelEvalRun": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'await evalClient.CancelEvalRunAsync(\n'
+        '    "eval_abc123", "run_abc123");'
+    ),
+    "deleteEvalRun": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'await evalClient.DeleteEvalRunAsync(\n'
+        '    "eval_abc123", "run_abc123");'
+    ),
+    "getEvalRunOutputItems": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var items = evalClient.GetEvalRunOutputItems(\n'
+        '    "eval_abc123", "run_abc123");\n'
+        '\n'
+        'foreach (var item in items)\n'
+        '    Console.WriteLine(item.Id);'
+    ),
+    "getEvalRunOutputItem": (
+        'var evalClient = client.OpenAI.GetEvalClient();\n'
+        'var item = await evalClient.GetEvalRunOutputItemAsync(\n'
+        '    "eval_abc123", "run_abc123", "item_abc123");\n'
+        '\n'
+        'Console.WriteLine(item.Value.Id);'
+    ),
+
+    # ── Realtime ──────────────────────────────────────────────────────
+    "createRealtimeSession": (
+        'var realtimeClient = client.OpenAI.GetRealtimeClient();\n'
+        'var session = await realtimeClient.CreateSessionAsync(\n'
+        '    "gpt-4o-realtime-preview");\n'
+        '\n'
+        'Console.WriteLine(session.Value.Id);'
+    ),
+    "createRealtimeClientSecret": (
+        'var realtimeClient = client.OpenAI.GetRealtimeClient();\n'
+        'var secret = await realtimeClient.CreateClientSecretAsync(\n'
+        '    "gpt-4o-realtime-preview");\n'
+        '\n'
+        'Console.WriteLine(secret.Value.ClientSecret.Value);'
+    ),
+    "createRealtimeTranscriptionSession": (
+        'var realtimeClient = client.OpenAI.GetRealtimeClient();\n'
+        'var session = await realtimeClient\n'
+        '    .CreateTranscriptionSessionAsync("gpt-4o-transcribe");\n'
+        '\n'
+        'Console.WriteLine(session.Value.Id);'
+    ),
+    "createRealtimeCall": (
+        'var realtimeClient = client.OpenAI.GetRealtimeClient();\n'
+        'var call = await realtimeClient.CreateCallAsync(\n'
+        '    "gpt-4o-realtime-preview", "YOUR_SDP_OFFER");\n'
+        '\n'
+        'Console.WriteLine(call.Value.Id);'
+    ),
+    "acceptRealtimeCall": (
+        'var realtimeClient = client.OpenAI.GetRealtimeClient();\n'
+        'await realtimeClient.AcceptCallAsync(\n'
+        '    "call_abc123", "gpt-4o-realtime-preview");'
+    ),
+    "hangupRealtimeCall": (
+        'var realtimeClient = client.OpenAI.GetRealtimeClient();\n'
+        'await realtimeClient.HangupCallAsync("call_abc123");'
+    ),
+    "referRealtimeCall": (
+        'var realtimeClient = client.OpenAI.GetRealtimeClient();\n'
+        'await realtimeClient.ReferCallAsync(\n'
+        '    "call_abc123", "sip:destination@example.com");'
+    ),
+    "rejectRealtimeCall": (
+        'var realtimeClient = client.OpenAI.GetRealtimeClient();\n'
+        'await realtimeClient.RejectCallAsync(\n'
+        '    "call_abc123", "busy");'
+    ),
+
+    # ── Containers ────────────────────────────────────────────────────
+    "listContainers": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'var containers = containerClient.GetContainers();\n'
+        '\n'
+        'foreach (var c in containers)\n'
+        '    Console.WriteLine($"{c.Id} {c.Name}");'
+    ),
+    "createContainer": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'var container = await containerClient\n'
+        '    .CreateContainerAsync("my-container");\n'
+        '\n'
+        'Console.WriteLine(container.Value.Id);'
+    ),
+    "retrieveContainer": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'var container = await containerClient\n'
+        '    .GetContainerAsync("container_abc123");\n'
+        '\n'
+        'Console.WriteLine(container.Value.Name);'
+    ),
+    "deleteContainer": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'await containerClient.DeleteContainerAsync("container_abc123");'
+    ),
+    "listContainerFiles": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'var files = containerClient\n'
+        '    .GetContainerFiles("container_abc123");\n'
+        '\n'
+        'foreach (var f in files)\n'
+        '    Console.WriteLine($"{f.Id} {f.Path}");'
+    ),
+    "createContainerFile": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'var file = await containerClient.CreateContainerFileAsync(\n'
+        '    "container_abc123",\n'
+        '    File.OpenRead("data.txt"), "data.txt");\n'
+        '\n'
+        'Console.WriteLine(file.Value.Id);'
+    ),
+    "retrieveContainerFile": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'var file = await containerClient.GetContainerFileAsync(\n'
+        '    "container_abc123", "file_abc123");\n'
+        '\n'
+        'Console.WriteLine(file.Value.Path);'
+    ),
+    "deleteContainerFile": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'await containerClient.DeleteContainerFileAsync(\n'
+        '    "container_abc123", "file_abc123");'
+    ),
+    "retrieveContainerFileContent": (
+        'var containerClient = client.OpenAI.GetContainerClient();\n'
+        'var content = await containerClient\n'
+        '    .GetContainerFileContentAsync(\n'
+        '        "container_abc123", "file_abc123");\n'
+        '\n'
+        'Console.WriteLine(content.Value.ToString());'
+    ),
+
+    # ── Threads (legacy) ──────────────────────────────────────────────
+    "createThread": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var thread = await threadClient.CreateThreadAsync();\n'
+        '\n'
+        'Console.WriteLine(thread.Value.Id);'
+    ),
+    "retrieveThread": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var thread = await threadClient.GetThreadAsync("thread_abc123");\n'
+        '\n'
+        'Console.WriteLine(thread.Value.Id);'
+    ),
+    "modifyThread": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'await threadClient.ModifyThreadAsync("thread_abc123",\n'
+        '    new ThreadModificationOptions\n'
+        '    {\n'
+        '        Metadata = { ["topic"] = "science" },\n'
+        '    });'
+    ),
+    "deleteThread": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'await threadClient.DeleteThreadAsync("thread_abc123");'
+    ),
+    "createMessage": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var message = await threadClient.CreateMessageAsync(\n'
+        '    "thread_abc123", MessageRole.User,\n'
+        '    new[] { MessageContent.FromText("What is the capital of France?") });\n'
+        '\n'
+        'Console.WriteLine(message.Value.Id);'
+    ),
+    "listMessages": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var messages = threadClient.GetMessages("thread_abc123");\n'
+        '\n'
+        'foreach (var msg in messages)\n'
+        '    Console.WriteLine($"{msg.Role} {msg.Content[0].Text}");'
+    ),
+    "retrieveMessage": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var message = await threadClient.GetMessageAsync(\n'
+        '    "thread_abc123", "msg_abc123");\n'
+        '\n'
+        'Console.WriteLine(message.Value.Content[0].Text);'
+    ),
+    "modifyMessage": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'await threadClient.ModifyMessageAsync(\n'
+        '    "thread_abc123", "msg_abc123",\n'
+        '    new MessageModificationOptions\n'
+        '    {\n'
+        '        Metadata = { ["reviewed"] = "true" },\n'
+        '    });'
+    ),
+    "deleteMessage": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'await threadClient.DeleteMessageAsync(\n'
+        '    "thread_abc123", "msg_abc123");'
+    ),
+    "createRun": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var run = await threadClient.CreateRunAsync(\n'
+        '    "thread_abc123", "asst_abc123");\n'
+        '\n'
+        'Console.WriteLine($"{run.Value.Id} {run.Value.Status}");'
+    ),
+    "createThreadAndRun": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var run = await threadClient.CreateThreadAndRunAsync(\n'
+        '    "asst_abc123",\n'
+        '    new ThreadCreationOptions\n'
+        '    {\n'
+        '        InitialMessages = { new ThreadInitializationMessage(\n'
+        '            MessageRole.User, new[] { MessageContent.FromText("Hello") }) },\n'
+        '    });\n'
+        '\n'
+        'Console.WriteLine(run.Value.Id);'
+    ),
+    "listRuns": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var runs = threadClient.GetRuns("thread_abc123");\n'
+        '\n'
+        'foreach (var run in runs)\n'
+        '    Console.WriteLine($"{run.Id} {run.Status}");'
+    ),
+    "retrieveRun": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var run = await threadClient.GetRunAsync(\n'
+        '    "thread_abc123", "run_abc123");\n'
+        '\n'
+        'Console.WriteLine(run.Value.Status);'
+    ),
+    "modifyRun": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'await threadClient.ModifyRunAsync(\n'
+        '    "thread_abc123", "run_abc123",\n'
+        '    new RunModificationOptions\n'
+        '    {\n'
+        '        Metadata = { ["priority"] = "high" },\n'
+        '    });'
+    ),
+    "cancelRun": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'await threadClient.CancelRunAsync(\n'
+        '    "thread_abc123", "run_abc123");'
+    ),
+    "submitToolOutputsToRun": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var run = await threadClient.SubmitToolOutputsToRunAsync(\n'
+        '    "thread_abc123", "run_abc123",\n'
+        '    new[] { new ToolOutput("call_abc123", "result") });\n'
+        '\n'
+        'Console.WriteLine(run.Value.Status);'
+    ),
+    "listRunSteps": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var steps = threadClient.GetRunSteps(\n'
+        '    "thread_abc123", "run_abc123");\n'
+        '\n'
+        'foreach (var step in steps)\n'
+        '    Console.WriteLine($"{step.Id} {step.Type}");'
+    ),
+    "getRunStep": (
+        'var threadClient = client.OpenAI.GetAssistantClient();\n'
+        'var step = await threadClient.GetRunStepAsync(\n'
+        '    "thread_abc123", "run_abc123", "step_abc123");\n'
+        '\n'
+        'Console.WriteLine($"{step.Value.Type} {step.Value.Status}");'
+    ),
+
+    # ── Vector Stores ─────────────────────────────────────────────────
+    "listVectorStores": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var stores = vsClient.GetVectorStores();\n'
+        '\n'
+        'foreach (var store in stores)\n'
+        '    Console.WriteLine($"{store.Id} {store.Name}");'
+    ),
+    "createVectorStore": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        '\n'
+        'var store = await vsClient.CreateVectorStoreAsync(\n'
+        '    new VectorStoreCreationOptions { Name = "my-store" });\n'
+        '\n'
+        'Console.WriteLine(store.Value.Id);'
+    ),
+    "getVectorStore": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var store = await vsClient.GetVectorStoreAsync("vs_abc123");\n'
+        '\n'
+        'Console.WriteLine($"{store.Value.Name}");'
+    ),
+    "modifyVectorStore": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'await vsClient.ModifyVectorStoreAsync("vs_abc123",\n'
+        '    new VectorStoreModificationOptions { Name = "updated-name" });'
+    ),
+    "deleteVectorStore": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'await vsClient.DeleteVectorStoreAsync("vs_abc123");'
+    ),
+    "searchVectorStore": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var results = vsClient.SearchVectorStore(\n'
+        '    "vs_abc123", "search query");\n'
+        '\n'
+        'foreach (var result in results)\n'
+        '    Console.WriteLine($"{result.Score} {result.Content}");'
+    ),
+    "listVectorStoreFiles": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var files = vsClient.GetVectorStoreFiles("vs_abc123");\n'
+        '\n'
+        'foreach (var f in files)\n'
+        '    Console.WriteLine($"{f.Id} {f.Status}");'
+    ),
+    "createVectorStoreFile": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var file = await vsClient.AddFileToVectorStoreAsync(\n'
+        '    "vs_abc123", "file_abc123");\n'
+        '\n'
+        'Console.WriteLine($"{file.Value.Id} {file.Value.Status}");'
+    ),
+    "getVectorStoreFile": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var file = await vsClient.GetVectorStoreFileAsync(\n'
+        '    "vs_abc123", "file_abc123");\n'
+        '\n'
+        'Console.WriteLine(file.Value.Status);'
+    ),
+    "updateVectorStoreFileAttributes": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'await vsClient.UpdateVectorStoreFileAttributesAsync(\n'
+        '    "vs_abc123", "file_abc123",\n'
+        '    new { key = "value" });'
+    ),
+    "deleteVectorStoreFile": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'await vsClient.RemoveFileFromVectorStoreAsync(\n'
+        '    "vs_abc123", "file_abc123");'
+    ),
+    "retrieveVectorStoreFileContent": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var content = await vsClient\n'
+        '    .GetVectorStoreFileContentAsync(\n'
+        '        "vs_abc123", "file_abc123");\n'
+        '\n'
+        'Console.WriteLine(content.Value.ToString());'
+    ),
+    "createVectorStoreFileBatch": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var batch = await vsClient.CreateBatchFileJobAsync(\n'
+        '    "vs_abc123",\n'
+        '    new[] { "file_abc123", "file_def456" });\n'
+        '\n'
+        'Console.WriteLine($"{batch.Value.BatchId} {batch.Value.Status}");'
+    ),
+    "getVectorStoreFileBatch": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var batch = await vsClient.GetBatchFileJobAsync(\n'
+        '    "vs_abc123", "vsfb_abc123");\n'
+        '\n'
+        'Console.WriteLine(batch.Value.Status);'
+    ),
+    "cancelVectorStoreFileBatch": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'await vsClient.CancelBatchFileJobAsync(\n'
+        '    "vs_abc123", "vsfb_abc123");'
+    ),
+    "listFilesInVectorStoreBatch": (
+        'var vsClient = client.OpenAI.GetVectorStoreClient();\n'
+        'var files = vsClient.GetFileAssociations(\n'
+        '    "vs_abc123", "vsfb_abc123");\n'
+        '\n'
+        'foreach (var f in files)\n'
+        '    Console.WriteLine($"{f.Id} {f.Status}");'
+    ),
+
+    # ── Audio ─────────────────────────────────────────────────────────
+    "createSpeech": (
+        'var audioClient = client.OpenAI.GetAudioClient("tts-1");\n'
+        'var result = await audioClient.GenerateSpeechAsync(\n'
+        '    "Hello, how are you today?", GeneratedSpeechVoice.Alloy);\n'
+        '\n'
+        'await File.WriteAllBytesAsync(\n'
+        '    "output.mp3", result.Value.ToArray());'
+    ),
+    "createTranscription": (
+        'var audioClient = client.OpenAI.GetAudioClient("whisper-1");\n'
+        'var result = await audioClient.TranscribeAudioAsync(\n'
+        '    "audio.mp3");\n'
+        '\n'
+        'Console.WriteLine(result.Value.Text);'
+    ),
+    "createTranslation": (
+        'var audioClient = client.OpenAI.GetAudioClient("whisper-1");\n'
+        'var result = await audioClient.TranslateAudioAsync(\n'
+        '    "audio.mp3");\n'
+        '\n'
+        'Console.WriteLine(result.Value.Text);'
+    ),
+
+    # ── Images ────────────────────────────────────────────────────────
+    "createImage": (
+        'var imageClient = client.OpenAI.GetImageClient("dall-e-3");\n'
+        'var result = await imageClient.GenerateImageAsync(\n'
+        '    "A white cat sitting on a windowsill",\n'
+        '    new ImageGenerationOptions { Size = GeneratedImageSize.W1024xH1024 });\n'
+        '\n'
+        'Console.WriteLine(result.Value.ImageUri);'
+    ),
+    "createImageEdit": (
+        'var imageClient = client.OpenAI.GetImageClient("dall-e-2");\n'
+        'var result = await imageClient.GenerateImageEditAsync(\n'
+        '    File.OpenRead("image.png"),\n'
+        '    "image.png",\n'
+        '    "Add a sunset in the background",\n'
+        '    new ImageEditOptions { Size = GeneratedImageSize.W1024xH1024 });\n'
+        '\n'
+        'Console.WriteLine(result.Value.ImageUri);'
+    ),
+    "createImageVariation": (
+        'var imageClient = client.OpenAI.GetImageClient("dall-e-2");\n'
+        'var result = await imageClient.GenerateImageVariationAsync(\n'
+        '    File.OpenRead("image.png"),\n'
+        '    "image.png",\n'
+        '    new ImageVariationOptions { Size = GeneratedImageSize.W1024xH1024 });\n'
+        '\n'
+        'Console.WriteLine(result.Value.ImageUri);'
+    ),
+
+    # ── Video ─────────────────────────────────────────────────────────
+    "Videos_Create": (
+        'var videoClient = client.OpenAI.GetVideoClient();\n'
+        'var job = await videoClient.CreateVideoAsync(\n'
+        '    "sora", "A serene mountain landscape at sunset");\n'
+        '\n'
+        'Console.WriteLine($"{job.Value.Id} {job.Value.Status}");'
+    ),
+    "Videos_List": (
+        'var videoClient = client.OpenAI.GetVideoClient();\n'
+        'var videos = videoClient.GetVideos();\n'
+        '\n'
+        'foreach (var v in videos)\n'
+        '    Console.WriteLine($"{v.Id} {v.Status}");'
+    ),
+    "Videos_Get": (
+        'var videoClient = client.OpenAI.GetVideoClient();\n'
+        'var video = await videoClient.GetVideoAsync("video_abc123");\n'
+        '\n'
+        'Console.WriteLine(video.Value.Status);'
+    ),
+    "Videos_Delete": (
+        'var videoClient = client.OpenAI.GetVideoClient();\n'
+        'await videoClient.DeleteVideoAsync("video_abc123");'
+    ),
+    "Videos_RetrieveContent": (
+        'var videoClient = client.OpenAI.GetVideoClient();\n'
+        'var content = await videoClient\n'
+        '    .GetVideoContentAsync("video_abc123");\n'
+        '\n'
+        'Console.WriteLine(content.Value.Url);'
+    ),
+    "Videos_Remix": (
+        'var videoClient = client.OpenAI.GetVideoClient();\n'
+        'var job = await videoClient.RemixVideoAsync(\n'
+        '    "video_abc123", "Make it a night scene");\n'
+        '\n'
+        'Console.WriteLine(job.Value.Id);'
+    ),
 }
 
 CSHARP_PROJECTS_SAMPLES = {
@@ -334,6 +1143,21 @@ CSHARP_PROJECTS_SAMPLES = {
     "Indexes_ListLatest": 'var indexes = client.GetIndexes();\n\nforeach (var idx in indexes)\n    Console.WriteLine($"{idx.Name} v{idx.Version}");',
     "Indexes_GetVersion": 'var index = client.GetIndex("my-index", "1");\n\nConsole.WriteLine(index.Name);',
     "Indexes_DeleteVersion": 'client.DeleteIndex("my-index", "1");',
+    "Datasets_ListVersions": 'var versions = client.GetDatasetVersions("my-dataset");\n\nforeach (var v in versions)\n    Console.WriteLine($"v{v.Version} {v.CreatedDate}");',
+    "Datasets_CreateOrUpdateVersion": 'var dataset = client.CreateOrUpdateDataset(\n    "my-dataset", "1",\n    new DatasetVersionOptions { Description = "Training data" });\n\nConsole.WriteLine(dataset.Name);',
+    "Datasets_GetCredentials": 'var creds = client.GetDatasetCredentials("my-dataset", "1");\n\nConsole.WriteLine(creds.CredentialType);',
+    "Datasets_StartPendingUploadVersion": 'var upload = client.StartPendingDatasetUpload(\n    "my-dataset", "1",\n    new PendingUploadOptions { PendingUploadType = "temporary_sas" });\n\nConsole.WriteLine(upload.BlobReference);',
+    "Indexes_ListVersions": 'var versions = client.GetIndexVersions("my-index");\n\nforeach (var v in versions)\n    Console.WriteLine(v.Version);',
+    "Indexes_CreateOrUpdateVersion": 'var index = client.CreateOrUpdateIndex(\n    "my-index", "1",\n    new IndexVersionOptions { Description = "Search index" });\n\nConsole.WriteLine(index.Name);',
+    "Evaluations_List": 'var runs = client.GetEvaluations();\n\nforeach (var run in runs)\n    Console.WriteLine($"{run.Name} {run.Status}");',
+    "Evaluations_Get": 'var run = client.GetEvaluation("my-eval-run");\n\nConsole.WriteLine($"{run.Name} {run.Status}");',
+    "Evaluations_Delete": 'client.DeleteEvaluation("my-eval-run");',
+    "Evaluations_Cancel": 'client.CancelEvaluation("my-eval-run");',
+    "Evaluations_Create": 'var run = client.CreateEvaluation(new EvaluationOptions\n{\n    DisplayName = "my-eval-run",\n    Evaluators = { ["relevance"] = new EvaluatorConfig("relevance") },\n    Data = new DatasetConfig("my-dataset:1"),\n});\n\nConsole.WriteLine(run.Name);',
+    "Evaluations_CreateAgentEvaluation": 'var run = client.CreateAgentEvaluation(\n    new AgentEvaluationOptions\n    {\n        DisplayName = "agent-eval",\n        Evaluators = { ["relevance"] = new EvaluatorConfig("relevance") },\n        Target = new AgentTarget("my-agent:1"),\n    });\n\nConsole.WriteLine(run.Name);',
+    "RedTeams_List": 'var runs = client.GetRedTeams();\n\nforeach (var run in runs)\n    Console.WriteLine($"{run.Name} {run.Status}");',
+    "RedTeams_Get": 'var run = client.GetRedTeam("my-redteam-run");\n\nConsole.WriteLine($"{run.Name} {run.Status}");',
+    "RedTeams_Create": 'var run = client.CreateRedTeam(new RedTeamOptions\n{\n    DisplayName = "my-redteam",\n    Target = new AgentTarget("my-agent:1"),\n    RiskCategories = { "violence", "hate" },\n});\n\nConsole.WriteLine(run.Name);',
 }
 
 
@@ -342,27 +1166,659 @@ CSHARP_PROJECTS_SAMPLES = {
 # ---------------------------------------------------------------------------
 
 JS_OPENAI_SAMPLES = {
-    "createResponse": 'const response = await openai.responses.create({\n    model: "gpt-4o",\n    input: "What is the capital of France?",\n});\nconsole.log(response.output_text);',
-    "createChatCompletion": 'const response = await openai.chat.completions.create({\n    model: "gpt-4o",\n    messages: [{ role: "user", content: "Hello!" }],\n});\nconsole.log(response.choices[0].message.content);',
-    "createCompletion": 'const response = await openai.completions.create({\n    model: "gpt-4o",\n    prompt: "Say hello",\n    max_tokens: 100,\n});\nconsole.log(response.choices[0].text);',
-    "createConversation": 'const conversation = await openai.conversations.create({\n    items: [{ type: "message", role: "user", content: "Hello" }],\n});\nconsole.log(conversation.id);',
-    "retrieveConversation": 'const conversation = await openai.conversations.retrieve("conv_abc123");\nconsole.log(conversation.id);',
+    # ── Responses ─────────────────────────────────────────────────────
+    "createResponse": (
+        'const response = await openai.responses.create({\n'
+        '    model: "gpt-4o",\n'
+        '    input: "What is the capital of France?",\n'
+        '});\n'
+        'console.log(response.output_text);'
+    ),
+    "getResponse": (
+        'const response = await openai.responses.retrieve("resp_abc123");\n'
+        'console.log(response.status, response.output_text);'
+    ),
+    "deleteResponse": 'await openai.responses.delete("resp_abc123");',
+    "cancelResponse": 'await openai.responses.cancel("resp_abc123");',
+    "listInputItems": (
+        'const items = await openai.responses.inputItems.list("resp_abc123");\n'
+        'for await (const item of items) {\n'
+        '    console.log(item.type, item.id);\n'
+        '}'
+    ),
+
+    # ── Chat ──────────────────────────────────────────────────────────
+    "createChatCompletion": (
+        'const response = await openai.chat.completions.create({\n'
+        '    model: "gpt-4o",\n'
+        '    messages: [{ role: "user", content: "Hello!" }],\n'
+        '});\n'
+        'console.log(response.choices[0].message.content);'
+    ),
+    "createCompletion": (
+        'const response = await openai.completions.create({\n'
+        '    model: "gpt-4o",\n'
+        '    prompt: "Say hello",\n'
+        '    max_tokens: 100,\n'
+        '});\n'
+        'console.log(response.choices[0].text);'
+    ),
+
+    # ── Conversations ─────────────────────────────────────────────────
+    "createConversation": (
+        'const conversation = await openai.conversations.create({\n'
+        '    items: [{ type: "message", role: "user", content: "Hello" }],\n'
+        '});\n'
+        'console.log(conversation.id);'
+    ),
+    "retrieveConversation": (
+        'const conversation = await openai.conversations.retrieve("conv_abc123");\n'
+        'console.log(conversation.id);'
+    ),
+    "updateConversation": (
+        'const conversation = await openai.conversations.update("conv_abc123", {\n'
+        '    metadata: { topic: "geography" },\n'
+        '});\n'
+        'console.log(conversation.id);'
+    ),
     "deleteConversation": 'await openai.conversations.delete("conv_abc123");',
-    "listConversationItems": 'const items = await openai.conversations.items.list("conv_abc123");\nfor await (const item of items) {\n    console.log(item.type, item.id);\n}',
-    "createConversationItems": 'await openai.conversations.items.create("conv_abc123", {\n    items: [{ type: "message", role: "user", content: "Follow-up" }],\n});',
-    "createEmbedding": 'const response = await openai.embeddings.create({\n    model: "text-embedding-3-large",\n    input: "Sample text to embed",\n});\nconsole.log(response.data[0].embedding.slice(0, 5));',
-    "listModels": 'const models = await openai.models.list();\nfor await (const model of models) {\n    console.log(model.id);\n}',
-    "retrieveModel": 'const model = await openai.models.retrieve("gpt-4o");\nconsole.log(model.id, model.owned_by);',
-    "createFile": 'const file = await openai.files.create({\n    file: fs.createReadStream("data.jsonl"),\n    purpose: "fine-tune",\n});\nconsole.log(file.id);',
-    "listFiles": 'const files = await openai.files.list();\nfor await (const f of files) {\n    console.log(f.id, f.filename);\n}',
-    "createBatch": 'const batch = await openai.batches.create({\n    input_file_id: "file-abc123",\n    endpoint: "/v1/chat/completions",\n    completion_window: "24h",\n});\nconsole.log(batch.id, batch.status);',
-    "listBatches": 'const batches = await openai.batches.list();\nfor await (const b of batches) {\n    console.log(b.id, b.status);\n}',
-    "createFineTuningJob": 'const job = await openai.fineTuning.jobs.create({\n    model: "gpt-4o-mini-2024-07-18",\n    training_file: "file-abc123",\n});\nconsole.log(job.id, job.status);',
-    "listEvals": 'const evals = await openai.evals.list();\nfor await (const e of evals) {\n    console.log(e.id, e.name);\n}',
-    "createRealtimeSession": 'const session = await openai.realtime.sessions.create({\n    model: "gpt-4o-realtime-preview",\n});\nconsole.log(session.id, session.client_secret.value);',
-    "listVectorStores": 'const stores = await openai.vectorStores.list();\nfor await (const store of stores) {\n    console.log(store.id, store.name);\n}',
-    "createVectorStore": 'const store = await openai.vectorStores.create({\n    name: "my-vector-store",\n});\nconsole.log(store.id);',
-    "searchVectorStore": 'const results = await openai.vectorStores.search("vs_abc123", {\n    query: "search query",\n});\nfor await (const result of results) {\n    console.log(result.score, result.content);\n}',
+    "listConversationItems": (
+        'const items = await openai.conversations.items.list("conv_abc123");\n'
+        'for await (const item of items) {\n'
+        '    console.log(item.type, item.id);\n'
+        '}'
+    ),
+    "createConversationItems": (
+        'await openai.conversations.items.create("conv_abc123", {\n'
+        '    items: [{ type: "message", role: "user", content: "Follow-up" }],\n'
+        '});'
+    ),
+    "retrieveConversationItem": (
+        'const item = await openai.conversations.items.retrieve(\n'
+        '    "conv_abc123", "item_abc123"\n'
+        ');\n'
+        'console.log(item.type);'
+    ),
+    "deleteConversationItem": (
+        'await openai.conversations.items.delete(\n'
+        '    "conv_abc123", "item_abc123"\n'
+        ');'
+    ),
+
+    # ── Embeddings ────────────────────────────────────────────────────
+    "createEmbedding": (
+        'const response = await openai.embeddings.create({\n'
+        '    model: "text-embedding-3-large",\n'
+        '    input: "Sample text to embed",\n'
+        '});\n'
+        'console.log(response.data[0].embedding.slice(0, 5));'
+    ),
+
+    # ── Models ────────────────────────────────────────────────────────
+    "listModels": (
+        'const models = await openai.models.list();\n'
+        'for await (const model of models) {\n'
+        '    console.log(model.id);\n'
+        '}'
+    ),
+    "retrieveModel": (
+        'const model = await openai.models.retrieve("gpt-4o");\n'
+        'console.log(model.id, model.owned_by);'
+    ),
+    "deleteModel": 'await openai.models.delete("ft:gpt-4o:your-org:custom-suffix:id");',
+
+    # ── Files ─────────────────────────────────────────────────────────
+    "createFile": (
+        'const file = await openai.files.create({\n'
+        '    file: fs.createReadStream("data.jsonl"),\n'
+        '    purpose: "fine-tune",\n'
+        '});\n'
+        'console.log(file.id);'
+    ),
+    "listFiles": (
+        'const files = await openai.files.list();\n'
+        'for await (const f of files) {\n'
+        '    console.log(f.id, f.filename);\n'
+        '}'
+    ),
+    "retrieveFile": (
+        'const file = await openai.files.retrieve("file-abc123");\n'
+        'console.log(file.filename, file.status);'
+    ),
+    "deleteFile": 'await openai.files.delete("file-abc123");',
+    "downloadFile": (
+        'const content = await openai.files.content("file-abc123");\n'
+        'console.log(await content.text());'
+    ),
+
+    # ── Batch ─────────────────────────────────────────────────────────
+    "createBatch": (
+        'const batch = await openai.batches.create({\n'
+        '    input_file_id: "file-abc123",\n'
+        '    endpoint: "/v1/chat/completions",\n'
+        '    completion_window: "24h",\n'
+        '});\n'
+        'console.log(batch.id, batch.status);'
+    ),
+    "listBatches": (
+        'const batches = await openai.batches.list();\n'
+        'for await (const b of batches) {\n'
+        '    console.log(b.id, b.status);\n'
+        '}'
+    ),
+    "retrieveBatch": (
+        'const batch = await openai.batches.retrieve("batch_abc123");\n'
+        'console.log(batch.status, batch.request_counts);'
+    ),
+    "cancelBatch": 'await openai.batches.cancel("batch_abc123");',
+
+    # ── Fine-tuning ───────────────────────────────────────────────────
+    "createFineTuningJob": (
+        'const job = await openai.fineTuning.jobs.create({\n'
+        '    model: "gpt-4o-mini-2024-07-18",\n'
+        '    training_file: "file-abc123",\n'
+        '});\n'
+        'console.log(job.id, job.status);'
+    ),
+    "listPaginatedFineTuningJobs": (
+        'const jobs = await openai.fineTuning.jobs.list();\n'
+        'for await (const job of jobs) {\n'
+        '    console.log(job.id, job.status);\n'
+        '}'
+    ),
+    "retrieveFineTuningJob": (
+        'const job = await openai.fineTuning.jobs.retrieve("ftjob-abc123");\n'
+        'console.log(job.status, job.trained_tokens);'
+    ),
+    "cancelFineTuningJob": 'await openai.fineTuning.jobs.cancel("ftjob-abc123");',
+    "listFineTuningJobCheckpoints": (
+        'const checkpoints = await openai.fineTuning.jobs.checkpoints\n'
+        '    .list("ftjob-abc123");\n'
+        'for await (const cp of checkpoints) {\n'
+        '    console.log(cp.id, cp.step_number);\n'
+        '}'
+    ),
+    "listFineTuningEvents": (
+        'const events = await openai.fineTuning.jobs.listEvents("ftjob-abc123");\n'
+        'for await (const event of events) {\n'
+        '    console.log(event.message);\n'
+        '}'
+    ),
+    "pauseFineTuningJob": 'await openai.fineTuning.jobs.pause("ftjob-abc123");',
+    "resumeFineTuningJob": 'await openai.fineTuning.jobs.resume("ftjob-abc123");',
+    "FineTuning_CopyCheckpoint": (
+        'await openai.fineTuning.jobs.checkpoints.copy(\n'
+        '    "ftjob-abc123", "ftckpt-abc123"\n'
+        ');'
+    ),
+    "FineTuning_GetCheckpoint": (
+        'const checkpoint = await openai.fineTuning.jobs.checkpoints\n'
+        '    .retrieve("ftjob-abc123", "ftckpt-abc123");\n'
+        'console.log(checkpoint.id);'
+    ),
+    "listFineTuningCheckpointPermissions": (
+        'const permissions = await openai.fineTuning.checkpoints\n'
+        '    .permissions.list("ft:gpt-4o:org:suffix:id");\n'
+        'for await (const p of permissions) {\n'
+        '    console.log(p.id);\n'
+        '}'
+    ),
+    "createFineTuningCheckpointPermission": (
+        'await openai.fineTuning.checkpoints.permissions.create(\n'
+        '    "ft:gpt-4o:org:suffix:id",\n'
+        '    { project_ids: ["proj_abc123"] }\n'
+        ');'
+    ),
+    "deleteFineTuningCheckpointPermission": (
+        'await openai.fineTuning.checkpoints.permissions.delete(\n'
+        '    "ft:gpt-4o:org:suffix:id", "perm_abc123"\n'
+        ');'
+    ),
+    "runGrader": (
+        'const result = await openai.fineTuning.alpha.graders.run({\n'
+        '    grader: { type: "python", source: "return 1.0" },\n'
+        '    model_sample: "Hello world",\n'
+        '});\n'
+        'console.log(result);'
+    ),
+    "validateGrader": (
+        'const result = await openai.fineTuning.alpha.graders.validate({\n'
+        '    grader: { type: "python", source: "return 1.0" },\n'
+        '});\n'
+        'console.log(result);'
+    ),
+
+    # ── Evals ─────────────────────────────────────────────────────────
+    "listEvals": (
+        'const evals = await openai.evals.list();\n'
+        'for await (const e of evals) {\n'
+        '    console.log(e.id, e.name);\n'
+        '}'
+    ),
+    "createEval": (
+        'const evaluation = await openai.evals.create({\n'
+        '    name: "my-eval",\n'
+        '    data_source_config: { type: "custom", item_schema: {} },\n'
+        '    testing_criteria: [],\n'
+        '});\n'
+        'console.log(evaluation.id);'
+    ),
+    "getEval": (
+        'const evaluation = await openai.evals.retrieve("eval_abc123");\n'
+        'console.log(evaluation.name, evaluation.id);'
+    ),
+    "updateEval": (
+        'const evaluation = await openai.evals.update("eval_abc123", {\n'
+        '    name: "updated-name",\n'
+        '});\n'
+        'console.log(evaluation.name);'
+    ),
+    "deleteEval": 'await openai.evals.delete("eval_abc123");',
+    "getEvalRuns": (
+        'const runs = await openai.evals.runs.list("eval_abc123");\n'
+        'for await (const run of runs) {\n'
+        '    console.log(run.id, run.status);\n'
+        '}'
+    ),
+    "createEvalRun": (
+        'const run = await openai.evals.runs.create("eval_abc123", {\n'
+        '    model: "gpt-4o",\n'
+        '    data_source: { type: "completions" },\n'
+        '});\n'
+        'console.log(run.id);'
+    ),
+    "getEvalRun": (
+        'const run = await openai.evals.runs.retrieve(\n'
+        '    "eval_abc123", "run_abc123"\n'
+        ');\n'
+        'console.log(run.status);'
+    ),
+    "cancelEvalRun": 'await openai.evals.runs.cancel("eval_abc123", "run_abc123");',
+    "deleteEvalRun": 'await openai.evals.runs.delete("eval_abc123", "run_abc123");',
+    "getEvalRunOutputItems": (
+        'const items = await openai.evals.runs.outputItems\n'
+        '    .list("eval_abc123", "run_abc123");\n'
+        'for await (const item of items) {\n'
+        '    console.log(item.id);\n'
+        '}'
+    ),
+    "getEvalRunOutputItem": (
+        'const item = await openai.evals.runs.outputItems\n'
+        '    .retrieve("eval_abc123", "run_abc123", "item_abc123");\n'
+        'console.log(item.id);'
+    ),
+
+    # ── Realtime ──────────────────────────────────────────────────────
+    "createRealtimeSession": (
+        'const session = await openai.realtime.sessions.create({\n'
+        '    model: "gpt-4o-realtime-preview",\n'
+        '});\n'
+        'console.log(session.id, session.client_secret.value);'
+    ),
+    "createRealtimeClientSecret": (
+        'const secret = await openai.realtime.clientSecrets.create({\n'
+        '    model: "gpt-4o-realtime-preview",\n'
+        '});\n'
+        'console.log(secret.client_secret.value);'
+    ),
+    "createRealtimeTranscriptionSession": (
+        'const session = await openai.realtime.transcriptionSessions\n'
+        '    .create({ model: "gpt-4o-transcribe" });\n'
+        'console.log(session.id);'
+    ),
+    "createRealtimeCall": (
+        'const call = await openai.realtime.calls.create({\n'
+        '    model: "gpt-4o-realtime-preview",\n'
+        '    sdp: "YOUR_SDP_OFFER",\n'
+        '});\n'
+        'console.log(call.id, call.sdp);'
+    ),
+    "acceptRealtimeCall": (
+        'await openai.realtime.calls.accept("call_abc123", {\n'
+        '    model: "gpt-4o-realtime-preview",\n'
+        '});'
+    ),
+    "hangupRealtimeCall": 'await openai.realtime.calls.hangup("call_abc123");',
+    "referRealtimeCall": (
+        'await openai.realtime.calls.refer("call_abc123", {\n'
+        '    refer_to: "sip:destination@example.com",\n'
+        '});'
+    ),
+    "rejectRealtimeCall": (
+        'await openai.realtime.calls.reject("call_abc123", {\n'
+        '    reason: "busy",\n'
+        '});'
+    ),
+
+    # ── Containers ────────────────────────────────────────────────────
+    "listContainers": (
+        'const containers = await openai.containers.list();\n'
+        'for await (const c of containers) {\n'
+        '    console.log(c.id, c.name);\n'
+        '}'
+    ),
+    "createContainer": (
+        'const container = await openai.containers.create({\n'
+        '    name: "my-container",\n'
+        '});\n'
+        'console.log(container.id);'
+    ),
+    "retrieveContainer": (
+        'const container = await openai.containers.retrieve("container_abc123");\n'
+        'console.log(container.name);'
+    ),
+    "deleteContainer": 'await openai.containers.delete("container_abc123");',
+    "listContainerFiles": (
+        'const files = await openai.containers.files.list("container_abc123");\n'
+        'for await (const f of files) {\n'
+        '    console.log(f.id, f.path);\n'
+        '}'
+    ),
+    "createContainerFile": (
+        'const file = await openai.containers.files.create("container_abc123", {\n'
+        '    file: fs.createReadStream("data.txt"),\n'
+        '    file_path: "data.txt",\n'
+        '});\n'
+        'console.log(file.id);'
+    ),
+    "retrieveContainerFile": (
+        'const file = await openai.containers.files.retrieve(\n'
+        '    "container_abc123", "file_abc123"\n'
+        ');\n'
+        'console.log(file.path);'
+    ),
+    "deleteContainerFile": (
+        'await openai.containers.files.delete(\n'
+        '    "container_abc123", "file_abc123"\n'
+        ');'
+    ),
+    "retrieveContainerFileContent": (
+        'const content = await openai.containers.files.content(\n'
+        '    "container_abc123", "file_abc123"\n'
+        ');\n'
+        'console.log(await content.text());'
+    ),
+
+    # ── Threads (legacy) ──────────────────────────────────────────────
+    "createThread": (
+        'const thread = await openai.beta.threads.create();\n'
+        'console.log(thread.id);'
+    ),
+    "retrieveThread": (
+        'const thread = await openai.beta.threads.retrieve("thread_abc123");\n'
+        'console.log(thread.id);'
+    ),
+    "modifyThread": (
+        'const thread = await openai.beta.threads.update("thread_abc123", {\n'
+        '    metadata: { topic: "science" },\n'
+        '});\n'
+        'console.log(thread.id);'
+    ),
+    "deleteThread": 'await openai.beta.threads.delete("thread_abc123");',
+    "createMessage": (
+        'const message = await openai.beta.threads.messages.create(\n'
+        '    "thread_abc123",\n'
+        '    { role: "user", content: "What is the capital of France?" }\n'
+        ');\n'
+        'console.log(message.id);'
+    ),
+    "listMessages": (
+        'const messages = await openai.beta.threads.messages.list("thread_abc123");\n'
+        'for await (const msg of messages) {\n'
+        '    console.log(msg.role, msg.content[0].text.value);\n'
+        '}'
+    ),
+    "retrieveMessage": (
+        'const message = await openai.beta.threads.messages.retrieve(\n'
+        '    "thread_abc123", "msg_abc123"\n'
+        ');\n'
+        'console.log(message.content[0].text.value);'
+    ),
+    "modifyMessage": (
+        'await openai.beta.threads.messages.update(\n'
+        '    "thread_abc123", "msg_abc123",\n'
+        '    { metadata: { reviewed: "true" } }\n'
+        ');'
+    ),
+    "deleteMessage": (
+        'await openai.beta.threads.messages.delete(\n'
+        '    "thread_abc123", "msg_abc123"\n'
+        ');'
+    ),
+    "createRun": (
+        'const run = await openai.beta.threads.runs.create("thread_abc123", {\n'
+        '    assistant_id: "asst_abc123",\n'
+        '});\n'
+        'console.log(run.id, run.status);'
+    ),
+    "createThreadAndRun": (
+        'const run = await openai.beta.threads.createAndRun({\n'
+        '    assistant_id: "asst_abc123",\n'
+        '    thread: { messages: [{ role: "user", content: "Hello" }] },\n'
+        '});\n'
+        'console.log(run.id);'
+    ),
+    "listRuns": (
+        'const runs = await openai.beta.threads.runs.list("thread_abc123");\n'
+        'for await (const run of runs) {\n'
+        '    console.log(run.id, run.status);\n'
+        '}'
+    ),
+    "retrieveRun": (
+        'const run = await openai.beta.threads.runs.retrieve(\n'
+        '    "thread_abc123", "run_abc123"\n'
+        ');\n'
+        'console.log(run.status);'
+    ),
+    "modifyRun": (
+        'await openai.beta.threads.runs.update(\n'
+        '    "thread_abc123", "run_abc123",\n'
+        '    { metadata: { priority: "high" } }\n'
+        ');'
+    ),
+    "cancelRun": (
+        'await openai.beta.threads.runs.cancel(\n'
+        '    "thread_abc123", "run_abc123"\n'
+        ');'
+    ),
+    "submitToolOutputsToRun": (
+        'const run = await openai.beta.threads.runs.submitToolOutputs(\n'
+        '    "thread_abc123", "run_abc123",\n'
+        '    { tool_outputs: [{ tool_call_id: "call_abc123", output: "result" }] }\n'
+        ');\n'
+        'console.log(run.status);'
+    ),
+    "listRunSteps": (
+        'const steps = await openai.beta.threads.runs.steps.list(\n'
+        '    "thread_abc123", "run_abc123"\n'
+        ');\n'
+        'for await (const step of steps) {\n'
+        '    console.log(step.id, step.type);\n'
+        '}'
+    ),
+    "getRunStep": (
+        'const step = await openai.beta.threads.runs.steps.retrieve(\n'
+        '    "thread_abc123", "run_abc123", "step_abc123"\n'
+        ');\n'
+        'console.log(step.type, step.status);'
+    ),
+
+    # ── Vector Stores ─────────────────────────────────────────────────
+    "listVectorStores": (
+        'const stores = await openai.vectorStores.list();\n'
+        'for await (const store of stores) {\n'
+        '    console.log(store.id, store.name);\n'
+        '}'
+    ),
+    "createVectorStore": (
+        'const store = await openai.vectorStores.create({\n'
+        '    name: "my-vector-store",\n'
+        '});\n'
+        'console.log(store.id);'
+    ),
+    "getVectorStore": (
+        'const store = await openai.vectorStores.retrieve("vs_abc123");\n'
+        'console.log(store.name, store.file_counts);'
+    ),
+    "modifyVectorStore": (
+        'const store = await openai.vectorStores.update("vs_abc123", {\n'
+        '    name: "updated-name",\n'
+        '});\n'
+        'console.log(store.name);'
+    ),
+    "deleteVectorStore": 'await openai.vectorStores.delete("vs_abc123");',
+    "searchVectorStore": (
+        'const results = await openai.vectorStores.search("vs_abc123", {\n'
+        '    query: "search query",\n'
+        '});\n'
+        'for await (const result of results) {\n'
+        '    console.log(result.score, result.content);\n'
+        '}'
+    ),
+    "listVectorStoreFiles": (
+        'const files = await openai.vectorStores.files.list("vs_abc123");\n'
+        'for await (const f of files) {\n'
+        '    console.log(f.id, f.status);\n'
+        '}'
+    ),
+    "createVectorStoreFile": (
+        'const file = await openai.vectorStores.files.create("vs_abc123", {\n'
+        '    file_id: "file_abc123",\n'
+        '});\n'
+        'console.log(file.id, file.status);'
+    ),
+    "getVectorStoreFile": (
+        'const file = await openai.vectorStores.files.retrieve(\n'
+        '    "vs_abc123", "file_abc123"\n'
+        ');\n'
+        'console.log(file.status);'
+    ),
+    "updateVectorStoreFileAttributes": (
+        'await openai.vectorStores.files.update(\n'
+        '    "vs_abc123", "file_abc123",\n'
+        '    { attributes: { key: "value" } }\n'
+        ');'
+    ),
+    "deleteVectorStoreFile": (
+        'await openai.vectorStores.files.delete(\n'
+        '    "vs_abc123", "file_abc123"\n'
+        ');'
+    ),
+    "retrieveVectorStoreFileContent": (
+        'const content = await openai.vectorStores.files.content(\n'
+        '    "vs_abc123", "file_abc123"\n'
+        ');\n'
+        'console.log(await content.text());'
+    ),
+    "createVectorStoreFileBatch": (
+        'const batch = await openai.vectorStores.fileBatches.create(\n'
+        '    "vs_abc123",\n'
+        '    { file_ids: ["file_abc123", "file_def456"] }\n'
+        ');\n'
+        'console.log(batch.id, batch.status);'
+    ),
+    "getVectorStoreFileBatch": (
+        'const batch = await openai.vectorStores.fileBatches.retrieve(\n'
+        '    "vs_abc123", "vsfb_abc123"\n'
+        ');\n'
+        'console.log(batch.status, batch.file_counts);'
+    ),
+    "cancelVectorStoreFileBatch": (
+        'await openai.vectorStores.fileBatches.cancel(\n'
+        '    "vs_abc123", "vsfb_abc123"\n'
+        ');'
+    ),
+    "listFilesInVectorStoreBatch": (
+        'const files = await openai.vectorStores.fileBatches.listFiles(\n'
+        '    "vs_abc123", "vsfb_abc123"\n'
+        ');\n'
+        'for await (const f of files) {\n'
+        '    console.log(f.id, f.status);\n'
+        '}'
+    ),
+
+    # ── Audio ─────────────────────────────────────────────────────────
+    "createSpeech": (
+        'const response = await openai.audio.speech.create({\n'
+        '    model: "tts-1",\n'
+        '    voice: "alloy",\n'
+        '    input: "Hello, how are you today?",\n'
+        '});\n'
+        'const buffer = Buffer.from(await response.arrayBuffer());\n'
+        'fs.writeFileSync("output.mp3", buffer);'
+    ),
+    "createTranscription": (
+        'const transcription = await openai.audio.transcriptions.create({\n'
+        '    model: "whisper-1",\n'
+        '    file: fs.createReadStream("audio.mp3"),\n'
+        '});\n'
+        'console.log(transcription.text);'
+    ),
+    "createTranslation": (
+        'const translation = await openai.audio.translations.create({\n'
+        '    model: "whisper-1",\n'
+        '    file: fs.createReadStream("audio.mp3"),\n'
+        '});\n'
+        'console.log(translation.text);'
+    ),
+
+    # ── Images ────────────────────────────────────────────────────────
+    "createImage": (
+        'const response = await openai.images.generate({\n'
+        '    model: "dall-e-3",\n'
+        '    prompt: "A white cat sitting on a windowsill",\n'
+        '    n: 1,\n'
+        '    size: "1024x1024",\n'
+        '});\n'
+        'console.log(response.data[0].url);'
+    ),
+    "createImageEdit": (
+        'const response = await openai.images.edit({\n'
+        '    image: fs.createReadStream("image.png"),\n'
+        '    prompt: "Add a sunset in the background",\n'
+        '    n: 1,\n'
+        '    size: "1024x1024",\n'
+        '});\n'
+        'console.log(response.data[0].url);'
+    ),
+    "createImageVariation": (
+        'const response = await openai.images.createVariation({\n'
+        '    image: fs.createReadStream("image.png"),\n'
+        '    n: 1,\n'
+        '    size: "1024x1024",\n'
+        '});\n'
+        'console.log(response.data[0].url);'
+    ),
+
+    # ── Video ─────────────────────────────────────────────────────────
+    "Videos_Create": (
+        'const job = await openai.videos.create({\n'
+        '    model: "sora",\n'
+        '    prompt: "A serene mountain landscape at sunset",\n'
+        '});\n'
+        'console.log(job.id, job.status);'
+    ),
+    "Videos_List": (
+        'const videos = await openai.videos.list();\n'
+        'for await (const v of videos) {\n'
+        '    console.log(v.id, v.status);\n'
+        '}'
+    ),
+    "Videos_Get": (
+        'const video = await openai.videos.retrieve("video_abc123");\n'
+        'console.log(video.status);'
+    ),
+    "Videos_Delete": 'await openai.videos.delete("video_abc123");',
+    "Videos_RetrieveContent": (
+        'const content = await openai.videos.content("video_abc123");\n'
+        'console.log(content.url);'
+    ),
+    "Videos_Remix": (
+        'const job = await openai.videos.remix("video_abc123", {\n'
+        '    prompt: "Make it a night scene",\n'
+        '});\n'
+        'console.log(job.id);'
+    ),
 }
 
 JS_PROJECTS_SAMPLES = {
@@ -376,4 +1832,1079 @@ JS_PROJECTS_SAMPLES = {
     "Indexes_ListLatest": 'const indexes = await client.indexes.list();\nfor await (const idx of indexes) {\n    console.log(idx.name, idx.version);\n}',
     "Indexes_GetVersion": 'const index = await client.indexes.get("my-index", "1");\nconsole.log(index.name);',
     "Indexes_DeleteVersion": 'await client.indexes.delete("my-index", "1");',
+    "Connections_GetWithCredentials": 'const connection = await client.connections.getWithCredentials("my-connection");\nconsole.log(connection.name, connection.credentials);',
+    "Datasets_ListVersions": 'const versions = await client.datasets.listVersions("my-dataset");\nfor await (const v of versions) {\n    console.log(v.version, v.createdDate);\n}',
+    "Datasets_CreateOrUpdateVersion": 'const dataset = await client.datasets.createOrUpdate(\n    "my-dataset", "1",\n    { description: "Training data" },\n);\nconsole.log(dataset.name);',
+    "Datasets_GetCredentials": 'const creds = await client.datasets.getCredentials("my-dataset", "1");\nconsole.log(creds.credentialType);',
+    "Datasets_StartPendingUploadVersion": 'const upload = await client.datasets.startPendingUpload(\n    "my-dataset", "1",\n    { pendingUploadType: "temporary_sas" },\n);\nconsole.log(upload.blobReference);',
+    "Indexes_ListVersions": 'const versions = await client.indexes.listVersions("my-index");\nfor await (const v of versions) {\n    console.log(v.version);\n}',
+    "Indexes_CreateOrUpdateVersion": 'const index = await client.indexes.createOrUpdate(\n    "my-index", "1",\n    { description: "Search index" },\n);\nconsole.log(index.name);',
+    "Evaluations_List": 'const runs = await client.evaluations.list();\nfor await (const run of runs) {\n    console.log(run.name, run.status);\n}',
+    "Evaluations_Get": 'const run = await client.evaluations.get("my-eval-run");\nconsole.log(run.name, run.status);',
+    "Evaluations_Delete": 'await client.evaluations.delete("my-eval-run");',
+    "Evaluations_Cancel": 'await client.evaluations.cancel("my-eval-run");',
+    "Evaluations_Create": 'const run = await client.evaluations.create({\n    displayName: "my-eval-run",\n    evaluators: { relevance: { id: "relevance" } },\n    data: { type: "dataset", id: "my-dataset:1" },\n});\nconsole.log(run.name);',
+    "Evaluations_CreateAgentEvaluation": 'const run = await client.evaluations.createAgent({\n    displayName: "agent-eval",\n    evaluators: { relevance: { id: "relevance" } },\n    target: { agentId: "my-agent:1" },\n});\nconsole.log(run.name);',
+    "RedTeams_List": 'const runs = await client.redTeams.list();\nfor await (const run of runs) {\n    console.log(run.name, run.status);\n}',
+    "RedTeams_Get": 'const run = await client.redTeams.get("my-redteam-run");\nconsole.log(run.name, run.status);',
+    "RedTeams_Create": 'const run = await client.redTeams.create({\n    displayName: "my-redteam",\n    target: { agentId: "my-agent:1" },\n    riskCategories: ["violence", "hate"],\n});\nconsole.log(run.name);',
+}
+
+
+# ---------------------------------------------------------------------------
+# Java preambles — Projects API
+# ---------------------------------------------------------------------------
+
+JAVA_PROJECTS_PREAMBLE_ENTRA = """\
+import com.azure.ai.projects.AIProjectClient;
+import com.azure.ai.projects.AIProjectClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+AIProjectClient client = new AIProjectClientBuilder()
+    .endpoint("https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+
+"""
+
+JAVA_PROJECTS_PREAMBLE_APIKEY = """\
+import com.azure.ai.projects.AIProjectClient;
+import com.azure.ai.projects.AIProjectClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+AIProjectClient client = new AIProjectClientBuilder()
+    .endpoint("https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME")
+    .credential(new AzureKeyCredential("YOUR_API_KEY"))
+    .buildClient();
+
+"""
+
+
+# ---------------------------------------------------------------------------
+# Java samples — Projects API
+# ---------------------------------------------------------------------------
+
+JAVA_PROJECTS_SAMPLES = {
+    # ── Connections ────────────────────────────────────────────────────
+    "Connections_List": 'PagedIterable<Connection> connections = client.getConnections();\n\nfor (Connection conn : connections) {\n    System.out.printf("%s %s%n", conn.getName(), conn.getConnectionType());\n}',
+    "Connections_Get": 'Connection connection = client.getConnection("my-connection");\n\nSystem.out.printf("%s %s%n", connection.getName(), connection.getConnectionType());',
+    "Connections_GetWithCredentials": 'Connection connection = client.getConnectionWithCredentials(\n    "my-connection");\n\nSystem.out.println(connection.getCredentials());',
+
+    # ── Datasets ───────────────────────────────────────────────────────
+    "Datasets_ListLatest": 'PagedIterable<Dataset> datasets = client.getDatasets();\n\nfor (Dataset ds : datasets) {\n    System.out.printf("%s v%s%n", ds.getName(), ds.getVersion());\n}',
+    "Datasets_ListVersions": 'PagedIterable<Dataset> versions = client.getDatasetVersions("my-dataset");\n\nfor (Dataset v : versions) {\n    System.out.printf("v%s %s%n", v.getVersion(), v.getCreatedDate());\n}',
+    "Datasets_GetVersion": 'Dataset dataset = client.getDataset("my-dataset", "1");\n\nSystem.out.printf("%s v%s%n", dataset.getName(), dataset.getVersion());',
+    "Datasets_CreateOrUpdateVersion": 'Dataset dataset = client.createOrUpdateDataset(\n    "my-dataset", "1",\n    new DatasetVersionOptions().setDescription("Training data"));\n\nSystem.out.println(dataset.getName());',
+    "Datasets_DeleteVersion": 'client.deleteDataset("my-dataset", "1");',
+    "Datasets_GetCredentials": 'DatasetCredentials creds = client.getDatasetCredentials(\n    "my-dataset", "1");\n\nSystem.out.println(creds.getCredentialType());',
+    "Datasets_StartPendingUploadVersion": 'PendingUpload upload = client.startPendingDatasetUpload(\n    "my-dataset", "1",\n    new PendingUploadOptions().setPendingUploadType("temporary_sas"));\n\nSystem.out.println(upload.getBlobReference());',
+
+    # ── Deployments ────────────────────────────────────────────────────
+    "Deployments_List": 'PagedIterable<Deployment> deployments = client.getDeployments();\n\nfor (Deployment d : deployments) {\n    System.out.printf("%s %s%n", d.getName(), d.getModel());\n}',
+    "Deployments_Get": 'Deployment deployment = client.getDeployment("gpt-4o");\n\nSystem.out.printf("%s %s%n", deployment.getName(), deployment.getModel());',
+
+    # ── Indexes ────────────────────────────────────────────────────────
+    "Indexes_ListLatest": 'PagedIterable<Index> indexes = client.getIndexes();\n\nfor (Index idx : indexes) {\n    System.out.printf("%s v%s%n", idx.getName(), idx.getVersion());\n}',
+    "Indexes_ListVersions": 'PagedIterable<Index> versions = client.getIndexVersions("my-index");\n\nfor (Index v : versions) {\n    System.out.println(v.getVersion());\n}',
+    "Indexes_GetVersion": 'Index index = client.getIndex("my-index", "1");\n\nSystem.out.println(index.getName());',
+    "Indexes_CreateOrUpdateVersion": 'Index index = client.createOrUpdateIndex(\n    "my-index", "1",\n    new IndexVersionOptions().setDescription("Search index"));\n\nSystem.out.println(index.getName());',
+    "Indexes_DeleteVersion": 'client.deleteIndex("my-index", "1");',
+
+    # ── Evaluations (preview) ──────────────────────────────────────────
+    "Evaluations_List": 'PagedIterable<EvaluationRun> runs = client.getEvaluations();\n\nfor (EvaluationRun run : runs) {\n    System.out.printf("%s %s%n", run.getName(), run.getStatus());\n}',
+    "Evaluations_Get": 'EvaluationRun run = client.getEvaluation("my-eval-run");\n\nSystem.out.printf("%s %s%n", run.getName(), run.getStatus());',
+    "Evaluations_Delete": 'client.deleteEvaluation("my-eval-run");',
+    "Evaluations_Cancel": 'client.cancelEvaluation("my-eval-run");',
+    "Evaluations_Create": 'EvaluationRun run = client.createEvaluation(\n    new EvaluationOptions()\n        .setDisplayName("my-eval-run")\n        .setEvaluators(Map.of("relevance",\n            new EvaluatorConfig("relevance")))\n        .setData(new DatasetConfig("my-dataset:1")));\n\nSystem.out.println(run.getName());',
+    "Evaluations_CreateAgentEvaluation": 'EvaluationRun run = client.createAgentEvaluation(\n    new AgentEvaluationOptions()\n        .setDisplayName("agent-eval")\n        .setEvaluators(Map.of("relevance",\n            new EvaluatorConfig("relevance")))\n        .setTarget(new AgentTarget("my-agent:1")));\n\nSystem.out.println(run.getName());',
+
+    # ── RedTeams (preview) ─────────────────────────────────────────────
+    "RedTeams_List": 'PagedIterable<RedTeamRun> runs = client.getRedTeams();\n\nfor (RedTeamRun run : runs) {\n    System.out.printf("%s %s%n", run.getName(), run.getStatus());\n}',
+    "RedTeams_Get": 'RedTeamRun run = client.getRedTeam("my-redteam-run");\n\nSystem.out.printf("%s %s%n", run.getName(), run.getStatus());',
+    "RedTeams_Create": 'RedTeamRun run = client.createRedTeam(\n    new RedTeamOptions()\n        .setDisplayName("my-redteam")\n        .setTarget(new AgentTarget("my-agent:1"))\n        .setRiskCategories(List.of("violence", "hate")));\n\nSystem.out.println(run.getName());',
+}
+
+# ---------------------------------------------------------------------------
+# Java preamble templates
+# ---------------------------------------------------------------------------
+
+JAVA_OPENAI_PREAMBLE_ENTRA = """import com.azure.ai.projects.AIProjectClient;
+import com.azure.ai.projects.AIProjectClientBuilder;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+AIProjectClient project = new AIProjectClientBuilder()
+    .endpoint("https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME")
+    .credential(new DefaultAzureCredentialBuilder().build())
+    .buildClient();
+
+"""
+
+JAVA_OPENAI_PREAMBLE_APIKEY = """import com.azure.ai.projects.AIProjectClient;
+import com.azure.ai.projects.AIProjectClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+
+AIProjectClient project = new AIProjectClientBuilder()
+    .endpoint("https://RESOURCE_NAME.services.ai.azure.com/api/projects/PROJECT_NAME")
+    .credential(new AzureKeyCredential("YOUR_API_KEY"))
+    .buildClient();
+
+"""
+
+
+# ---------------------------------------------------------------------------
+# Java samples — OpenAI v1 API
+# ---------------------------------------------------------------------------
+
+JAVA_OPENAI_SAMPLES = {
+    # ── Responses ─────────────────────────────────────────────────────
+    "createResponse": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.responses()\n'
+        '    .create("gpt-4o", "What is the capital of France?");\n'
+        '\n'
+        'System.out.println(response.getOutputText());'
+    ),
+    "getResponse": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.responses().retrieve("resp_abc123");\n'
+        '\n'
+        'System.out.println(response.getStatus());'
+    ),
+    "deleteResponse": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.responses().delete("resp_abc123");'
+    ),
+    "cancelResponse": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.responses().cancel("resp_abc123");'
+    ),
+    "listInputItems": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var items = openai.responses().inputItems()\n'
+        '    .list("resp_abc123");\n'
+        '\n'
+        'for (var item : items) {\n'
+        '    System.out.println(item.getType() + " " + item.getId());\n'
+        '}'
+    ),
+
+    # ── Chat ──────────────────────────────────────────────────────────
+    "createChatCompletion": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.chat().completions().create(\n'
+        '    "gpt-4o",\n'
+        '    List.of(Map.of("role", "user", "content", "Hello!")));\n'
+        '\n'
+        'System.out.println(\n'
+        '    response.getChoices().get(0).getMessage().getContent());'
+    ),
+    "createCompletion": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.completions().create(\n'
+        '    "gpt-4o", "Say hello", 100);\n'
+        '\n'
+        'System.out.println(response.getChoices().get(0).getText());'
+    ),
+
+    # ── Conversations ─────────────────────────────────────────────────
+    "createConversation": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var conversation = openai.conversations().create(\n'
+        '    List.of(Map.of("type", "message", "role", "user",\n'
+        '        "content", "Hello")));\n'
+        '\n'
+        'System.out.println(conversation.getId());'
+    ),
+    "retrieveConversation": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var conversation = openai.conversations()\n'
+        '    .retrieve("conv_abc123");\n'
+        '\n'
+        'System.out.println(conversation.getId());'
+    ),
+    "updateConversation": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var conversation = openai.conversations()\n'
+        '    .update("conv_abc123",\n'
+        '        Map.of("metadata", Map.of("topic", "geography")));\n'
+        '\n'
+        'System.out.println(conversation.getId());'
+    ),
+    "deleteConversation": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.conversations().delete("conv_abc123");'
+    ),
+    "listConversationItems": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var items = openai.conversations().items()\n'
+        '    .list("conv_abc123");\n'
+        '\n'
+        'for (var item : items) {\n'
+        '    System.out.println(item.getType() + " " + item.getId());\n'
+        '}'
+    ),
+    "createConversationItems": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.conversations().items().create("conv_abc123",\n'
+        '    List.of(Map.of("type", "message", "role", "user",\n'
+        '        "content", "Follow-up")));'
+    ),
+    "retrieveConversationItem": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var item = openai.conversations().items()\n'
+        '    .retrieve("conv_abc123", "item_abc123");\n'
+        '\n'
+        'System.out.println(item.getType());'
+    ),
+    "deleteConversationItem": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.conversations().items()\n'
+        '    .delete("conv_abc123", "item_abc123");'
+    ),
+
+    # ── Embeddings ────────────────────────────────────────────────────
+    "createEmbedding": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.embeddings().create(\n'
+        '    "text-embedding-3-large", "Sample text to embed");\n'
+        '\n'
+        'System.out.println(\n'
+        '    response.getData().get(0).getEmbedding().size());'
+    ),
+
+    # ── Models ────────────────────────────────────────────────────────
+    "listModels": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var models = openai.models().list();\n'
+        '\n'
+        'for (var model : models) {\n'
+        '    System.out.println(model.getId());\n'
+        '}'
+    ),
+    "retrieveModel": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var model = openai.models().retrieve("gpt-4o");\n'
+        '\n'
+        'System.out.println(model.getId() + " " + model.getOwnedBy());'
+    ),
+    "deleteModel": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.models()\n'
+        '    .delete("ft:gpt-4o:your-org:custom-suffix:id");'
+    ),
+
+    # ── Files ─────────────────────────────────────────────────────────
+    "createFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var file = openai.files().create(\n'
+        '    Path.of("data.jsonl"), "fine-tune");\n'
+        '\n'
+        'System.out.println(file.getId());'
+    ),
+    "listFiles": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var files = openai.files().list();\n'
+        '\n'
+        'for (var f : files) {\n'
+        '    System.out.println(f.getId() + " " + f.getFilename());\n'
+        '}'
+    ),
+    "retrieveFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var file = openai.files().retrieve("file-abc123");\n'
+        '\n'
+        'System.out.println(file.getFilename() + " " + file.getStatus());'
+    ),
+    "deleteFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.files().delete("file-abc123");'
+    ),
+    "downloadFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var content = openai.files().content("file-abc123");\n'
+        '\n'
+        'System.out.println(new String(content));'
+    ),
+
+    # ── Batch ─────────────────────────────────────────────────────────
+    "createBatch": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var batch = openai.batches().create(\n'
+        '    "file-abc123", "/v1/chat/completions", "24h");\n'
+        '\n'
+        'System.out.println(batch.getId() + " " + batch.getStatus());'
+    ),
+    "listBatches": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var batches = openai.batches().list();\n'
+        '\n'
+        'for (var b : batches) {\n'
+        '    System.out.println(b.getId() + " " + b.getStatus());\n'
+        '}'
+    ),
+    "retrieveBatch": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var batch = openai.batches().retrieve("batch_abc123");\n'
+        '\n'
+        'System.out.println(batch.getStatus());'
+    ),
+    "cancelBatch": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.batches().cancel("batch_abc123");'
+    ),
+
+    # ── Fine-tuning ───────────────────────────────────────────────────
+    "createFineTuningJob": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var job = openai.fineTuning().jobs().create(\n'
+        '    "gpt-4o-mini-2024-07-18", "file-abc123");\n'
+        '\n'
+        'System.out.println(job.getId() + " " + job.getStatus());'
+    ),
+    "listPaginatedFineTuningJobs": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var jobs = openai.fineTuning().jobs().list();\n'
+        '\n'
+        'for (var job : jobs) {\n'
+        '    System.out.println(job.getId() + " " + job.getStatus());\n'
+        '}'
+    ),
+    "retrieveFineTuningJob": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var job = openai.fineTuning().jobs()\n'
+        '    .retrieve("ftjob-abc123");\n'
+        '\n'
+        'System.out.println(job.getStatus());'
+    ),
+    "cancelFineTuningJob": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.fineTuning().jobs().cancel("ftjob-abc123");'
+    ),
+    "listFineTuningJobCheckpoints": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var checkpoints = openai.fineTuning().jobs()\n'
+        '    .checkpoints().list("ftjob-abc123");\n'
+        '\n'
+        'for (var cp : checkpoints) {\n'
+        '    System.out.println(cp.getId() + " step " + cp.getStepNumber());\n'
+        '}'
+    ),
+    "listFineTuningEvents": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var events = openai.fineTuning().jobs()\n'
+        '    .listEvents("ftjob-abc123");\n'
+        '\n'
+        'for (var event : events) {\n'
+        '    System.out.println(event.getMessage());\n'
+        '}'
+    ),
+    "pauseFineTuningJob": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.fineTuning().jobs().pause("ftjob-abc123");'
+    ),
+    "resumeFineTuningJob": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.fineTuning().jobs().resume("ftjob-abc123");'
+    ),
+    "FineTuning_CopyCheckpoint": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.fineTuning().jobs().checkpoints()\n'
+        '    .copy("ftjob-abc123", "ftckpt-abc123");'
+    ),
+    "FineTuning_GetCheckpoint": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var checkpoint = openai.fineTuning().jobs()\n'
+        '    .checkpoints().retrieve("ftjob-abc123", "ftckpt-abc123");\n'
+        '\n'
+        'System.out.println(checkpoint.getId());'
+    ),
+    "listFineTuningCheckpointPermissions": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var permissions = openai.fineTuning().checkpoints()\n'
+        '    .permissions().list("ft:gpt-4o:org:suffix:id");\n'
+        '\n'
+        'for (var p : permissions) {\n'
+        '    System.out.println(p.getId());\n'
+        '}'
+    ),
+    "createFineTuningCheckpointPermission": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.fineTuning().checkpoints().permissions()\n'
+        '    .create("ft:gpt-4o:org:suffix:id",\n'
+        '        List.of("proj_abc123"));'
+    ),
+    "deleteFineTuningCheckpointPermission": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.fineTuning().checkpoints().permissions()\n'
+        '    .delete("ft:gpt-4o:org:suffix:id", "perm_abc123");'
+    ),
+    "runGrader": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var result = openai.fineTuning().alpha().graders()\n'
+        '    .run(Map.of("type", "python", "source", "return 1.0"),\n'
+        '        "Hello world");\n'
+        '\n'
+        'System.out.println(result);'
+    ),
+    "validateGrader": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var result = openai.fineTuning().alpha().graders()\n'
+        '    .validate(Map.of("type", "python",\n'
+        '        "source", "return 1.0"));\n'
+        '\n'
+        'System.out.println(result);'
+    ),
+
+    # ── Evals ─────────────────────────────────────────────────────────
+    "listEvals": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var evals = openai.evals().list();\n'
+        '\n'
+        'for (var e : evals) {\n'
+        '    System.out.println(e.getId() + " " + e.getName());\n'
+        '}'
+    ),
+    "createEval": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var evaluation = openai.evals().create(\n'
+        '    "my-eval",\n'
+        '    Map.of("type", "custom", "item_schema", Map.of()),\n'
+        '    List.of());\n'
+        '\n'
+        'System.out.println(evaluation.getId());'
+    ),
+    "getEval": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var evaluation = openai.evals()\n'
+        '    .retrieve("eval_abc123");\n'
+        '\n'
+        'System.out.println(evaluation.getName());'
+    ),
+    "updateEval": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var evaluation = openai.evals()\n'
+        '    .update("eval_abc123", Map.of("name", "updated-name"));\n'
+        '\n'
+        'System.out.println(evaluation.getName());'
+    ),
+    "deleteEval": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.evals().delete("eval_abc123");'
+    ),
+    "getEvalRuns": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var runs = openai.evals().runs().list("eval_abc123");\n'
+        '\n'
+        'for (var run : runs) {\n'
+        '    System.out.println(run.getId() + " " + run.getStatus());\n'
+        '}'
+    ),
+    "createEvalRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var run = openai.evals().runs().create(\n'
+        '    "eval_abc123", "gpt-4o",\n'
+        '    Map.of("type", "completions"));\n'
+        '\n'
+        'System.out.println(run.getId());'
+    ),
+    "getEvalRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var run = openai.evals().runs()\n'
+        '    .retrieve("eval_abc123", "run_abc123");\n'
+        '\n'
+        'System.out.println(run.getStatus());'
+    ),
+    "cancelEvalRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.evals().runs()\n'
+        '    .cancel("eval_abc123", "run_abc123");'
+    ),
+    "deleteEvalRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.evals().runs()\n'
+        '    .delete("eval_abc123", "run_abc123");'
+    ),
+    "getEvalRunOutputItems": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var items = openai.evals().runs().outputItems()\n'
+        '    .list("eval_abc123", "run_abc123");\n'
+        '\n'
+        'for (var item : items) {\n'
+        '    System.out.println(item.getId());\n'
+        '}'
+    ),
+    "getEvalRunOutputItem": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var item = openai.evals().runs().outputItems()\n'
+        '    .retrieve("eval_abc123", "run_abc123",\n'
+        '        "item_abc123");\n'
+        '\n'
+        'System.out.println(item.getId());'
+    ),
+
+    # ── Realtime ──────────────────────────────────────────────────────
+    "createRealtimeSession": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var session = openai.realtime().sessions()\n'
+        '    .create("gpt-4o-realtime-preview");\n'
+        '\n'
+        'System.out.println(session.getId());'
+    ),
+    "createRealtimeClientSecret": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var secret = openai.realtime().clientSecrets()\n'
+        '    .create("gpt-4o-realtime-preview");\n'
+        '\n'
+        'System.out.println(secret.getClientSecret().getValue());'
+    ),
+    "createRealtimeTranscriptionSession": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var session = openai.realtime().transcriptionSessions()\n'
+        '    .create("gpt-4o-transcribe");\n'
+        '\n'
+        'System.out.println(session.getId());'
+    ),
+    "createRealtimeCall": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var call = openai.realtime().calls().create(\n'
+        '    "gpt-4o-realtime-preview", "YOUR_SDP_OFFER");\n'
+        '\n'
+        'System.out.println(call.getId() + " " + call.getSdp());'
+    ),
+    "acceptRealtimeCall": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.realtime().calls()\n'
+        '    .accept("call_abc123", "gpt-4o-realtime-preview");'
+    ),
+    "hangupRealtimeCall": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.realtime().calls().hangup("call_abc123");'
+    ),
+    "referRealtimeCall": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.realtime().calls()\n'
+        '    .refer("call_abc123", "sip:destination@example.com");'
+    ),
+    "rejectRealtimeCall": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.realtime().calls()\n'
+        '    .reject("call_abc123", "busy");'
+    ),
+
+    # ── Containers ────────────────────────────────────────────────────
+    "listContainers": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var containers = openai.containers().list();\n'
+        '\n'
+        'for (var c : containers) {\n'
+        '    System.out.println(c.getId() + " " + c.getName());\n'
+        '}'
+    ),
+    "createContainer": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var container = openai.containers()\n'
+        '    .create("my-container");\n'
+        '\n'
+        'System.out.println(container.getId());'
+    ),
+    "retrieveContainer": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var container = openai.containers()\n'
+        '    .retrieve("container_abc123");\n'
+        '\n'
+        'System.out.println(container.getName());'
+    ),
+    "deleteContainer": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.containers().delete("container_abc123");'
+    ),
+    "listContainerFiles": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var files = openai.containers().files()\n'
+        '    .list("container_abc123");\n'
+        '\n'
+        'for (var f : files) {\n'
+        '    System.out.println(f.getId() + " " + f.getPath());\n'
+        '}'
+    ),
+    "createContainerFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var file = openai.containers().files()\n'
+        '    .create("container_abc123",\n'
+        '        Path.of("data.txt"), "data.txt");\n'
+        '\n'
+        'System.out.println(file.getId());'
+    ),
+    "retrieveContainerFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var file = openai.containers().files()\n'
+        '    .retrieve("container_abc123", "file_abc123");\n'
+        '\n'
+        'System.out.println(file.getPath());'
+    ),
+    "deleteContainerFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.containers().files()\n'
+        '    .delete("container_abc123", "file_abc123");'
+    ),
+    "retrieveContainerFileContent": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var content = openai.containers().files()\n'
+        '    .content("container_abc123", "file_abc123");\n'
+        '\n'
+        'System.out.println(new String(content));'
+    ),
+
+    # ── Threads (legacy) ──────────────────────────────────────────────
+    "createThread": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var thread = openai.beta().threads().create();\n'
+        '\n'
+        'System.out.println(thread.getId());'
+    ),
+    "retrieveThread": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var thread = openai.beta().threads()\n'
+        '    .retrieve("thread_abc123");\n'
+        '\n'
+        'System.out.println(thread.getId());'
+    ),
+    "modifyThread": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.beta().threads().update("thread_abc123",\n'
+        '    Map.of("metadata", Map.of("topic", "science")));'
+    ),
+    "deleteThread": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.beta().threads().delete("thread_abc123");'
+    ),
+    "createMessage": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var message = openai.beta().threads().messages()\n'
+        '    .create("thread_abc123", "user",\n'
+        '        "What is the capital of France?");\n'
+        '\n'
+        'System.out.println(message.getId());'
+    ),
+    "listMessages": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var messages = openai.beta().threads().messages()\n'
+        '    .list("thread_abc123");\n'
+        '\n'
+        'for (var msg : messages) {\n'
+        '    System.out.println(msg.getRole() + " "\n'
+        '        + msg.getContent().get(0).getText().getValue());\n'
+        '}'
+    ),
+    "retrieveMessage": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var message = openai.beta().threads().messages()\n'
+        '    .retrieve("thread_abc123", "msg_abc123");\n'
+        '\n'
+        'System.out.println(\n'
+        '    message.getContent().get(0).getText().getValue());'
+    ),
+    "modifyMessage": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.beta().threads().messages()\n'
+        '    .update("thread_abc123", "msg_abc123",\n'
+        '        Map.of("metadata", Map.of("reviewed", "true")));'
+    ),
+    "deleteMessage": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.beta().threads().messages()\n'
+        '    .delete("thread_abc123", "msg_abc123");'
+    ),
+    "createRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var run = openai.beta().threads().runs()\n'
+        '    .create("thread_abc123", "asst_abc123");\n'
+        '\n'
+        'System.out.println(run.getId() + " " + run.getStatus());'
+    ),
+    "createThreadAndRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var run = openai.beta().threads().createAndRun(\n'
+        '    "asst_abc123",\n'
+        '    Map.of("messages", List.of(\n'
+        '        Map.of("role", "user", "content", "Hello"))));\n'
+        '\n'
+        'System.out.println(run.getId());'
+    ),
+    "listRuns": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var runs = openai.beta().threads().runs()\n'
+        '    .list("thread_abc123");\n'
+        '\n'
+        'for (var run : runs) {\n'
+        '    System.out.println(run.getId() + " " + run.getStatus());\n'
+        '}'
+    ),
+    "retrieveRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var run = openai.beta().threads().runs()\n'
+        '    .retrieve("thread_abc123", "run_abc123");\n'
+        '\n'
+        'System.out.println(run.getStatus());'
+    ),
+    "modifyRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.beta().threads().runs()\n'
+        '    .update("thread_abc123", "run_abc123",\n'
+        '        Map.of("metadata", Map.of("priority", "high")));'
+    ),
+    "cancelRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.beta().threads().runs()\n'
+        '    .cancel("thread_abc123", "run_abc123");'
+    ),
+    "submitToolOutputsToRun": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var run = openai.beta().threads().runs()\n'
+        '    .submitToolOutputs("thread_abc123", "run_abc123",\n'
+        '        List.of(Map.of("tool_call_id", "call_abc123",\n'
+        '            "output", "result")));\n'
+        '\n'
+        'System.out.println(run.getStatus());'
+    ),
+    "listRunSteps": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var steps = openai.beta().threads().runs().steps()\n'
+        '    .list("thread_abc123", "run_abc123");\n'
+        '\n'
+        'for (var step : steps) {\n'
+        '    System.out.println(step.getId() + " " + step.getType());\n'
+        '}'
+    ),
+    "getRunStep": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var step = openai.beta().threads().runs().steps()\n'
+        '    .retrieve("thread_abc123", "run_abc123",\n'
+        '        "step_abc123");\n'
+        '\n'
+        'System.out.println(step.getType() + " " + step.getStatus());'
+    ),
+
+    # ── Vector Stores ─────────────────────────────────────────────────
+    "listVectorStores": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var stores = openai.vectorStores().list();\n'
+        '\n'
+        'for (var store : stores) {\n'
+        '    System.out.println(store.getId() + " " + store.getName());\n'
+        '}'
+    ),
+    "createVectorStore": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var store = openai.vectorStores()\n'
+        '    .create("my-vector-store");\n'
+        '\n'
+        'System.out.println(store.getId());'
+    ),
+    "getVectorStore": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var store = openai.vectorStores()\n'
+        '    .retrieve("vs_abc123");\n'
+        '\n'
+        'System.out.println(store.getName());'
+    ),
+    "modifyVectorStore": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.vectorStores().update("vs_abc123",\n'
+        '    Map.of("name", "updated-name"));'
+    ),
+    "deleteVectorStore": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.vectorStores().delete("vs_abc123");'
+    ),
+    "searchVectorStore": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var results = openai.vectorStores()\n'
+        '    .search("vs_abc123", "search query");\n'
+        '\n'
+        'for (var result : results) {\n'
+        '    System.out.println(result.getScore()\n'
+        '        + " " + result.getContent());\n'
+        '}'
+    ),
+    "listVectorStoreFiles": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var files = openai.vectorStores().files()\n'
+        '    .list("vs_abc123");\n'
+        '\n'
+        'for (var f : files) {\n'
+        '    System.out.println(f.getId() + " " + f.getStatus());\n'
+        '}'
+    ),
+    "createVectorStoreFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var file = openai.vectorStores().files()\n'
+        '    .create("vs_abc123", "file_abc123");\n'
+        '\n'
+        'System.out.println(file.getId() + " " + file.getStatus());'
+    ),
+    "getVectorStoreFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var file = openai.vectorStores().files()\n'
+        '    .retrieve("vs_abc123", "file_abc123");\n'
+        '\n'
+        'System.out.println(file.getStatus());'
+    ),
+    "updateVectorStoreFileAttributes": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.vectorStores().files().update(\n'
+        '    "vs_abc123", "file_abc123",\n'
+        '    Map.of("key", "value"));'
+    ),
+    "deleteVectorStoreFile": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.vectorStores().files()\n'
+        '    .delete("vs_abc123", "file_abc123");'
+    ),
+    "retrieveVectorStoreFileContent": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var content = openai.vectorStores().files()\n'
+        '    .content("vs_abc123", "file_abc123");\n'
+        '\n'
+        'System.out.println(new String(content));'
+    ),
+    "createVectorStoreFileBatch": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var batch = openai.vectorStores().fileBatches()\n'
+        '    .create("vs_abc123",\n'
+        '        List.of("file_abc123", "file_def456"));\n'
+        '\n'
+        'System.out.println(batch.getId() + " " + batch.getStatus());'
+    ),
+    "getVectorStoreFileBatch": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var batch = openai.vectorStores().fileBatches()\n'
+        '    .retrieve("vs_abc123", "vsfb_abc123");\n'
+        '\n'
+        'System.out.println(batch.getStatus());'
+    ),
+    "cancelVectorStoreFileBatch": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.vectorStores().fileBatches()\n'
+        '    .cancel("vs_abc123", "vsfb_abc123");'
+    ),
+    "listFilesInVectorStoreBatch": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var files = openai.vectorStores().fileBatches()\n'
+        '    .listFiles("vs_abc123", "vsfb_abc123");\n'
+        '\n'
+        'for (var f : files) {\n'
+        '    System.out.println(f.getId() + " " + f.getStatus());\n'
+        '}'
+    ),
+
+    # ── Audio ─────────────────────────────────────────────────────────
+    "createSpeech": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.audio().speech().create(\n'
+        '    "tts-1", "alloy",\n'
+        '    "Hello, how are you today?");\n'
+        '\n'
+        'Files.write(Path.of("output.mp3"), response);'
+    ),
+    "createTranscription": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var transcription = openai.audio().transcriptions()\n'
+        '    .create("whisper-1", Path.of("audio.mp3"));\n'
+        '\n'
+        'System.out.println(transcription.getText());'
+    ),
+    "createTranslation": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var translation = openai.audio().translations()\n'
+        '    .create("whisper-1", Path.of("audio.mp3"));\n'
+        '\n'
+        'System.out.println(translation.getText());'
+    ),
+
+    # ── Images ────────────────────────────────────────────────────────
+    "createImage": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.images().generate(\n'
+        '    "dall-e-3",\n'
+        '    "A white cat sitting on a windowsill",\n'
+        '    1, "1024x1024");\n'
+        '\n'
+        'System.out.println(response.getData().get(0).getUrl());'
+    ),
+    "createImageEdit": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.images().edit(\n'
+        '    Path.of("image.png"),\n'
+        '    "Add a sunset in the background",\n'
+        '    1, "1024x1024");\n'
+        '\n'
+        'System.out.println(response.getData().get(0).getUrl());'
+    ),
+    "createImageVariation": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var response = openai.images().createVariation(\n'
+        '    Path.of("image.png"), 1, "1024x1024");\n'
+        '\n'
+        'System.out.println(response.getData().get(0).getUrl());'
+    ),
+
+    # ── Video ─────────────────────────────────────────────────────────
+    "Videos_Create": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var job = openai.videos().create(\n'
+        '    "sora", "A serene mountain landscape at sunset");\n'
+        '\n'
+        'System.out.println(job.getId() + " " + job.getStatus());'
+    ),
+    "Videos_List": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var videos = openai.videos().list();\n'
+        '\n'
+        'for (var v : videos) {\n'
+        '    System.out.println(v.getId() + " " + v.getStatus());\n'
+        '}'
+    ),
+    "Videos_Get": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var video = openai.videos().retrieve("video_abc123");\n'
+        '\n'
+        'System.out.println(video.getStatus());'
+    ),
+    "Videos_Delete": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'openai.videos().delete("video_abc123");'
+    ),
+    "Videos_RetrieveContent": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var content = openai.videos()\n'
+        '    .content("video_abc123");\n'
+        '\n'
+        'System.out.println(content.getUrl());'
+    ),
+    "Videos_Remix": (
+        'var openai = project.getOpenAIClient();\n'
+        '\n'
+        'var job = openai.videos().remix(\n'
+        '    "video_abc123", "Make it a night scene");\n'
+        '\n'
+        'System.out.println(job.getId());'
+    ),
 }


### PR DESCRIPTION
## Summary

Complete SDK code sample and response example coverage for the API Reference tab.

### Code samples: 2,670 total (was ~486)
- **Python**: 100% → 100% (unchanged)
- **cURL**: 100% → 100% (unchanged)
- **C#**: 9.4% → **100%** (+96 operations)
- **JavaScript**: 19.8% → **100%** (+85 operations)
- **Java**: 0% → **100%** (new language, +267 operations)

Each operation has 5 langs × 2 auth variants (Entra ID + API Key) = 10 samples.

### Response examples: 0 → 120
Added realistic JSON response examples to all JSON-returning endpoints. Mintlify now renders actual data (`"The capital of France is Paris."`) instead of `"<string>"` placeholders.

### Comment cleanup
All comments stripped from code samples — pure code only, no preamble hints or output comments.

### Scripts
| Script | Purpose |
|--------|---------|
| `sdk_samples_multilang.py` | C#, JS, Java, cURL sample dictionaries (+2,600 lines) |
| `generate_sdk_samples.py` | Java wired as 5th language in injection pipeline |
| `add_response_examples.py` | New: injects response examples into OpenAPI specs |