### PR TITLE
Fix dall-e.mdx MDX parse error (stray zone markers)

### DIFF
--- a/docs/foundry-models/dall-e.mdx
+++ b/docs/foundry-models/dall-e.mdx
@@ -237,10 +237,6 @@ Remember to remove the key from your code when you're done, and never post your 
     - [Azure portal](/setup/multi-service-resource)
     - [Azure CLI](/setup/multi-service-resource)
 
-    ::: zone-end
-
-    ::: zone pivot="programming-language-python"
-
     Use this guide to get started generating images with the Azure OpenAI SDK for Python.
 
     [Library source code](https://github.com/openai/openai-python/tree/main/src/openai) | [Package](https://github.com/openai/openai-python) | [Samples](https://github.com/openai/openai-python/tree/main/examples)
@@ -278,7 +274,7 @@ Remember to remove the key from your code when you're done, and never post your 
 
     Create and assign persistent environment variables for your key and endpoint.
 
-  </Tab>
+<Tabs>
   <Tab title="Command Line">
 
     ```cmd

--- a/scripts/convert_to_mdx.py
+++ b/scripts/convert_to_mdx.py
@@ -491,7 +491,8 @@ def convert_zone_pivots(content: str) -> str:
         line = lines[i]
 
         # Match zone start: :::zone pivot="python" or ::: zone pivot="python"
-        zone_start = re.match(r':::\s*zone\s+pivot="([^"]+)"\s*$', line)
+        # Use .strip() to handle indented zone markers
+        zone_start = re.match(r':::\s*zone\s+pivot="([^"]+)"\s*$', line.strip())
         if zone_start:
             pivot_name = zone_start.group(1)
             zones.append((pivot_name, []))
@@ -499,7 +500,7 @@ def convert_zone_pivots(content: str) -> str:
             continue
 
         # Match zone end: :::zone-end or ::: zone-end
-        if re.match(r':::\s*zone-end\s*$', line):
+        if re.match(r':::\s*zone-end\s*$', line.strip()):
             if zones:
                 pivot_name, zone_content = zones.pop()
                 zone_groups.append((pivot_name, zone_content))


### PR DESCRIPTION
## Problem
Deployment still failing after PR #168:
```
Failed to parse page content at path foundry-models/dall-e.mdx: Unexpected closing slash `/` in tag, expected an open tag first
```

## Root cause
Two `:::zone` markers on indented lines weren't converted by `convert_zone_pivots()` because `re.match()` anchors at string start and the leading whitespace prevented matching. This left an orphan `</Tab>` with no opening tag.

## Fix
- Removed the two stray zone markers and restructured the env var section with a proper `<Tabs>` wrapper
- Fixed `convert_to_mdx.py`: added `.strip()` before regex matching so indented zone markers are handled
- Verified all **434 MDX files** parse clean with the MDX compiler, **85 tests** pass