### PR TITLE
feat: add interactive Model Explorer with search, filter, and faceted navigation

### DIFF
--- a/.github/workflows/model-catalog-sync.md
+++ b/.github/workflows/model-catalog-sync.md
@@ -1,0 +1,106 @@
+---
+name: Model Catalog Sync
+description: Scrapes Azure AI model catalog API and regenerates models.json for the interactive model explorer
+on:
+  schedule:
+    - cron: daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+tracker-id: model-catalog-sync
+engine: copilot
+strict: true
+timeout-minutes: 15
+concurrency:
+  group: "gh-aw-${{ github.workflow }}"
+  cancel-in-progress: true
+
+network:
+  allowed:
+    - defaults
+    - github
+    - ai.azure.com
+
+safe-outputs:
+  create-pull-request:
+    title-prefix: "[model-catalog] "
+    labels: [automation, model-catalog]
+    auto-merge: true
+    expires: 2d
+    draft: false
+  noop:
+
+tools:
+  cache-memory: true
+  github:
+    toolsets: [default]
+  edit:
+  bash:
+    - "python3 scripts/*"
+    - "git *"
+    - "cat *"
+    - "diff *"
+    - "wc *"
+    - "ls *"
+    - "pip *"
+
+imports:
+  - shared/mood.md
+  - shared/reporting.md
+
+---
+
+# Model Catalog Sync
+
+You are an automation agent that regenerates the model catalog data file for the interactive Model Explorer page.
+
+## Context
+
+- **Repository**: ${{ github.repository }}
+- **Script**: `scripts/scrape_model_catalog.py`
+- **Output**: `docs-vnext/static/data/models.json`
+- The script scrapes the public Azure AI Asset Gallery API, normalizes model metadata, and writes a JSON file
+
+## Step 1: Run the Catalog Scraper
+
+Run the scraper script to regenerate models.json:
+
+```bash
+python3 scripts/scrape_model_catalog.py --output docs-vnext/static/data
+```
+
+If the script exits with a non-zero code, call `noop` with the error output and STOP — do NOT create a PR with bad data.
+
+## Step 2: Check for Changes
+
+```bash
+git diff --stat docs-vnext/static/data/models.json
+```
+
+If there are no changes, call `noop` with message "Model catalog data is up to date — no changes detected."
+
+## Step 3: Summarize Changes
+
+If models.json changed, analyze the diff to summarize:
+- Number of models before vs after
+- New models added
+- Models removed
+- Changed fields
+
+Use this to build the PR description.
+
+## Step 4: Create Pull Request
+
+Use `create_pull_request` with:
+- Title describing what changed (e.g., "Update model catalog: 3 new models, 1 removed")
+- Body with the change summary from Step 3
+- The changed file: `docs-vnext/static/data/models.json`
+
+## Error Handling
+
+- If the scraper fails: `noop` with error message
+- If no changes: `noop` with "up to date" message
+- Never commit or PR bad data

--- a/docs-vnext/docs.json
+++ b/docs-vnext/docs.json
@@ -102,6 +102,7 @@
               {
                 "group": "Model catalog",
                 "pages": [
+                  "models/catalog/model-explorer",
                   "models/catalog/models-sold-directly-by-azure",
                   "models/catalog/models-from-partners",
                   "models/catalog/model-versions",

--- a/docs-vnext/models/catalog/model-explorer.mdx
+++ b/docs-vnext/models/catalog/model-explorer.mdx
@@ -1,0 +1,18 @@
+---
+title: "Model Explorer"
+description: "Search and filter all available Azure AI models by provider, capability, deployment type, and more"
+---
+
+import { ModelCatalog } from "/snippets/model-catalog.jsx"
+
+# Model Explorer
+
+Browse all models available directly from Azure in Microsoft Foundry. Use the search bar and faceted filters to find models by provider, capability, deployment type, and task.
+
+<Tip>
+This catalog is auto-generated from the Azure AI model registry and refreshed daily.
+For detailed model documentation, see [Models sold directly by Azure](/models/catalog/models-sold-directly-by-azure).
+For deployment guidance, see [Deployment types](/models/catalog/deployment-types).
+</Tip>
+
+<ModelCatalog />

--- a/docs-vnext/snippets/model-catalog.jsx
+++ b/docs-vnext/snippets/model-catalog.jsx
@@ -1,0 +1,463 @@
+export const ModelCatalog = () => {
+  const [models, setModels] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [activeFilters, setActiveFilters] = useState({})
+  const [sortBy, setSortBy] = useState("name")
+  const [expandedModel, setExpandedModel] = useState(null)
+
+  useEffect(() => {
+    fetch("/static/data/models.json")
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      })
+      .then((data) => {
+        setModels(data.models || [])
+        setLoading(false)
+      })
+      .catch((err) => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [])
+
+  const facetConfig = useMemo(
+    () => [
+      { key: "publisher", label: "Provider" },
+      { key: "tasks", label: "Task" },
+      { key: "capabilities", label: "Capability" },
+      { key: "deploymentTypes", label: "Deployment" },
+    ],
+    []
+  )
+
+  const facetCounts = useMemo(() => {
+    const counts = {}
+    for (const f of facetConfig) {
+      const map = {}
+      for (const m of models) {
+        const vals = Array.isArray(m[f.key]) ? m[f.key] : [m[f.key]]
+        for (const v of vals) {
+          if (v) map[v] = (map[v] || 0) + 1
+        }
+      }
+      counts[f.key] = Object.entries(map)
+        .sort((a, b) => b[1] - a[1])
+        .map(([value, count]) => ({ value, count }))
+    }
+    return counts
+  }, [models, facetConfig])
+
+  const filteredModels = useMemo(() => {
+    let result = models
+
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      result = result.filter(
+        (m) =>
+          m.displayName?.toLowerCase().includes(q) ||
+          m.publisher?.toLowerCase().includes(q) ||
+          m.summary?.toLowerCase().includes(q) ||
+          m.id?.toLowerCase().includes(q) ||
+          m.keywords?.some((k) => k.toLowerCase().includes(q))
+      )
+    }
+
+    for (const [key, values] of Object.entries(activeFilters)) {
+      if (values && values.length > 0) {
+        result = result.filter((m) => {
+          const mVal = m[key]
+          if (Array.isArray(mVal)) {
+            return values.some((v) => mVal.includes(v))
+          }
+          return values.includes(mVal)
+        })
+      }
+    }
+
+    result = [...result].sort((a, b) => {
+      if (sortBy === "name")
+        return (a.displayName || "").localeCompare(b.displayName || "")
+      if (sortBy === "context")
+        return (b.contextWindow || 0) - (a.contextWindow || 0)
+      if (sortBy === "publisher")
+        return (a.publisher || "").localeCompare(b.publisher || "")
+      return 0
+    })
+
+    return result
+  }, [models, searchQuery, activeFilters, sortBy])
+
+  const toggleFilter = (facetKey, value) => {
+    setActiveFilters((prev) => {
+      const current = prev[facetKey] || []
+      const next = current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value]
+      return { ...prev, [facetKey]: next }
+    })
+  }
+
+  const clearFilters = () => {
+    setActiveFilters({})
+    setSearchQuery("")
+  }
+
+  const hasActiveFilters =
+    searchQuery ||
+    Object.values(activeFilters).some((v) => v && v.length > 0)
+
+  const DEPLOY_LABELS = {
+    "aoai-deployment": "Azure OpenAI",
+    "batch-enabled": "Batch",
+    "maas-inference": "Serverless API",
+    "maap-inference": "Managed Compute",
+  }
+
+  const TASK_LABELS = {
+    "chat-completion": "Chat",
+    responses: "Responses",
+    embeddings: "Embeddings",
+    "text-to-image": "Image Gen",
+    "image-to-image": "Image Edit",
+    "audio-generation": "Audio Gen",
+    "speech-to-text": "Speech-to-Text",
+    "text-to-speech": "Text-to-Speech",
+    "video-generation": "Video Gen",
+    "automatic-speech-recognition": "ASR",
+  }
+
+  const CAP_LABELS = {
+    agentsV2: "Agents",
+    agents: "Agents (v1)",
+    reasoning: "Reasoning",
+    streaming: "Streaming",
+    "tool-calling": "Tool Calling",
+    "fine-tuning": "Fine-tuning",
+    assistants: "Assistants",
+  }
+
+  const formatLabel = (key, value) => {
+    if (key === "deploymentTypes") return DEPLOY_LABELS[value] || value
+    if (key === "tasks") return TASK_LABELS[value] || value
+    if (key === "capabilities") return CAP_LABELS[value] || value
+    return value
+  }
+
+  const formatNumber = (n) => {
+    if (!n) return "—"
+    if (n >= 1000000) return `${(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)}M`
+    if (n >= 1000) return `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}K`
+    return String(n)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="text-zinc-500 dark:text-zinc-400 text-sm">
+          Loading model catalog…
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-4">
+        <p className="text-red-700 dark:text-red-400 text-sm">
+          Failed to load model catalog: {error}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="not-prose">
+      {/* Search + Sort bar */}
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+        <div className="relative flex-1">
+          <input
+            type="text"
+            placeholder="Search models by name, provider, or keyword…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full px-4 py-2.5 pl-10 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
+            aria-label="Search models"
+          />
+          <svg
+            className="absolute left-3 top-3 h-4 w-4 text-zinc-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value)}
+          className="px-3 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm"
+          aria-label="Sort models"
+        >
+          <option value="name">Sort: Name</option>
+          <option value="publisher">Sort: Provider</option>
+          <option value="context">Sort: Context Window</option>
+        </select>
+      </div>
+
+      {/* Active filter pills + clear */}
+      {hasActiveFilters && (
+        <div className="flex flex-wrap gap-2 mb-4 items-center">
+          {Object.entries(activeFilters).map(([key, values]) =>
+            (values || []).map((v) => (
+              <button
+                key={`${key}-${v}`}
+                onClick={() => toggleFilter(key, v)}
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800/50 transition-colors"
+              >
+                {formatLabel(key, v)}
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            ))
+          )}
+          <button
+            onClick={clearFilters}
+            className="text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 underline"
+          >
+            Clear all
+          </button>
+        </div>
+      )}
+
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Faceted sidebar */}
+        <div className="lg:w-56 shrink-0 space-y-5">
+          {facetConfig.map((facet) => (
+            <div key={facet.key}>
+              <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+                {facet.label}
+              </h4>
+              <div className="space-y-1">
+                {(facetCounts[facet.key] || []).slice(0, 12).map(({ value, count }) => {
+                  const isActive = (activeFilters[facet.key] || []).includes(value)
+                  return (
+                    <button
+                      key={value}
+                      onClick={() => toggleFilter(facet.key, value)}
+                      className={`w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors text-left ${
+                        isActive
+                          ? "bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 font-medium"
+                          : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                      }`}
+                      aria-pressed={isActive}
+                    >
+                      <span className="truncate">{formatLabel(facet.key, value)}</span>
+                      <span className="text-zinc-400 dark:text-zinc-500 ml-2 tabular-nums">
+                        {count}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Model cards grid */}
+        <div className="flex-1 min-w-0">
+          <div className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
+            {filteredModels.length} model{filteredModels.length !== 1 ? "s" : ""}
+            {hasActiveFilters ? " matching filters" : ""}
+          </div>
+
+          {filteredModels.length === 0 ? (
+            <div className="text-center py-12 text-zinc-500 dark:text-zinc-400">
+              <p className="text-sm">No models match your filters.</p>
+              <button
+                onClick={clearFilters}
+                className="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Clear all filters
+              </button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {filteredModels.map((m) => (
+                <div
+                  key={`${m.publisher}-${m.id}`}
+                  className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-4 hover:border-zinc-300 dark:hover:border-zinc-600 transition-colors cursor-pointer"
+                  onClick={() =>
+                    setExpandedModel(
+                      expandedModel === `${m.publisher}-${m.id}`
+                        ? null
+                        : `${m.publisher}-${m.id}`
+                    )
+                  }
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      setExpandedModel(
+                        expandedModel === `${m.publisher}-${m.id}`
+                          ? null
+                          : `${m.publisher}-${m.id}`
+                      )
+                    }
+                  }}
+                  aria-expanded={expandedModel === `${m.publisher}-${m.id}`}
+                >
+                  {/* Card header */}
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <div className="min-w-0">
+                      <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">
+                        {m.displayName}
+                      </h3>
+                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {m.publisher} · v{m.latestVersion}
+                      </p>
+                    </div>
+                    {m.isPreview && (
+                      <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
+                        Preview
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Summary */}
+                  <p className="text-xs text-zinc-600 dark:text-zinc-400 line-clamp-2 mb-3">
+                    {m.summary || "No description available."}
+                  </p>
+
+                  {/* Spec row */}
+                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-zinc-500 dark:text-zinc-400 mb-2">
+                    {m.contextWindow && (
+                      <span title="Context window">
+                        📐 {formatNumber(m.contextWindow)} ctx
+                      </span>
+                    )}
+                    {m.maxOutputTokens && (
+                      <span title="Max output tokens">
+                        📝 {formatNumber(m.maxOutputTokens)} out
+                      </span>
+                    )}
+                    {m.versions && m.versions.length > 1 && (
+                      <span title="Available versions">
+                        📦 {m.versions.length} versions
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Capability tags */}
+                  <div className="flex flex-wrap gap-1">
+                    {m.tasks?.slice(0, 3).map((t) => (
+                      <span
+                        key={t}
+                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300"
+                      >
+                        {TASK_LABELS[t] || t}
+                      </span>
+                    ))}
+                    {m.capabilities?.slice(0, 3).map((c) => (
+                      <span
+                        key={c}
+                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
+                      >
+                        {CAP_LABELS[c] || c}
+                      </span>
+                    ))}
+                  </div>
+
+                  {/* Expanded details */}
+                  {expandedModel === `${m.publisher}-${m.id}` && (
+                    <div className="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800 space-y-2">
+                      {m.deploymentTypes?.length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Deployment:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {m.deploymentTypes
+                              .map((d) => DEPLOY_LABELS[d] || d)
+                              .join(", ")}
+                          </span>
+                        </div>
+                      )}
+                      {m.inputModalities?.length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Input:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {m.inputModalities.join(", ")}
+                          </span>
+                        </div>
+                      )}
+                      {m.outputModalities?.length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Output:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {m.outputModalities.join(", ")}
+                          </span>
+                        </div>
+                      )}
+                      {m.toolsSupported?.length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Tools:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {m.toolsSupported.slice(0, 8).join(", ")}
+                            {m.toolsSupported.length > 8 &&
+                              ` +${m.toolsSupported.length - 8} more`}
+                          </span>
+                        </div>
+                      )}
+                      {m.regions && Object.keys(m.regions).length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Regions:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {Object.entries(m.regions)
+                              .map(
+                                ([sku, regions]) =>
+                                  `${sku} (${regions.length} regions)`
+                              )
+                              .join(", ")}
+                          </span>
+                        </div>
+                      )}
+                      {m.pricingLink && (
+                        <a
+                          href={m.pricingLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline mt-1"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          View pricing →
+                        </a>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/docs-vnext/static/data/models.json
+++ b/docs-vnext/static/data/models.json
@@ -1,0 +1,6140 @@
+{
+  "generatedAt": "2026-04-08T17:36:11Z",
+  "totalModels": 103,
+  "models": [
+    {
+      "id": "qwen3-32b",
+      "displayName": "qwen3-32b",
+      "publisher": "Alibaba",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Flux-1.1-Pro",
+      "displayName": "FLUX1.1 [pro]",
+      "publisher": "Black Forest Labs",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Generate images with amazing image quality, prompt adherence, and diversity at blazing fast speeds. FLUX1.1 [pro] delivers six times faster image generation and achieved the highest Elo score on Artificial Analysis benchmarks when launched, surpassing all",
+      "tasks": [
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Flux.1-Kontext-pro",
+      "displayName": "FLUX.1 Kontext [pro]",
+      "publisher": "Black Forest Labs",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Generate and edit images through both text and image prompts. FLUX.1 Kontext is a multimodal flow matching model that enables both text-to-image generation and in-context image editing. Modify images while maintaining character consistency and performing l",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "FLUX.2-flex",
+      "displayName": "FLUX.2-flex",
+      "publisher": "Black Forest Labs",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Professional text-to-image generation with adjustable inference steps and guidance scale for fine-tuned control. Features superior typography and text rendering, supports up to 4MP resolution, 32K prompt tokens, and up to 8 reference images. Ideal for deve",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 32768,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "FLUX.2-pro",
+      "displayName": "FLUX.2 [pro]",
+      "publisher": "Black Forest Labs",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Generate and edit images through both text and image prompts. FLUX.2-pro is a multimodal flow matching model that enables both text-to-image generation and in-context image editing. Modify images while maintaining character consistency and performing local",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "cohere-command-a",
+      "displayName": "Cohere Command A",
+      "publisher": "Cohere",
+      "latestVersion": "4",
+      "versions": [
+        "4"
+      ],
+      "summary": "Command A is a highly efficient generative model that excels at agentic and multilingual use cases.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "VM-withSurcharge",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "pt-br",
+        "ja",
+        "ko",
+        "zh-cn",
+        "ar"
+      ],
+      "keywords": [
+        "RAG",
+        "Multilingual"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Cohere-rerank-v4.0-fast",
+      "displayName": "Cohere Rerank v4.0 Fast",
+      "publisher": "Cohere",
+      "latestVersion": "2",
+      "versions": [
+        "2",
+        "1"
+      ],
+      "summary": "Rerank improves search systems by sorting documents based on their semantic similarity to a query",
+      "tasks": [
+        "text-classification"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "VM-withSurcharge",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text",
+        "image"
+      ],
+      "contextWindow": 4096,
+      "maxOutputTokens": 2048,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "pt-br",
+        "ja",
+        "zh-cn",
+        "ar",
+        "vi",
+        "hi",
+        "ru",
+        "id",
+        "nl"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/CohereRerank4Blog",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Cohere-rerank-v4.0-pro",
+      "displayName": "Cohere Rerank v4.0 Pro",
+      "publisher": "Cohere",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Rerank improves search systems by sorting documents based on their semantic similarity to a query",
+      "tasks": [
+        "text-classification"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text",
+        "image"
+      ],
+      "contextWindow": 4096,
+      "maxOutputTokens": 2048,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "pt-br",
+        "ja",
+        "zh-cn",
+        "ar",
+        "vi",
+        "hi",
+        "ru",
+        "id",
+        "nl"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/CohereRerank4Blog",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "embed-v-4-0",
+      "displayName": "Cohere Embed 4",
+      "publisher": "Cohere",
+      "latestVersion": "6",
+      "versions": [
+        "6"
+      ],
+      "summary": "Embed 4 transforms texts and images into numerical vectors",
+      "tasks": [
+        "embeddings",
+        "summarization"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "VM-withSurcharge",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "image",
+        "text"
+      ],
+      "outputModalities": [
+        "image",
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "pt-br",
+        "ja",
+        "ko",
+        "zh-cn",
+        "ar"
+      ],
+      "keywords": [
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-R1",
+      "displayName": "DeepSeek-R1",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-R1 excels at reasoning tasks using a step-by-step training process, such as language, scientific reasoning, and coding tasks.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "reasoning"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Coding",
+        "Agents"
+      ],
+      "license": "MIT",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-R1-0528",
+      "displayName": "DeepSeek-R1-0528",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "The DeepSeek R1 0528 model has improved reasoning capabilities, this version also offers a reduced hallucination rate, enhanced support for function calling, and better experience for vibe coding.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Coding",
+        "Agents"
+      ],
+      "license": "MIT",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-V3-0324",
+      "displayName": "DeepSeek-V3-0324",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-V3-0324 demonstrates notable improvements over its predecessor, DeepSeek-V3, in several key aspects, including enhanced reasoning, improved function calling, and superior code generation capabilities.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents"
+      ],
+      "license": "MIT",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-V3.1",
+      "displayName": "DeepSeek-V3.1",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-V3.1 is a hybrid model that enhances tool usage, thinking efficiency, and supports both thinking and non-thinking modes via chat template switching",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-V3.2",
+      "displayName": "DeepSeek-V3.2",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-V3.2, a model that harmonizes high computational efficiency with superior reasoning and agent performance",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-V3.2-Speciale",
+      "displayName": "DeepSeek-V3.2-Speciale",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-V3.2 Speciale, a model that harmonizes high computational efficiency with superior reasoning and agent performance",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Llama-3.3-70B-Instruct",
+      "displayName": "Llama-3.3-70B-Instruct",
+      "publisher": "Meta",
+      "latestVersion": "9",
+      "versions": [
+        "9",
+        "8",
+        "7"
+      ],
+      "summary": "Llama 3.3 70B Instruct offers enhanced reasoning, math, and instruction following with performance comparable to Llama 3.1 405B.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maap-inference",
+        "maas-finetuning",
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th"
+      ],
+      "keywords": [
+        "Conversation"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/meta-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "December 2023",
+      "regions": {}
+    },
+    {
+      "id": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+      "displayName": "Llama 4 Maverick 17B 128E Instruct FP8",
+      "publisher": "Meta",
+      "latestVersion": "3",
+      "versions": [
+        "3",
+        "2",
+        "1"
+      ],
+      "summary": "Llama 4 Maverick 17B 128E Instruct FP8 is great at precise image understanding and creative writing, offering high quality at a lower price compared to Llama 3.3 70B",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "assistants",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maap-inference",
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1000000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "ar",
+        "en",
+        "fr",
+        "de",
+        "hi",
+        "id",
+        "it",
+        "pt",
+        "es",
+        "tl",
+        "th",
+        "vi"
+      ],
+      "keywords": [
+        "Multimodal",
+        "Conversation",
+        "Multilingual"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/meta-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "August 2024",
+      "regions": {}
+    },
+    {
+      "id": "MAI-DS-R1",
+      "displayName": "MAI-DS-R1",
+      "publisher": "Microsoft",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "MAI-DS-R1 is a DeepSeek-R1 reasoning model that has been post-trained by the Microsoft AI team to fill in information gaps in the previous version of the model and improve its harm protections while maintaining R1 reasoning capabilities.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "browser_automation",
+        "code_interpreter",
+        "function",
+        "mcp"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Coding",
+        "Agents"
+      ],
+      "license": "MIT",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "MAI-Image-2",
+      "displayName": "MAI-Image-2",
+      "publisher": "Microsoft",
+      "latestVersion": "2026-02-20",
+      "versions": [
+        "2026-02-20"
+      ],
+      "summary": "Built for creatives, delivering enhanced photorealism at scale.",
+      "tasks": [
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/MAIModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "model-router",
+      "displayName": "Model router",
+      "publisher": "Microsoft",
+      "latestVersion": "2025-11-18",
+      "versions": [
+        "2025-11-18",
+        "2025-08-07"
+      ],
+      "summary": "Model router is a deployable AI model that is trained to select the most suitable large language model (LLM) for a given prompt.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled",
+        "maap-inference"
+      ],
+      "azureOffers": [
+        "VM"
+      ],
+      "toolsSupported": [
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "fabric_dataagent",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1048576,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "November 2025",
+      "regions": {}
+    },
+    {
+      "id": "mistral-document-ai-2505",
+      "displayName": "Mistral Document AI (25.05)",
+      "publisher": "Mistral AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Document conversion to markdown with interleaved images and text",
+      "tasks": [
+        "image-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "pdf",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Vision",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "mistral-document-ai-2512",
+      "displayName": "Mistral Document AI (25.12)",
+      "publisher": "Mistral AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Document conversion to markdown with interleaved images and text",
+      "tasks": [
+        "image-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "pdf",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "de",
+        "fr",
+        "es",
+        "nl",
+        "it",
+        "pt",
+        "hu",
+        "pl",
+        "cs",
+        "da",
+        "ro",
+        "no",
+        "sv",
+        "id",
+        "th",
+        "vi",
+        "tl",
+        "ar",
+        "he",
+        "hi",
+        "bn",
+        "gu",
+        "kn",
+        "ta",
+        "te",
+        "ml",
+        "en",
+        "ru",
+        "uk",
+        "ko",
+        "ja",
+        "zh",
+        "tr",
+        "hy",
+        "ka"
+      ],
+      "keywords": [
+        "Vision",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/mistral-document-ai-2512",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Mistral-Large-3",
+      "displayName": "Mistral Large 3",
+      "publisher": "Mistral AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Mistral Large 3 is a state-of-the-art General-purpose Multimodal granular Mixture-of-Experts model with 39B active parameters, 673B total parameters featuring 128 experts per layer and Multi-Latent attention.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "de",
+        "it",
+        "pt",
+        "nl",
+        "zh",
+        "ja",
+        "ko",
+        "ar"
+      ],
+      "keywords": [
+        "Multimodal",
+        "Vision",
+        "Multipurpose"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/MistralLarge3blog",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Kimi-K2-Thinking",
+      "displayName": "Kimi-K2-Thinking",
+      "publisher": "Moonshot AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Kimi K2 Thinking is the latest, most capable version of open-source thinking model",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 262144,
+      "maxOutputTokens": 262144,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual"
+      ],
+      "license": "other",
+      "pricingLink": "https://aka.ms/MoonshotAIPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Kimi-K2.5",
+      "displayName": "Kimi-K2.5",
+      "publisher": "Moonshot AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Kimi K2.5 is an open-source, native multimodal agentic model built through continual pretraining on approximately 15 trillion mixed visual and text tokens atop Kimi-K2-Base.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 262144,
+      "maxOutputTokens": 262144,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual"
+      ],
+      "license": "other",
+      "pricingLink": "https://aka.ms/MoonshotAIPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "codex-mini",
+      "displayName": "codex-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-05-16",
+      "versions": [
+        "2025-05-16"
+      ],
+      "summary": "codex-mini is a fine-tuned variant of the o4-mini model, designed to deliver rapid, instruction-following performance for developers working in CLI workflows. Whether you're automating shell commands, editing scripts, or refactoring repositories, Codex-Min",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "dall-e-3",
+      "displayName": "dall-e-3",
+      "publisher": "OpenAI",
+      "latestVersion": "3.0",
+      "versions": [
+        "3.0"
+      ],
+      "summary": "",
+      "tasks": [
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "davinci-002",
+      "displayName": "davinci-002",
+      "publisher": "OpenAI",
+      "latestVersion": "3",
+      "versions": [
+        "3"
+      ],
+      "summary": "",
+      "tasks": [
+        "completions"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": 16384,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2021",
+      "regions": {}
+    },
+    {
+      "id": "gpt-35-turbo",
+      "displayName": "gpt-35-turbo",
+      "publisher": "OpenAI",
+      "latestVersion": "0125",
+      "versions": [
+        "0125"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agents",
+        "assistants",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-35-turbo-16k",
+      "displayName": "gpt-35-turbo-16k",
+      "publisher": "OpenAI",
+      "latestVersion": "0613",
+      "versions": [
+        "0613"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-35-turbo-instruct",
+      "displayName": "gpt-35-turbo-instruct",
+      "publisher": "OpenAI",
+      "latestVersion": "0914",
+      "versions": [
+        "0914"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4",
+      "displayName": "gpt-4",
+      "publisher": "OpenAI",
+      "latestVersion": "turbo-2024-04-09",
+      "versions": [
+        "turbo-2024-04-09"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "assistants",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "batch-paygo",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "code_interpreter",
+        "file_search"
+      ],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "December 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4-32k",
+      "displayName": "gpt-4-32k",
+      "publisher": "OpenAI",
+      "latestVersion": "0613",
+      "versions": [
+        "0613"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2021",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4.1",
+      "displayName": "OpenAI GPT-4.1",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-14",
+      "versions": [
+        "2025-04-14"
+      ],
+      "summary": "gpt-4.1 outperforms gpt-4o across the board, with major gains in coding, instruction following, and long-context understanding",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1048576,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4.1-mini",
+      "displayName": "OpenAI GPT-4.1-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-14",
+      "versions": [
+        "2025-04-14"
+      ],
+      "summary": "gpt-4.1-mini outperform gpt-4o-mini across the board, with major gains in coding, instruction following, and long-context handling",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1048576,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4.1-nano",
+      "displayName": "OpenAI GPT-4.1-nano",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-14",
+      "versions": [
+        "2025-04-14"
+      ],
+      "summary": "gpt-4.1-nano provides gains in coding, instruction following, and long-context handling along with lower latency and cost",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1048576,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4.5-preview",
+      "displayName": "GPT-4.5 Preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-02-27",
+      "versions": [
+        "2025-02-27"
+      ],
+      "summary": "the largest and strongest general purpose model in the gpt model family up to date, best suited for diverse text and image tasks.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o",
+      "displayName": "OpenAI GPT-4o",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-11-20",
+      "versions": [
+        "2024-11-20"
+      ],
+      "summary": "OpenAI's most advanced multimodal model in the gpt-4o family. Can handle both text and image inputs.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "assistants",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "batch-paygo",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-audio-preview",
+      "displayName": "OpenAI gpt-4o-audio-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini",
+      "displayName": "OpenAI GPT-4o mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-07-18",
+      "versions": [
+        "2024-07-18"
+      ],
+      "summary": "An affordable, efficient AI solution for diverse text and image tasks.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "assistants",
+        "fine-tuning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "batch-paygo",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "fabric_dataagent",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini-audio-preview",
+      "displayName": "OpenAI gpt-4o-mini-audio-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini-realtime-preview",
+      "displayName": "OpenAI gpt-4o-mini-realtime-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini-transcribe",
+      "displayName": "gpt-4o-mini-transcribe",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-15",
+      "versions": [
+        "2025-12-15",
+        "2025-03-20"
+      ],
+      "summary": "A highly efficient and cost effective speech-to-text solution that deliverables reliable and accurate transcripts.",
+      "tasks": [
+        "speech-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 16000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "af",
+        "ar",
+        "hy",
+        "az",
+        "be",
+        "bs",
+        "bg",
+        "ca",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "gl",
+        "de",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "is",
+        "id",
+        "it",
+        "ja",
+        "kn",
+        "kk",
+        "ko",
+        "lv",
+        "lt",
+        "mk",
+        "ms",
+        "mr",
+        "mi",
+        "ne",
+        "no",
+        "fa",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sr",
+        "sk",
+        "sl",
+        "es",
+        "sw",
+        "sv",
+        "tl",
+        "ta",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "vi",
+        "cy"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini-tts",
+      "displayName": "gpt-4o-mini-tts",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-15",
+      "versions": [
+        "2025-12-15",
+        "2025-03-20"
+      ],
+      "summary": "An advanced text-to-speech solution designed to convert written text into natural-sounding speech.",
+      "tasks": [
+        "text-to-speech"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment",
+        "batch-enabled",
+        "maap-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "audio"
+      ],
+      "outputModalities": [
+        "text",
+        "audio"
+      ],
+      "contextWindow": 2000,
+      "maxOutputTokens": 2000,
+      "languages": [
+        "af",
+        "ar",
+        "hy",
+        "az",
+        "be",
+        "bs",
+        "bg",
+        "ca",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "gl",
+        "de",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "is",
+        "id",
+        "it",
+        "ja",
+        "kn",
+        "kk",
+        "ko",
+        "lv",
+        "lt",
+        "mk",
+        "ms",
+        "mr",
+        "mi",
+        "ne",
+        "no",
+        "fa",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sr",
+        "sk",
+        "sl",
+        "es",
+        "sw",
+        "sv",
+        "tl",
+        "ta",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "vi",
+        "cy"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-realtime-preview",
+      "displayName": "OpenAI gpt-4o-realtime-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-transcribe",
+      "displayName": "gpt-4o-transcribe",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-03-20",
+      "versions": [
+        "2025-03-20"
+      ],
+      "summary": "A cutting-edge speech-to-text solution that deliverables reliable and accurate transcripts.",
+      "tasks": [
+        "speech-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 16000,
+      "maxOutputTokens": 2000,
+      "languages": [
+        "af",
+        "ar",
+        "hy",
+        "az",
+        "be",
+        "bs",
+        "bg",
+        "ca",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "gl",
+        "de",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "is",
+        "id",
+        "it",
+        "ja",
+        "kn",
+        "kk",
+        "ko",
+        "lv",
+        "lt",
+        "mk",
+        "ms",
+        "mr",
+        "mi",
+        "ne",
+        "no",
+        "fa",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sr",
+        "sk",
+        "sl",
+        "es",
+        "sw",
+        "sv",
+        "tl",
+        "ta",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "vi",
+        "cy"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-transcribe-diarize",
+      "displayName": "OpenAI gpt-4o-transcribe-diarize",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-15",
+      "versions": [
+        "2025-10-15"
+      ],
+      "summary": "A cutting-edge speech-to-text solution that deliverables reliable and accurate transcripts; now equipped with diarization support aka identifying different speakers through the transcription.",
+      "tasks": [
+        "speech-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 16000,
+      "maxOutputTokens": 2000,
+      "languages": [
+        "af",
+        "ar",
+        "hy",
+        "az",
+        "be",
+        "bs",
+        "bg",
+        "ca",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "gl",
+        "de",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "is",
+        "id",
+        "it",
+        "ja",
+        "kn",
+        "kk",
+        "ko",
+        "lv",
+        "lt",
+        "mk",
+        "ms",
+        "mr",
+        "mi",
+        "ne",
+        "no",
+        "fa",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sr",
+        "sk",
+        "sl",
+        "es",
+        "sw",
+        "sv",
+        "tl",
+        "ta",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "vi",
+        "cy"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "July 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5",
+      "displayName": "OpenAI gpt-5",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-07",
+      "versions": [
+        "2025-08-07"
+      ],
+      "summary": "gpt-5 is designed for logic-heavy and multi-step tasks.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "image_generation",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-chat",
+      "displayName": "OpenAI gpt-5-chat (preview)",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-03",
+      "versions": [
+        "2025-10-03",
+        "2025-08-07"
+      ],
+      "summary": "gpt-5-chat (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "code_interpreter",
+        "file_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-codex",
+      "displayName": "gpt-5-codex",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-09-15",
+      "versions": [
+        "2025-09-15"
+      ],
+      "summary": "gpt-5-codex is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "mcp"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-mini",
+      "displayName": "OpenAI gpt-5-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-07",
+      "versions": [
+        "2025-08-07"
+      ],
+      "summary": "gpt-5-mini is a lightweight version for cost-sensitive applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "code_interpreter",
+        "file_search",
+        "mcp",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "June 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-nano",
+      "displayName": "OpenAI gpt-5-nano",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-07",
+      "versions": [
+        "2025-08-07"
+      ],
+      "summary": "gpt-5-nano is optimized for speed, ideal for applications requiring low latency.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "code_interpreter",
+        "file_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-pro",
+      "displayName": "OpenAI gpt-5-pro",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-06",
+      "versions": [
+        "2025-10-06"
+      ],
+      "summary": "gpt-5-pro uses more compute to think harder and provide consistently better answers.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 400000,
+      "maxOutputTokens": 2720000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1",
+      "displayName": "OpenAI gpt-5.1",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-11-13",
+      "versions": [
+        "2025-11-13"
+      ],
+      "summary": "gpt-5.1 is designed for logic-heavy and multi-step tasks.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "azure_ai_search",
+        "azure_function",
+        "bing_grounding",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1-chat",
+      "displayName": "OpenAI gpt-5.1-chat (preview)",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-11-13",
+      "versions": [
+        "2025-11-13"
+      ],
+      "summary": "gpt-5.1-chat (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1-codex",
+      "displayName": "gpt-5.1-codex",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-11-13",
+      "versions": [
+        "2025-11-13"
+      ],
+      "summary": "gpt-5.1-codex is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "mcp"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1-codex-max",
+      "displayName": "gpt-5.1-codex-max",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-04",
+      "versions": [
+        "2025-12-04"
+      ],
+      "summary": "gpt-5.1-codex-max is agentic coding model designed to streamline complex development workflows with advanced efficiency",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/codexmax-blog",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1-codex-mini",
+      "displayName": "gpt-5.1-codex-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-11-13",
+      "versions": [
+        "2025-11-13"
+      ],
+      "summary": "gpt-5.1-codex-mini is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.2",
+      "displayName": "OpenAI gpt-5.2",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-11",
+      "versions": [
+        "2025-12-11"
+      ],
+      "summary": "GPT-5.2 is engineered for enterprise agent scenarios—delivering structured, auditable outputs, reliable tool use, and governed integrations.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "azure_ai_search",
+        "azure_function",
+        "bing_grounding",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.2-chat",
+      "displayName": "OpenAI gpt-5.2-chat (preview)",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-02-10",
+      "versions": [
+        "2026-02-10",
+        "2025-12-11"
+      ],
+      "summary": "gpt-5.2-chat (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.2-codex",
+      "displayName": "gpt-5.2-codex",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-01-14",
+      "versions": [
+        "2026-01-14"
+      ],
+      "summary": "gpt-5.2-codex is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "mcp"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 228000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/gpt5.2codex",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.3-chat",
+      "displayName": "OpenAI gpt-5.3-chat (preview)",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-03",
+      "versions": [
+        "2026-03-03"
+      ],
+      "summary": "gpt-5.3-chat (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/gpt5.3chat",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.3-codex",
+      "displayName": "gpt-5.3-codex",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-02-24",
+      "versions": [
+        "2026-02-24"
+      ],
+      "summary": "gpt-5.3-codex is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 228000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AOAI/NewReleases/Feb24",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.4",
+      "displayName": "OpenAI gpt-5.4",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-05",
+      "versions": [
+        "2026-03-05"
+      ],
+      "summary": "GPT‑5.4 is OpenAI’s most capable frontier model, built to deliver faster, more reliable results for complex professional work.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "displayName": "OpenAI gpt-5.4-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-17",
+      "versions": [
+        "2026-03-17"
+      ],
+      "summary": "GPT‑5.4‑mini is a compact, cost‑efficient model designed for reliable performance across high‑volume, everyday AI workloads.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 400000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.4-nano",
+      "displayName": "OpenAI gpt-5.4-nano",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-17",
+      "versions": [
+        "2026-03-17"
+      ],
+      "summary": "GPT‑5.4‑nano is a lightweight, ultra‑efficient model designed for low‑latency, cost‑effective tasks at massive scale.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 400000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.4-pro",
+      "displayName": "OpenAI gpt-5.4",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-05",
+      "versions": [
+        "2026-03-05"
+      ],
+      "summary": "GPT‑5.4-Pro is OpenAI’s most capable frontier model, built to deliver faster, more reliable results for complex professional work.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-audio",
+      "displayName": "OpenAI gpt-audio",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-28",
+      "versions": [
+        "2025-08-28"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-audio-1.5",
+      "displayName": "OpenAI gpt-audio",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-02-23",
+      "versions": [
+        "2026-02-23"
+      ],
+      "summary": "A new S2S (speech to speech) model with improved instruction following.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-audio-mini",
+      "displayName": "OpenAI gpt-audio-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-06",
+      "versions": [
+        "2025-10-06"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-image-1",
+      "displayName": "Gpt-image-1",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-15",
+      "versions": [
+        "2025-04-15"
+      ],
+      "summary": "An efficient AI solution for diverse text and image tasks, including text to image, image to image, inpainting, and prompt transformation.",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text",
+        "image"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-image-1-mini",
+      "displayName": "GPT-image-1-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-06",
+      "versions": [
+        "2025-10-06"
+      ],
+      "summary": "An efficient AI solution for diverse text and image tasks, including high quality, cheap text to image generation",
+      "tasks": [
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-image-1.5",
+      "displayName": "GPT-image-1.5",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-16",
+      "versions": [
+        "2025-12-16"
+      ],
+      "summary": "An efficient AI solution for diverse text and image tasks, including high quality, and editing scenarios",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled",
+        "maap-inference"
+      ],
+      "azureOffers": [
+        "VM"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-oss-120B",
+      "displayName": "gpt-oss-120b",
+      "publisher": "OpenAI",
+      "latestVersion": "4",
+      "versions": [
+        "4",
+        "3",
+        "2",
+        "1"
+      ],
+      "summary": "Push the open model frontier with GPT-OSS models, released under the permissive Apache 2.0 license, allowing anyone to use, modify, and deploy them freely.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maap-inference",
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "function",
+        "mcp"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 131072,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-realtime",
+      "displayName": "OpenAI gpt-realtime",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-28",
+      "versions": [
+        "2025-08-28"
+      ],
+      "summary": "A new S2S (speech to speech) model with improved instruction following.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-realtime-1.5",
+      "displayName": "OpenAI gpt-realtime",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-02-23",
+      "versions": [
+        "2026-02-23"
+      ],
+      "summary": "A new S2S (speech to speech) model with improved instruction following.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-realtime-mini",
+      "displayName": "OpenAI gpt-realtime-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-15",
+      "versions": [
+        "2025-12-15",
+        "2025-10-06"
+      ],
+      "summary": "gpt-realtime-mini is a smaller version of gpt-realtime S2S (speech to speech) model built on chive architecture. This model excels at instruction following and is optimized for cost efficiency.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio"
+      ],
+      "outputModalities": [
+        "audio"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2025",
+      "regions": {}
+    },
+    {
+      "id": "o1",
+      "displayName": "OpenAI o1",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "Focused on advanced reasoning and solving complex problems, including math and science tasks. Ideal for applications that require deep contextual understanding and agentic workflows.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "browser_automation",
+        "file_search",
+        "function",
+        "mcp",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "o1-mini",
+      "displayName": "OpenAI o1-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-09-12",
+      "versions": [
+        "2024-09-12"
+      ],
+      "summary": "Smaller, faster, and 80% cheaper than o1-preview, performs well at code generation and small context operations.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 65536,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "o1-preview",
+      "displayName": "OpenAI o1-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Focused on advanced reasoning and solving complex problems, including math and science tasks. Ideal for applications that require deep contextual understanding and agentic workflows.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "o3",
+      "displayName": "OpenAI o3",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-16",
+      "versions": [
+        "2025-04-16"
+      ],
+      "summary": "o3 includes significant improvements on quality and safety while supporting the existing features of o1 and delivering comparable or better performance.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "o3-deep-research",
+      "displayName": "o3-deep-research",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-06-26",
+      "versions": [
+        "2025-06-26"
+      ],
+      "summary": "The o3 series of models are trained with reinforcement learning to think before they answer and perform complex reasoning. The o1-pro model uses more compute to think harder and provide consistently better answers.",
+      "tasks": [
+        "data-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "mcp",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Agents"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "o3-mini",
+      "displayName": "OpenAI o3-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-01-31",
+      "versions": [
+        "2025-01-31"
+      ],
+      "summary": "o3-mini includes the o1 features with significant cost-efficiencies for scenarios requiring high performance.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "batch-paygo",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "fabric_dataagent"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "o3-pro",
+      "displayName": "o3-pro",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-06-10",
+      "versions": [
+        "2025-06-10"
+      ],
+      "summary": "The o3 series of models are trained with reinforcement learning to think before they answer and perform complex reasoning. The o1-pro model uses more compute to think harder and provide consistently better answers.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "o4-mini",
+      "displayName": "OpenAI o4-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-16",
+      "versions": [
+        "2025-04-16"
+      ],
+      "summary": "o4-mini includes significant improvements on quality and safety while supporting the existing features of o3-mini and delivering comparable or better performance.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "reasoning",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "sora",
+      "displayName": "sora",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-05-02",
+      "versions": [
+        "2025-05-02"
+      ],
+      "summary": "An efficient AI solution to generate videos",
+      "tasks": [
+        "video-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "video"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "sora-2",
+      "displayName": "OpenAI Sora-2",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-06",
+      "versions": [
+        "2025-10-06"
+      ],
+      "summary": "Sora 2 in Azure AI Foundry isn't just another video generation tool; it's a creative powerhouse, seamlessly integrated into a platform built for innovation, trust, and scale.",
+      "tasks": [
+        "video-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "outputModalities": [
+        "video",
+        "audio"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "text-embedding-3-large",
+      "displayName": "OpenAI Text Embedding 3 (large)",
+      "publisher": "OpenAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Text-embedding-3 series models are the latest and most capable embedding model from OpenAI.",
+      "tasks": [
+        "embeddings"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "embeddings"
+      ],
+      "contextWindow": 8191,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "RAG"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2021",
+      "regions": {}
+    },
+    {
+      "id": "text-embedding-3-small",
+      "displayName": "OpenAI Text Embedding 3 (small)",
+      "publisher": "OpenAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Text-embedding-3 series models are the latest and most capable embedding model from OpenAI.",
+      "tasks": [
+        "embeddings"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "embeddings"
+      ],
+      "contextWindow": 8191,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "RAG"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2021",
+      "regions": {}
+    },
+    {
+      "id": "text-embedding-ada-002",
+      "displayName": "text-embedding-ada-002",
+      "publisher": "OpenAI",
+      "latestVersion": "2",
+      "versions": [
+        "2"
+      ],
+      "summary": "",
+      "tasks": [
+        "embeddings"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "tts",
+      "displayName": "tts",
+      "publisher": "OpenAI",
+      "latestVersion": "001",
+      "versions": [
+        "001"
+      ],
+      "summary": "",
+      "tasks": [
+        "text-to-speech"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "tts-hd",
+      "displayName": "tts-hd",
+      "publisher": "OpenAI",
+      "latestVersion": "001",
+      "versions": [
+        "001"
+      ],
+      "summary": "",
+      "tasks": [
+        "text-to-speech"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "whisper",
+      "displayName": "whisper",
+      "publisher": "OpenAI",
+      "latestVersion": "001",
+      "versions": [
+        "001"
+      ],
+      "summary": "",
+      "tasks": [
+        "automatic-speech-recognition"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "grok-3",
+      "displayName": "Grok 3",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 3 is xAI's debut model, pretrained by Colossus at supermassive scale to excel in specialized domains like finance, healthcare, and the law.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "fabric_dataagent",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "es",
+        "fr",
+        "af",
+        "ar",
+        "bn",
+        "cy",
+        "de",
+        "el",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ko",
+        "lv",
+        "mr",
+        "ne",
+        "pa",
+        "pl",
+        "ru",
+        "sw",
+        "te",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "zh"
+      ],
+      "keywords": [
+        "Understanding",
+        "Instruction",
+        "Summarization"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "grok-3-mini",
+      "displayName": "Grok 3 Mini",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 3 Mini is a lightweight model that thinks before responding. Trained on mathematic and scientific problems, it is great for logic-based tasks.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "es",
+        "fr",
+        "af",
+        "ar",
+        "bn",
+        "cy",
+        "de",
+        "el",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ko",
+        "lv",
+        "mr",
+        "ne",
+        "pa",
+        "pl",
+        "ru",
+        "sw",
+        "te",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "zh"
+      ],
+      "keywords": [
+        "Agents",
+        "Reasoning",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "grok-4",
+      "displayName": "Grok 4",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4 is the latest reasoning model from xAI with advanced reasoning and tool-use capabilities, enabling it to achieve new state-of-the-art performance across challenging academic and industry benchmarks.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 256000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "December 2024",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-1-fast-non-reasoning",
+      "displayName": "Grok 4.1 Fast Non Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4.1 Fast Non‑Reasoning is designed for low‑latency, near‑instant responses, emphasizing speed, high‑quality outputs, and smooth tool‑calling in agentic workflows, making it well‑suited for high‑throughput, real‑time scenarios where immediate responses",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Low latency",
+        "Agents",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-1-fast-reasoning",
+      "displayName": "Grok 4.1 Fast Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4.1 Fast Reasoning is a frontier multimodal model built for high‑performance, agentic execution—combining strong reasoning, advanced tool calling, and agentic search to handle complex tasks with speed and precision. It delivers natural, fluid dialogue",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Low latency",
+        "Agents",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-20-non-reasoning",
+      "displayName": "Grok 4.2 Non-Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4.2 is xAI’s latest large language model, built for strong reasoning, multimodal understanding, and enterprise use. It improves instruction following, honesty, and calibration over earlier Grok versions, while supporting both single‑agent and multi‑ag",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 262144,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Low latency",
+        "Agents",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-20-reasoning",
+      "displayName": "Grok 4.2 Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4.2 is xAI’s latest large language model, built for strong reasoning, multimodal understanding, and enterprise use. It improves instruction following, honesty, and calibration over earlier Grok versions, while supporting both single‑agent and multi‑ag",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 262144,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Low latency",
+        "Agents",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-fast-non-reasoning",
+      "displayName": "Grok 4 Fast Non Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4 Fast is an efficiency-focused large language model developed by xAI, pre-trained on general-purpose data and post-trained on task demonstrations and tool use, with built-in safety features including refusal behaviors, a fixed system prompt enforcing",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 2000000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-fast-reasoning",
+      "displayName": "Grok 4 Fast Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4 Fast is an efficiency-focused large language model developed by xAI, pre-trained on general-purpose data and post-trained on task demonstrations and tool use, with built-in safety features including refusal behaviors, a fixed system prompt enforcing",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 2000000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-code-fast-1",
+      "displayName": "Grok Code Fast 1",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok Code Fast 1 is a fast, economical AI model for agentic coding, built from scratch with a new architecture, trained on programming-rich data, and fine-tuned for real-world coding tasks like bug fixes and project setup.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 256000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    }
+  ]
+}

--- a/research/reverse-engineering-model-availability.md
+++ b/research/reverse-engineering-model-availability.md
@@ -1,0 +1,382 @@
+# Reverse Engineering: https://model-availability.azurewebsites.net/
+
+## Executive Summary
+
+The Azure OpenAI Model Regional Availability website is a **Python Flask application** served by **gunicorn**, hosted on **Azure App Service**. It has no external API calls from the browser — all data is pre-rendered server-side from markdown files and served as HTML table fragments via simple same-origin AJAX GET requests. The frontend is a minimal jQuery 1.10.2 + Bootstrap app. Telemetry flows to **Azure Application Insights** in the Central US region. The underlying data source is strongly correlated with the `model-matrix` markdown files maintained in the public [MicrosoftDocs/azure-ai-docs](https://github.com/MicrosoftDocs/azure-ai-docs) GitHub repository.
+
+---
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         BROWSER (Client)                         │
+│                                                                  │
+│  ┌────────────┐   jQuery $.ajax()    ┌─────────────────────┐    │
+│  │  index.html │ ──── GET /sku ────▶ │  Same-origin server │    │
+│  │  (jQuery +  │ ◀── HTML table ──── │  (no external API)  │    │
+│  │  Bootstrap) │                     └─────────────────────┘    │
+│  └─────┬──────┘                                                  │
+│        │                                                         │
+│        │  POST /v2/track (telemetry)                             │
+│        ▼                                                         │
+│  ┌─────────────────────────────────────────┐                    │
+│  │  Application Insights SDK (ai.3.gbl.js) │                    │
+│  └──────────────┬──────────────────────────┘                    │
+└─────────────────┼────────────────────────────────────────────────┘
+                  │
+                  ▼
+┌──────────────────────────────────────────────┐
+│  centralus-0.in.applicationinsights.azure.com│
+│  (Azure Monitor telemetry ingestion)         │
+│  iKey: d1a4755f-6372-4086-9d2b-04b1b8b43d2c │
+└──────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────┐
+│                    AZURE APP SERVICE (Server)                     │
+│          model-availability.azurewebsites.net                     │
+│                                                                  │
+│  ┌──────────┐     ┌──────────────────────┐                      │
+│  │ gunicorn │────▶│  Flask Application   │                      │
+│  │  (WSGI)  │     │                      │                      │
+│  └──────────┘     │  Routes:             │                      │
+│                   │  GET /               │  → index.html         │
+│                   │  GET /{sku_name}     │  → HTML table frag   │
+│                   │  GET /download_      │                      │
+│                   │    unified_markdown  │  → .md file download  │
+│                   │                      │                      │
+│                   │  Reads from:         │                      │
+│                   │  Pre-generated       │                      │
+│                   │  markdown → HTML     │                      │
+│                   └──────────┬───────────┘                      │
+│                              │                                   │
+│                              ▼                                   │
+│                   ┌──────────────────────┐                      │
+│                   │  Markdown data files │                      │
+│                   │  (server-side disk)  │                      │
+│                   │                      │                      │
+│                   │  Same structure as:  │                      │
+│                   │  MicrosoftDocs/      │                      │
+│                   │  azure-ai-docs/      │                      │
+│                   │  model-matrix/       │                      │
+│                   └──────────────────────┘                      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Backend Technology Stack
+
+| Component | Technology | Evidence |
+|-----------|-----------|----------|
+| **Web Server** | gunicorn | `Server: gunicorn` response header[^1] |
+| **Framework** | Flask (Python) | Flask-style 404 page: `<!doctype html><html lang=en><title>404 Not Found</title>...`[^2] |
+| **Hosting** | Azure App Service (Linux) | `*.azurewebsites.net` domain + `ARRAffinity` cookie for instance pinning[^3] |
+| **Static files** | Flask `static/` convention | `/static/content/style.css`, `/static/scripts/jquery-1.10.2.min.js`[^4] |
+| **Frontend** | jQuery 1.10.2 + Bootstrap | Loaded via `<script>` and `<link>` tags[^4] |
+| **Telemetry** | Azure Application Insights SDK v3.3.11 | `ai.3.gbl.min.js` loaded from `js.monitor.azure.com`[^5] |
+
+---
+
+## Network Traffic Analysis
+
+### Outbound Requests (from browser)
+
+All API calls are **same-origin** — the browser makes **zero cross-origin data requests**. The only external calls are:
+
+| # | Request | Type | Purpose |
+|---|---------|------|---------|
+| 1 | `GET /` | Document | Initial HTML page load |
+| 2 | `GET /globalstandard` | XHR (jQuery.ajax) | Default SKU data table (HTML fragment) |
+| 3 | `GET /static/content/bootstrap.min.css` | CSS | Styling |
+| 4 | `GET /static/content/style.css` | CSS | Custom dark-theme styling |
+| 5 | `GET /static/scripts/jquery-1.10.2.min.js` | Script | jQuery library |
+| 6 | `GET https://js.monitor.azure.com/scripts/b/ai.3.gbl.min.js` | Script | Application Insights SDK[^5] |
+| 7 | `GET https://js.monitor.azure.com/scripts/b/ai.config.1.cfg.json` | Fetch | App Insights config |
+| 8 | `POST https://centralus-0.in.applicationinsights.azure.com/v2/track` | XHR | Telemetry (pageviews, performance)[^6] |
+
+**Key finding**: There is **no external API** being called for data. All model availability data is served by the Flask backend itself at same-origin paths.
+
+---
+
+## Complete API Endpoint Map
+
+### Data Endpoints (all return HTML table fragments)
+
+These are the 13 SKU endpoints discovered from the DOM's `data-value` attributes on `.sku-option` elements[^7]:
+
+| Endpoint | SKU Label | HTTP Methods | Response Size |
+|----------|-----------|-------------|---------------|
+| `GET /standard` | Standard | HEAD, OPTIONS, GET | ~9.2 KB |
+| `GET /globalstandard` | Global Standard | HEAD, OPTIONS, GET | ~36.2 KB |
+| `GET /datazonestandard` | Data Zone Standard | HEAD, OPTIONS, GET | ~8.8 KB |
+| `GET /globalbatch` | Global Batch | HEAD, OPTIONS, GET | ~6.5 KB |
+| `GET /datazonebatch` | Data Zone Batch | HEAD, OPTIONS, GET | ~3.7 KB |
+| `GET /provisioned` | Provisioned | HEAD, OPTIONS, GET | ~9.8 KB |
+| `GET /globalprovisionedmanaged` | Global Provisioned Managed | HEAD, OPTIONS, GET | ~11.7 KB |
+| `GET /datazoneprovisioned` | Data Zone Provisioned | HEAD, OPTIONS, GET | ~5.5 KB |
+| `GET /standardfinetune` | Fine-tuning Standard | HEAD, OPTIONS, GET | ~1.0 KB |
+| `GET /globalstandardfinetune` | Fine-tuning Global Standard | HEAD, OPTIONS, GET | ~4.9 KB |
+| `GET /developertier` | Fine-tuning Developer Tier | HEAD, OPTIONS, GET | ~3.9 KB |
+| `GET /priorityglobalstandard` | Priority Global Standard | HEAD, OPTIONS, GET | ~3.7 KB |
+| `GET /prioritydatazonestandard` | Priority Data Zone Standard | HEAD, OPTIONS, GET | ~1.2 KB |
+
+### File Download Endpoint
+
+| Endpoint | Purpose | Content-Type |
+|----------|---------|-------------|
+| `GET /download_unified_markdown` | Download all data as a single markdown file | `application/octet-stream` (~544 KB)[^8] |
+
+The download endpoint serves a file named `unified_markdown.md` which contains **28 markdown table sections** covering all SKUs and capability types[^9].
+
+### Response Format
+
+Each SKU endpoint returns a **complete HTML fragment** (not JSON) containing:
+- A `<head>` tag linking to the stylesheet
+- A `<table>` with class `dark-theme` containing:
+  - Row 1: Model names (some with `colspan` for multi-version models)
+  - Row 2: Version dates
+  - Body rows: One per Azure region, with ✅ or `-` indicators[^10]
+
+Example response structure:
+```html
+<head><link rel="stylesheet" type="text/css" href="/static/content/style.css"></head>
+<table border="1" class="dark-theme">
+  <thead>
+    <tr>
+      <th>Region</th>
+      <th>gpt-5.4-mini</th>
+      <th colspan="2">gpt-5.2-chat</th>
+      ...
+    </tr>
+    <tr>
+      <th>Version</th>
+      <th>2026-03-17</th>
+      <th>2026-02-10</th>
+      <th>2025-12-11</th>
+      ...
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>eastus</td><td>✅</td><td>✅</td>...</tr>
+    ...
+  </tbody>
+</table>
+```
+
+---
+
+## Frontend JavaScript Architecture
+
+The frontend is entirely contained in **two inline `<script>` blocks**[^11]:
+
+### Script 0: Application Insights Instrumentation
+- Standard Azure Application Insights bootstrap snippet (minified)
+- Connection string: `InstrumentationKey=d1a4755f-6372-4086-9d2b-04b1b8b43d2c;IngestionEndpoint=https://centralus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/`[^5]
+
+### Script 1: Application Logic
+The entire app logic fits in a single inline script with these key functions:
+
+| Function | Purpose |
+|----------|---------|
+| `changeContent(page)` | Core data loader — calls `$.ajax({ url: page, type: "GET" })` and injects response HTML into `#displayArea`[^12] |
+| `buildModelSelector()` | Parses the loaded table headers to build model filter checkboxes |
+| `buildRegionSelector()` | Parses table body to build region filter checkboxes |
+| `applyFilters()` | Client-side column/row visibility toggling (CSS `display: none`) |
+| `toggleSkuSelector()` | Opens/closes the SKU dropdown |
+| `downloadLatestLogs()` | Fetches `/download_unified_markdown` and triggers browser download[^13] |
+| `filterDropdownList()` | Search-as-you-type filtering within dropdowns |
+
+**Data flow on page load**:
+1. `$(document).ready()` calls `changeContent('/globalstandard')`[^12]
+2. jQuery AJAX fetches the HTML table from the server
+3. HTML is injected into `#displayArea` via `.html()`
+4. `buildModelSelector()` and `buildRegionSelector()` parse the table DOM to populate filter UI
+5. `applyFilters()` applies any active filters
+
+**Data flow on SKU change**:
+1. User clicks a `.sku-option` div
+2. Click handler reads `data-value` attribute (e.g., `/provisioned`)
+3. Calls `changeContent(value)` which fetches new table HTML
+4. Steps 3-5 from above repeat
+
+---
+
+## Telemetry Details
+
+### Application Insights Configuration[^5][^6]
+
+| Property | Value |
+|----------|-------|
+| Instrumentation Key | `d1a4755f-6372-4086-9d2b-04b1b8b43d2c` |
+| Ingestion Endpoint | `https://centralus-0.in.applicationinsights.azure.com/` |
+| Live Endpoint | `https://centralus.livediagnostics.monitor.azure.com/` |
+| SDK Version | `javascript:3.3.11` |
+| Snippet Version | `7` |
+
+### Telemetry Events Sent
+
+The App Insights SDK sends two types of telemetry to `centralus-0.in.applicationinsights.azure.com/v2/track`:
+
+1. **PageviewData** — page title, URL, duration
+2. **PageviewPerformanceData** — detailed timing breakdown (network, request, response, DOM processing)[^6]
+
+---
+
+## Data Source Analysis
+
+### Unified Markdown Sections
+
+The `/download_unified_markdown` endpoint serves a file containing 28 markdown table sections[^9]:
+
+```
+ProvisionedManaged_Chat_Completions.md
+DataZoneStandard_Chat_Completions.md
+GlobalBatch_Chat_Completions.md
+model_metadata.md
+GlobalProvisionedManaged_Chat_Completions.md
+DataZoneStandard.md
+Standard_Image_Generation.md
+DataZoneProvisionedManaged_Chat_Completions.md
+GlobalStandard_Chat_Completions.md
+DeveloperTier.md
+GlobalStandard_Embeddings.md
+GlobalStandard_Audio.md
+Standard.md
+Standard_Embeddings.md
+Standard_Chat_Completions.md
+DataZoneBatch.md
+GlobalStandardFineTune.md
+DataZoneProvisionedManaged.md
+ProvisionedManaged.md
+DataZoneStandard_Embeddings.md
+StandardFineTune.md
+PriorityGlobalStandard.md
+PriorityDataZoneStandard.md
+GlobalProvisionedManaged.md
+GlobalStandard.md
+DataZoneBatch_Chat_Completions.md
+GlobalBatch.md
+Standard_Audio.md
+```
+
+### Correlation with Azure AI Docs Repository
+
+The data structure closely mirrors the **model-matrix** include files in [MicrosoftDocs/azure-ai-docs](https://github.com/MicrosoftDocs/azure-ai-docs)[^14]:
+
+| Website Endpoint | Unified MD Section | Docs Repo File |
+|-----------------|-------------------|----------------|
+| `/globalstandard` | `GlobalStandard.md` | `model-matrix/standard-global.md` |
+| `/standard` | `Standard.md` | `model-matrix/standard-models.md` |
+| `/provisioned` | `ProvisionedManaged.md` | `model-matrix/provisioned-models.md` |
+| `/globalprovisionedmanaged` | `GlobalProvisionedManaged.md` | `model-matrix/provisioned-global.md` |
+| `/globalbatch` | `GlobalBatch.md` | `model-matrix/global-batch.md` |
+| `/datazonebatch` | `DataZoneBatch.md` | `model-matrix/global-batch-datazone.md` |
+| `/datazonestandard` | `DataZoneStandard.md` | `model-matrix/datazone-standard.md` |
+| `/datazoneprovisioned` | `DataZoneProvisionedManaged.md` | `model-matrix/datazone-provisioned-managed.md` |
+| `/priorityglobalstandard` | `PriorityGlobalStandard.md` | `model-matrix/standard-global-priority-processing.md` |
+| `/prioritydatazonestandard` | `PriorityDataZoneStandard.md` | `model-matrix/datazone-standard-priority-processing.md` |
+
+The docs repo files live at: `articles/foundry/openai/includes/model-matrix/`[^14]
+
+### model_metadata.md Section
+
+The unified markdown includes a `model_metadata.md` section with ~120 rows of model metadata including[^15]:
+- Model name, version, lifecycle status
+- Capability flags (chatCompletion, embeddings, audio, realtime, imageGenerations, etc.)
+- Rate limits per SKU tier (Standard, GlobalStandard, DataZoneStandard, DeveloperTier)
+- Fine-tuning configuration parameters
+- Token limits, context windows, and output limits
+- Retirement dates and deprecation status
+
+This metadata is more detailed than what the public docs contain and likely comes from an internal model registry/configuration system.
+
+---
+
+## Azure App Service Infrastructure
+
+### Hosting Evidence
+
+| Signal | Value | Implication |
+|--------|-------|-------------|
+| Domain | `*.azurewebsites.net` | Azure App Service |
+| ARRAffinity cookie | `e9cd5ec577e988e...` | Multi-instance App Service with sticky sessions[^3] |
+| Server header | `gunicorn` | Python WSGI server |
+| 404 format | Flask default HTML | Flask web framework[^2] |
+| Static files | `/static/` path convention | Flask default static folder[^4] |
+| Response times | 48-69ms (from browser) | Pre-rendered content, not computed on-the-fly |
+| `download_unified_markdown` ETag | `"1775666705.1721544-544500-2959610287"` | Unix timestamp-based, indicating file serving[^8] |
+| `download_unified_markdown` Last-Modified | `Wed, 08 Apr 2026 16:45:05 GMT` | File was recently updated/regenerated[^8] |
+
+### Interesting HTML Comments
+
+The source contains commented-out alternative titles suggesting a planned rebrand[^16]:
+```html
+<!--<title>Foundry Model Regional Availability</title>-->
+<!--<h1>Foundry Model Regional Availability</h1>-->
+```
+
+This aligns with Microsoft's rebranding of "Azure AI" to "Microsoft Foundry".
+
+---
+
+## What the Site Does NOT Do
+
+1. **No external API calls for data** — All availability data is served from the Flask backend itself
+2. **No authentication** — Completely public, no login required
+3. **No client-side data transformation** — Server returns pre-rendered HTML tables
+4. **No WebSocket connections** — Purely HTTP request/response
+5. **No localStorage/sessionStorage usage** — No client-side state persistence
+6. **No service workers** — No offline capability
+7. **No CORS headers** — Same-origin only (except telemetry)
+
+---
+
+## Confidence Assessment
+
+| Finding | Confidence | Basis |
+|---------|-----------|-------|
+| Flask + gunicorn backend | **High** | Server header + 404 page format are definitive |
+| Azure App Service hosting | **High** | Domain, ARRAffinity cookie are definitive |
+| All data served same-origin | **High** | Complete network trace shows no external data APIs |
+| Application Insights telemetry | **High** | SDK loaded, connection string visible, POST requests observed |
+| Data sourced from markdown files | **High** | ETag/Last-Modified on download endpoint, naming patterns match docs repo |
+| Correlation with MicrosoftDocs/azure-ai-docs | **Medium-High** | File naming patterns match closely; exact pipeline from repo to site is inferred |
+| No public source repository | **High** | Searched GitHub extensively — no matching repo found |
+| Periodic data refresh mechanism | **Medium** | Last-Modified header was very recent (3 min before request), suggesting automated updates |
+
+---
+
+## Footnotes
+
+[^1]: HTTP response header `Server: gunicorn` observed on all responses from `model-availability.azurewebsites.net`
+
+[^2]: 404 responses return `<!doctype html><html lang=en><title>404 Not Found</title><h1>Not Found</h1><p>The requested URL was not found on the server...` — this is the default Flask 404 template
+
+[^3]: `curl -sI` reveals `Set-Cookie: ARRAffinity=e9cd5ec577e988e26c6aeea6b26633bcce9c726369b3780126ec189abfe4b215;Path=/;HttpOnly;Secure;Domain=model-availability.azurewebsites.net` — Azure App Service Application Request Routing affinity cookie
+
+[^4]: Page source `<head>` section loads `/static/content/bootstrap.min.css`, `/static/content/style.css`, `/static/scripts/jquery-1.10.2.min.js`
+
+[^5]: Application Insights connection string extracted from inline script: `InstrumentationKey=d1a4755f-6372-4086-9d2b-04b1b8b43d2c;IngestionEndpoint=https://centralus-0.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/`
+
+[^6]: Network trace shows `POST https://centralus-0.in.applicationinsights.azure.com/v2/track` with JSON body containing `PageviewData` and `PageviewPerformanceData` telemetry events
+
+[^7]: HTML source contains `<div class="sku-option" data-value="/globalstandard">Global Standard</div>` and 12 other similar elements defining all available endpoints
+
+[^8]: Response headers from `/download_unified_markdown`: `Content-Disposition: attachment; filename=unified_markdown.md`, `Content-Length: 544500`, `ETag: "1775666705.1721544-544500-2959610287"`, `Last-Modified: Wed, 08 Apr 2026 16:45:05 GMT`
+
+[^9]: Unified markdown file contains 28 `## SectionName.md` headings extracted via regex match on the full downloaded content
+
+[^10]: Response body from `/globalstandard` starts with `<head><link rel="stylesheet"...></head><table border="1" class="dark-theme"><thead>...` containing model availability data in ✅/- format
+
+[^11]: Page source contains exactly 2 inline `<script>` blocks (no `src` attribute): Script 0 = App Insights bootstrap, Script 1 = all application logic
+
+[^12]: JavaScript function `changeContent(page)` uses `$.ajax({ url: page, type: "GET", success: function(response) { $("#displayArea").html(response); ... } })` — discovered via DOM extraction of inline scripts
+
+[^13]: JavaScript function `downloadLatestLogs()` uses `$.ajax({ url: '/download_unified_markdown', type: "GET", ... })` with blob download pattern
+
+[^14]: [MicrosoftDocs/azure-ai-docs](https://github.com/MicrosoftDocs/azure-ai-docs) repository, path `articles/foundry/openai/includes/model-matrix/` contains: `standard-global.md`, `standard-models.md`, `provisioned-models.md`, `provisioned-global.md`, `global-batch.md`, `global-batch-datazone.md`, `datazone-standard.md`, `datazone-provisioned-managed.md`, `standard-global-priority-processing.md`, `datazone-standard-priority-processing.md`
+
+[^15]: `model_metadata.md` section in unified markdown contains a wide table with 120 rows and 40+ columns including: Model Name, Version, Lifecycle Status, capability flags, rate limits, token limits, and retirement dates
+
+[^16]: HTML comments in page source: `<!--<title>Foundry Model Regional Availability</title>-->` and `<!--<h1>Foundry Model Regional Availability</h1>-->`

--- a/research/reverse-engineering-model-catalog-api.md
+++ b/research/reverse-engineering-model-catalog-api.md
@@ -1,0 +1,491 @@
+# Reverse Engineering the Azure AI Model Catalog & Building a Custom Enriched Catalog
+
+## Executive Summary
+
+The Azure AI Model Catalog at `https://ai.azure.com/catalog` is powered by a **public, unauthenticated REST API** at `POST https://ai.azure.com/api/westus2/asset-gallery/v1.0/models` that returns rich model metadata for all 14,879+ model versions across 55+ publishers. The API supports pagination, text search, and returns structured data including publisher, deployment types, capabilities, inference tasks, supported tools, pricing links, context windows, and more. Separately, the **`az cognitiveservices model list`** CLI command returns per-region model availability with SKU types. By combining these two data sources, we can build a comprehensive model catalog with region availability. Mintlify supports **custom React components** in MDX files, enabling an interactive search/filter/faceted catalog page.
+
+---
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    DATA COLLECTION PIPELINE                         │
+│                                                                     │
+│  ┌──────────────────────┐      ┌──────────────────────────┐        │
+│  │ Azure AI Catalog API  │      │ Azure RM Model List API  │        │
+│  │ (model metadata)     │      │ (region availability)    │        │
+│  │                      │      │                          │        │
+│  │ POST /asset-gallery/  │      │ az cognitiveservices     │        │
+│  │   v1.0/models        │      │   model list --location  │        │
+│  │                      │      │                          │        │
+│  │ Returns:             │      │ Returns:                 │        │
+│  │ - name, publisher    │      │ - model name + version   │        │
+│  │ - capabilities       │      │ - SKU types per region   │        │
+│  │ - deployment types   │      │ - rate limits            │        │
+│  │ - context window     │      │ - lifecycle status       │        │
+│  │ - pricing link       │      │ - capabilities           │        │
+│  │ - tools supported    │      │                          │        │
+│  │ - tasks, modalities  │      │                          │        │
+│  └──────────┬───────────┘      └───────────┬──────────────┘        │
+│             │                               │                       │
+│             ▼                               ▼                       │
+│  ┌──────────────────────────────────────────────────────┐          │
+│  │              ENRICHMENT + MERGE STEP                  │          │
+│  │  Join on model name → unified JSON catalog            │          │
+│  └───────────────────────┬──────────────────────────────┘          │
+│                          │                                          │
+│                          ▼                                          │
+│  ┌──────────────────────────────────────────────────────┐          │
+│  │              OUTPUT: models.json                      │          │
+│  │  Array of enriched model objects with:                │          │
+│  │  - All catalog metadata                               │          │
+│  │  - Region availability per deployment type            │          │
+│  │  - Facet-friendly tags                                │          │
+│  └───────────────────────┬──────────────────────────────┘          │
+└──────────────────────────┼──────────────────────────────────────────┘
+                           │
+                           ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                MINTLIFY DOCS SITE                                 │
+│                                                                  │
+│  docs-vnext/                                                     │
+│  ├── snippets/                                                   │
+│  │   └── model-catalog.jsx     ← React component                │
+│  ├── models/                                                     │
+│  │   └── catalog/                                                │
+│  │       └── model-explorer.mdx  ← Page that imports component  │
+│  └── static/                                                     │
+│      └── data/                                                   │
+│          └── models.json         ← Generated catalog data        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## API #1: Azure AI Model Catalog (Asset Gallery)
+
+### Endpoint
+
+```
+POST https://ai.azure.com/api/westus2/asset-gallery/v1.0/models
+```
+
+**No authentication required.** Works from curl with the `x-ms-use-full-service-contracts: true` header[^1].
+
+### Request Schema
+
+```json
+{
+  "pageSize": 100,
+  "filters": [],
+  "searchParameters": {
+    "searchText": "optional search query"
+  },
+  "continuationToken": "optional — from previous response"
+}
+```
+
+**Available filter fields** (returned in error message when using invalid fields)[^2]:
+
+| Field | Example Values |
+|-------|---------------|
+| `Name` | Model identifier |
+| `Version` | Version string |
+| `Labels` | `"latest"` |
+| `Publisher` | `"OpenAI"`, `"Meta"` |
+| `Author` | Publisher name |
+| `InferenceTasks` | `"chat-completion"`, `"text-to-image"` |
+| `FineTuningTasks` | `"chat-completion"`, `"chat"` |
+| `ModelCapabilities` | `"streaming"`, `"tool-calling"`, `"reasoning"` |
+| `AzureOffers` | `"standard-paygo"`, `"vm"`, `"ptu"`, `"batch-paygo"` |
+| `License` | `"custom"`, `"mit"`, `"apache-2.0"` |
+| `ModelLimits/TextLimits/MaxOutputTokens` | Integer |
+| `ModelLimits/TextLimits/InputContextWindow` | Integer |
+| `ModelLimits/SupportedInputModalities` | `"text"`, `"image"` |
+| `ModelLimits/SupportedOutputModalities` | `"text"`, `"image"` |
+| `Deprecation/InferenceRetirementDate` | ISO date |
+| `DisplayName` | Display name string |
+| `Summary` | Summary text |
+
+Filter operators: `eq`, `ne`[^2].
+
+**Note**: The `facets` parameter works only through the browser's BFF (backend-for-frontend) session, not from bare curl requests[^3]. Facets return counts by category (e.g., 38 models with "streaming" capability).
+
+### Response Schema — Model Object
+
+Each model in the `value` array has this structure[^4]:
+
+```json
+{
+  "relevancyScore": 1.0,
+  "entityResourceName": "azureml-registry-name",
+  "entityId": "azureml://registries/.../models/model-name/version/X",
+  "kind": "Versioned",
+  "version": "2026-03-17",
+  "annotations": {
+    "name": "gpt-5.4-nano",
+    "archived": false,
+    "labels": ["default", "latest", "invisibleLatest"],
+    "description": "...(markdown)...",
+    "tags": {
+      "displayName": "OpenAI gpt-5.4-nano",
+      "author": "OpenAI",
+      "summary": "...",
+      "task": "chat-completion",
+      "textContextWindow": "400000",
+      "maxOutputTokens": "128000",
+      "inputModalities": "text, image",
+      "outputModalities": "text",
+      "languages": "en",
+      "keywords": "Multipurpose,Multilingual,Multimodal",
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "modelCapabilities": "agentsV2, reasoning, tool-calling, streaming",
+      "deploymentOptions": "UnifiedEndpointMaaS, AOAI",
+      "evaluation": "...(markdown)...",
+      "notes": "...(markdown - responsible AI)...",
+      "benchmark": "quality",
+      "trainingDataDate": "August 2025",
+      "isDirectFromAzure": "true",
+      "playgroundRateLimitTier": "custom"
+    },
+    "systemCatalogData": {
+      "publisher": "OpenAI",
+      "displayName": "OpenAI gpt-5.4-nano",
+      "summary": "GPT-5.4-nano is a lightweight...",
+      "inferenceTasks": ["chat-completion", "responses"],
+      "deploymentTypes": ["batch-enabled"],
+      "modelCapabilities": ["agentsV2", "reasoning", "tool-calling", "streaming"],
+      "featuresSupported": ["streaming", "function_calling"],
+      "toolsSupported": ["code_interpreter", "azure_ai_search", "file_search", "web_search", "mcp", ...],
+      "inputModalities": ["text", "image"],
+      "outputModalities": ["text"],
+      "keywords": ["Multipurpose", "Multilingual", "Multimodal"],
+      "languages": ["en"],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "textContextWindow": 400000,
+      "maxOutputTokens": 128000,
+      "trainingDataDate": "August 2025",
+      "isDirectFromAzure": true,
+      "azureOffers": null,
+      "evaluation": "...(markdown)...",
+      "notes": "...(markdown - responsible AI)..."
+    }
+  }
+}
+```
+
+### Key Data Fields for the Catalog
+
+| Field Path | Type | Description |
+|-----------|------|-------------|
+| `annotations.tags.displayName` | string | Human-friendly model name |
+| `annotations.tags.author` | string | Publisher/provider |
+| `annotations.tags.summary` | string | One-line description |
+| `annotations.tags.task` | string | Primary inference task |
+| `annotations.tags.textContextWindow` | string | Context window size |
+| `annotations.tags.maxOutputTokens` | string | Max output tokens |
+| `annotations.tags.inputModalities` | string | Comma-separated: "text, image" |
+| `annotations.tags.outputModalities` | string | Comma-separated |
+| `annotations.tags.languages` | string | Comma-separated language codes |
+| `annotations.tags.keywords` | string | Comma-separated keywords |
+| `annotations.tags.license` | string | License type |
+| `annotations.tags.pricingLink` | string | URL to pricing page |
+| `annotations.tags.modelCapabilities` | string | Comma-separated capabilities |
+| `annotations.tags.isDirectFromAzure` | string | "true" if Azure-direct model |
+| `annotations.systemCatalogData.deploymentTypes` | array | `["aoai-deployment", "batch-enabled", "maas-inference", "maap-inference"]` |
+| `annotations.systemCatalogData.toolsSupported` | array | List of supported agent tools |
+| `annotations.systemCatalogData.azureOffers` | array | `["standard-paygo", "vm", "ptu", "batch-paygo"]` |
+| `version` | string | Model version identifier |
+
+### Pagination
+
+The API uses continuation token pagination[^5]:
+1. First request: `{"pageSize": 100, "filters": [], "searchParameters": {}}`
+2. Response includes `continuationToken` (base64-encoded, ~260 chars)
+3. Next request: add `"continuationToken": "<token>"` to request body
+4. Repeat until `continuationToken` is null/absent
+
+With `pageSize: 100`, you need ~149 requests to get all 14,879 model versions, or fewer if filtering to "latest" only.
+
+### Publishers Endpoint
+
+```
+POST https://ai.azure.com/api/westus2/asset-gallery/v1.0/publishers/list
+Body: {}
+```
+
+Returns 55 publishers with `publisherName`, `displayName`, and icon URLs[^6].
+
+---
+
+## API #2: Azure Resource Manager Model List
+
+The `az cognitiveservices model list --location <region>` CLI command calls[^7]:
+
+```
+GET /subscriptions/{subId}/providers/Microsoft.CognitiveServices/locations/{location}/models?api-version=2025-06-01
+```
+
+This returns all Azure OpenAI models available in a given region, including:
+- Model name and version
+- SKU types (GlobalStandard, Standard, Provisioned, etc.)
+- Rate limits per SKU
+- Capabilities (chatCompletion, embeddings, etc.)
+- Lifecycle status and retirement dates
+- Max capacity
+
+The existing `scripts/generate_model_availability.py` already handles this[^8].
+
+---
+
+## Facet Values Discovered
+
+From the browser BFF session, these facet values were extracted[^9]:
+
+### Deployment Types
+| Value | Count |
+|-------|-------|
+| `aoai-deployment` | 38 |
+| `batch-enabled` | 30 |
+| `maap-inference` | 6 |
+| `maas-inference` | 1 |
+
+### Capabilities
+| Value | Count |
+|-------|-------|
+| `streaming` | 38 |
+| `agentsV2` | 36 |
+| `reasoning` | 31 |
+| `tool-calling` | 28 |
+| `agents` | 16 |
+| `fine-tuning` | 8 |
+| `assistants` | 4 |
+
+### Inference Tasks
+| Value | Count |
+|-------|-------|
+| `chat-completion` | 37 |
+| `responses` | 37 |
+| `audio-generation` | 10 |
+| `text-to-image` | 4 |
+| `embeddings` | 3 |
+| `speech-to-text` | 3 |
+| `text-to-speech` | 3 |
+| `image-to-image` | 2 |
+| `video-generation` | 2 |
+| `automatic-speech-recognition` | 1 |
+
+### Azure Offers
+| Value | Description |
+|-------|-------------|
+| `vm` | Self-hosted on VM |
+| `standard-paygo` | Pay-as-you-go |
+| `ptu` | Provisioned Throughput Units |
+| `batch-paygo` | Batch processing |
+
+---
+
+## Implementation Plan
+
+### Step 1: Build Catalog Scraper Script
+
+Create `scripts/scrape_model_catalog.py` that:
+1. Paginates through the Asset Gallery API to collect all models
+2. Extracts and normalizes key fields into a flat, facet-friendly JSON structure
+3. Optionally merges with region availability data from `generate_model_availability.py`
+4. Outputs `docs-vnext/static/data/models.json`
+
+**Scraping approach:**
+```python
+# Pseudocode for catalog scraper
+models = []
+continuation_token = None
+while True:
+    body = {"pageSize": 100, "filters": [], "searchParameters": {}}
+    if continuation_token:
+        body["continuationToken"] = continuation_token
+    resp = requests.post(URL, json=body, headers=HEADERS)
+    data = resp.json()
+    models.extend(data.get("value", []))
+    continuation_token = data.get("continuationToken")
+    if not continuation_token:
+        break
+```
+
+**Normalized output schema:**
+```json
+{
+  "name": "gpt-5.4-nano",
+  "displayName": "OpenAI gpt-5.4-nano",
+  "publisher": "OpenAI",
+  "version": "2026-03-17",
+  "summary": "GPT-5.4-nano is a lightweight...",
+  "task": "chat-completion",
+  "inferenceTasks": ["chat-completion", "responses"],
+  "deploymentTypes": ["batch-enabled"],
+  "capabilities": ["agentsV2", "reasoning", "tool-calling", "streaming"],
+  "toolsSupported": ["code_interpreter", "azure_ai_search", "mcp", ...],
+  "azureOffers": ["standard-paygo"],
+  "inputModalities": ["text", "image"],
+  "outputModalities": ["text"],
+  "contextWindow": 400000,
+  "maxOutputTokens": 128000,
+  "languages": ["en"],
+  "keywords": ["Multipurpose", "Multilingual", "Multimodal"],
+  "license": "custom",
+  "pricingLink": "https://aka.ms/AzureOAIpricing",
+  "isDirectFromAzure": true,
+  "trainingDataDate": "August 2025",
+  "regions": {
+    "GlobalStandard": ["eastus", "westus2", "swedencentral", ...],
+    "Standard": ["eastus", "westus2", ...],
+    "Provisioned": ["eastus", ...]
+  }
+}
+```
+
+### Step 2: Merge Region Availability
+
+The `generate_model_availability.py` script already produces `raw_data.json`. The merge logic would:
+1. Run both scripts
+2. Match catalog models to RM models by name
+3. Attach region availability grouped by SKU type
+
+### Step 3: Mintlify Custom Catalog Page
+
+Mintlify supports React components in MDX files[^10]. The approach:
+
+1. **Static data file**: `docs-vnext/static/data/models.json` — generated at build time
+2. **React component**: `docs-vnext/snippets/model-catalog.jsx` — search/filter/faceted UI
+3. **MDX page**: `docs-vnext/models/catalog/model-explorer.mdx` — imports and renders the component
+
+**React component features:**
+- Text search across name, publisher, summary
+- Faceted filters for: Publisher, Deployment Type, Capabilities, Tasks, Region
+- Tag-based UI with counts
+- Card-based model display
+- Sort by name, context window, popularity
+- Uses `useState`, `useEffect`, `useMemo` for client-side filtering
+- Loads JSON data via fetch or static import
+
+**Key Mintlify constraints:**
+- Component files must live in `/snippets/` folder[^10]
+- Nested imports not supported — all components must be imported directly in the MDX file[^10]
+- Client-side rendering (not SSR) — acceptable since this is an interactive tool
+- Tailwind CSS classes are available[^10]
+
+### Example MDX Page
+
+```mdx
+---
+title: "Model Explorer"
+description: "Search and filter Azure AI models by provider, region, deployment type, and capabilities"
+---
+
+import { ModelCatalog } from "/snippets/model-catalog.jsx"
+
+# Model Explorer
+
+Browse all available models in Microsoft Foundry. Filter by provider, deployment type,
+capabilities, and region availability.
+
+<ModelCatalog />
+```
+
+---
+
+## Data Flow Summary
+
+```
+┌─────────────┐         ┌──────────────────┐
+│ az cog model│         │ Asset Gallery API │
+│ list        │         │ /v1.0/models      │
+│ (32 regions)│         │ (paginated)       │
+└──────┬──────┘         └────────┬─────────┘
+       │                         │
+       ▼                         ▼
+  raw_data.json          catalog_raw.json
+       │                         │
+       └──────────┬──────────────┘
+                  │
+                  ▼
+          merge + normalize
+                  │
+                  ▼
+    docs-vnext/static/data/models.json
+                  │
+                  ▼
+    docs-vnext/snippets/model-catalog.jsx
+    (React component: search/filter/facet)
+                  │
+                  ▼
+    docs-vnext/models/catalog/model-explorer.mdx
+    (Mintlify page: imports component)
+```
+
+---
+
+## Technical Considerations
+
+### Rate Limits
+- The Asset Gallery API has no visible rate limiting for reads. Paginating ~150 requests at 100/page completes in under a minute[^5].
+- The RM model list API benefits from parallelism (8+ workers across 32 regions)[^8].
+
+### Data Freshness
+- The catalog API returns live data from the Azure ML registry.
+- Region availability changes as Microsoft rolls out new models.
+- Recommended: run the scraper as a CI job (daily or on-demand) and commit the JSON.
+
+### Model Deduplication
+- The catalog API returns 14,879 items across all versions[^5].
+- Filter to "latest" versions in post-processing, or use the `Name` filter approach.
+- Some models appear under multiple publishers (e.g., Llama variants).
+
+### Data Size
+- Full catalog JSON (all versions, all fields): ~50-80 MB
+- Compact latest-only catalog (essential fields): ~2-5 MB
+- With region data merged: ~5-10 MB
+- Mintlify can serve static JSON files from the `static/` directory.
+
+---
+
+## Confidence Assessment
+
+| Finding | Confidence | Basis |
+|---------|-----------|-------|
+| Asset Gallery API is unauthenticated | **High** | Verified via curl — no auth headers needed[^1] |
+| API returns complete model metadata | **High** | Full model objects with all catalog fields returned[^4] |
+| Pagination via continuationToken works | **High** | Tested from curl, 100 items/page[^5] |
+| Filter field names documented in error messages | **High** | API returns valid field list when invalid field is used[^2] |
+| Facets only work through BFF session | **High** | Curl returns error "Facets are not supported for model summaries"[^3] |
+| 55 publishers, 14,879 model versions | **High** | Direct counts from API responses[^5][^6] |
+| Mintlify supports custom React in MDX | **High** | Official documentation confirms with examples[^10] |
+| Region availability merge is feasible | **High** | Both data sources use model name as key[^8] |
+| Build-time JSON generation approach | **Medium-High** | Standard Mintlify pattern; may need `static/` directory testing |
+
+---
+
+## Footnotes
+
+[^1]: Direct curl test: `curl -s -X POST 'https://ai.azure.com/api/westus2/asset-gallery/v1.0/models' -H 'Content-Type: application/json' -H 'x-ms-use-full-service-contracts: true' -d '{"pageSize":5,"filters":[],"searchParameters":{}}'` returns 200 with model data
+
+[^2]: Error response from invalid filter field returns: "Fields have to be one of Name, Version, Labels, freePlayground, Popularity, CreatedTime, DisplayName, Summary, License, Publisher, Author, InferenceTasks, FineTuningTasks, ModelLimits/TextLimits/MaxOutputTokens, ModelLimits/TextLimits/InputContextWindow, ModelLimits/SupportedInputModalities, ModelLimits/SupportedOutputModalities, ModelLimits/SupportedLanguages, PlaygroundLimits/RateLimitTier, ModelCapabilities, AzureOffers, VariantInformation/..., Deprecation/InferenceRetirementDate"
+
+[^3]: Error from curl with facets: "Facets are not supported for model summaries, please remove them from the request."
+
+[^4]: Full model object extracted from API response for `gpt-5.4-nano` including `annotations.tags` and `annotations.systemCatalogData` with all fields
+
+[^5]: Pagination test: `pageSize: 100` returns 100 items with `continuationToken` (260 chars, base64). `totalCount: 14879` returned on each page.
+
+[^6]: Publishers endpoint `POST /api/westus2/asset-gallery/v1.0/publishers/list` returns 55 publishers including OpenAI, Meta, Microsoft, Mistral AI, xAI, DeepSeek, Cohere, Nvidia, etc.
+
+[^7]: Azure CLI command `az cognitiveservices model list --location eastus` calls REST API `GET /subscriptions/{subId}/providers/Microsoft.CognitiveServices/locations/{location}/models?api-version=2025-06-01`
+
+[^8]: Existing script at `scripts/generate_model_availability.py` in the foundry-docs repository handles parallel region querying across 32 regions
+
+[^9]: Facet data extracted from browser network trace of `POST /api/westus2/asset-gallery/v1.0/models` with facet parameters, filtered to OpenAI publisher
+
+[^10]: Mintlify React components documentation: https://www.mintlify.com/docs/customize/react-components — components must be in `/snippets/` folder, support `useState`/`useEffect`/`useMemo`, Tailwind CSS available

--- a/scripts/generate_model_availability.py
+++ b/scripts/generate_model_availability.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""
+Azure OpenAI Model Availability Matrix Generator
+
+Queries the Azure Resource Manager API via `az cognitiveservices model list`
+for every relevant region and builds availability tables (HTML + Markdown)
+grouped by deployment SKU type — replicating what
+https://model-availability.azurewebsites.net/ shows.
+
+Prerequisites:
+  - Azure CLI (`az`) installed and logged in
+  - A valid Azure subscription
+  - `az extension add -n cognitiveservices` (if not already)
+
+Usage:
+  python generate.py                  # Generate output/index.html + output/*.md
+  python generate.py --format md      # Markdown only
+  python generate.py --format html    # HTML only
+  python generate.py --regions eastus westus2  # Specific regions only
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+
+# Regions known to host Azure OpenAI — avoids wasting time on 102 regions.
+# Override with --regions if needed.
+AOAI_REGIONS = [
+    "australiaeast",
+    "brazilsouth",
+    "canadacentral",
+    "canadaeast",
+    "centralindia",
+    "centralus",
+    "eastus",
+    "eastus2",
+    "francecentral",
+    "germanywestcentral",
+    "italynorth",
+    "japaneast",
+    "japanwest",
+    "koreacentral",
+    "mexicocentral",
+    "northcentralus",
+    "norwayeast",
+    "polandcentral",
+    "qatarcentral",
+    "southafricanorth",
+    "southcentralus",
+    "southeastasia",
+    "southindia",
+    "spaincentral",
+    "swedencentral",
+    "switzerlandnorth",
+    "switzerlandwest",
+    "uaenorth",
+    "uksouth",
+    "westeurope",
+    "westus",
+    "westus3",
+]
+
+SKU_DISPLAY_ORDER = [
+    "GlobalStandard",
+    "Standard",
+    "DataZoneStandard",
+    "GlobalBatch",
+    "DataZoneBatch",
+    "ProvisionedManaged",
+    "Provisioned",
+    "GlobalProvisionedManaged",
+    "DataZoneProvisionedManaged",
+    "DeveloperTier",
+]
+
+SKU_LABELS = {
+    "GlobalStandard": "Global Standard",
+    "Standard": "Standard",
+    "DataZoneStandard": "Data Zone Standard",
+    "GlobalBatch": "Global Batch",
+    "DataZoneBatch": "Data Zone Batch",
+    "ProvisionedManaged": "Provisioned Managed",
+    "Provisioned": "Provisioned",
+    "GlobalProvisionedManaged": "Global Provisioned Managed",
+    "DataZoneProvisionedManaged": "Data Zone Provisioned",
+    "DeveloperTier": "Developer Tier",
+}
+
+
+def fetch_models_for_region(region: str) -> dict:
+    """Call `az cognitiveservices model list` for a single region."""
+    try:
+        result = subprocess.run(
+            ["az", "cognitiveservices", "model", "list",
+             "--location", region, "-o", "json"],
+            capture_output=True, text=True, timeout=120
+        )
+        if result.returncode != 0:
+            print(f"  ⚠ {region}: {result.stderr.strip()[:120]}", file=sys.stderr)
+            return {"region": region, "models": []}
+        models = json.loads(result.stdout)
+        openai_models = [m for m in models if m.get("kind") == "OpenAI"]
+        print(f"  ✓ {region}: {len(openai_models)} OpenAI models")
+        return {"region": region, "models": openai_models}
+    except subprocess.TimeoutExpired:
+        print(f"  ⚠ {region}: timeout", file=sys.stderr)
+        return {"region": region, "models": []}
+    except Exception as e:
+        print(f"  ⚠ {region}: {e}", file=sys.stderr)
+        return {"region": region, "models": []}
+
+
+def build_availability_matrix(all_region_data: list[dict]) -> dict:
+    """
+    Build a nested dict:
+      sku_name -> {
+        "models": { (model_name, version): set_of_regions },
+        "regions": set_of_all_regions_with_this_sku
+      }
+    """
+    matrix = defaultdict(lambda: {
+        "models": defaultdict(set),
+        "regions": set()
+    })
+
+    for rd in all_region_data:
+        region = rd["region"]
+        for entry in rd["models"]:
+            m = entry.get("model", {})
+            name = m.get("name", "")
+            version = m.get("version", "")
+            lifecycle = m.get("lifecycleStatus", "")
+            if lifecycle in ("Deprecated",):
+                continue
+            for sku in m.get("skus", []):
+                sku_name = sku.get("name", "")
+                if not sku_name:
+                    continue
+                matrix[sku_name]["models"][(name, version)].add(region)
+                matrix[sku_name]["regions"].add(region)
+
+    return matrix
+
+
+def sort_model_key(model_tuple):
+    """Sort models: by name, then by version descending."""
+    name, version = model_tuple
+    return (name.lower(), version)
+
+
+def generate_markdown(matrix: dict) -> dict[str, str]:
+    """Generate a markdown table per SKU type. Returns {sku_name: md_string}."""
+    outputs = {}
+
+    for sku_name in SKU_DISPLAY_ORDER:
+        if sku_name not in matrix:
+            continue
+
+        data = matrix[sku_name]
+        models = sorted(data["models"].keys(), key=sort_model_key)
+        regions = sorted(data["regions"])
+
+        if not models or not regions:
+            continue
+
+        label = SKU_LABELS.get(sku_name, sku_name)
+        lines = [f"# {label}\n"]
+
+        # Header
+        header = "| **Region** |"
+        sep = "|:---|"
+        for name, ver in models:
+            header += f" **{name}** ({ver}) |"
+            sep += ":---:|"
+        lines.append(header)
+        lines.append(sep)
+
+        # Data rows
+        for region in regions:
+            row = f"| {region} |"
+            for model_key in models:
+                row += " ✅ |" if region in data["models"][model_key] else " - |"
+            lines.append(row)
+
+        lines.append("")
+        outputs[sku_name] = "\n".join(lines)
+
+    return outputs
+
+
+def generate_html(matrix: dict) -> str:
+    """Generate a single-page HTML with tabs for each SKU type."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    sku_tables = []
+
+    for sku_name in SKU_DISPLAY_ORDER:
+        if sku_name not in matrix:
+            continue
+
+        data = matrix[sku_name]
+        models = sorted(data["models"].keys(), key=sort_model_key)
+        regions = sorted(data["regions"])
+
+        if not models or not regions:
+            continue
+
+        sku_id = sku_name.lower()
+
+        # Build table HTML
+        header_row1 = "<th>Region</th>"
+        header_row2 = "<th>Version</th>"
+        for name, ver in models:
+            header_row1 += f"<th>{name}</th>"
+            header_row2 += f"<th>{ver}</th>"
+
+        body_rows = ""
+        for region in regions:
+            cells = f"<td>{region}</td>"
+            for model_key in models:
+                if region in data["models"][model_key]:
+                    cells += '<td>✅</td>'
+                else:
+                    cells += '<td>-</td>'
+            body_rows += f"<tr>{cells}</tr>\n"
+
+        table = f"""
+<div class="sku-table" id="table-{sku_id}" style="display:none;">
+  <table>
+    <thead>
+      <tr>{header_row1}</tr>
+      <tr>{header_row2}</tr>
+    </thead>
+    <tbody>
+      {body_rows}
+    </tbody>
+  </table>
+</div>"""
+        sku_tables.append(table)
+
+    first_sku = next(
+        (s.lower() for s in SKU_DISPLAY_ORDER if s in matrix), ""
+    )
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Azure OpenAI Model Regional Availability (Self-Generated)</title>
+<style>
+  body {{
+    background: #212121; color: #ECECEC; font-family: 'Segoe UI', sans-serif;
+    padding: 20px 30px; margin: 0;
+  }}
+  h1 {{
+    color: white; font-size: medium; padding: 10px;
+    border: 2px solid white; display: inline-block;
+  }}
+  .subtitle {{ color: #999; font-size: 12px; margin-top: 8px; }}
+  .controls {{ margin: 20px 0 10px; }}
+  select {{
+    padding: 6px 12px; background: #2b2b2b; color: #ECECEC;
+    border: 1px solid #515151; border-radius: 4px; font-size: 13px;
+    cursor: pointer;
+  }}
+  input[type=text] {{
+    padding: 6px 12px; background: #2b2b2b; color: #ECECEC;
+    border: 1px solid #515151; border-radius: 4px; font-size: 13px;
+    margin-left: 10px; width: 250px;
+  }}
+  table {{
+    background: #2b2b2b; border-collapse: separate; border-spacing: 0;
+    border-radius: 10px; font-size: 12px; text-align: left;
+    margin-top: 10px; width: auto;
+  }}
+  thead th {{
+    text-align: center; padding: 12px 16px; position: sticky; top: 0;
+    background: rgba(107, 64, 216, 0.3); z-index: 2;
+  }}
+  thead tr:nth-child(2) th {{ background: #2b2b2b; }}
+  td {{ text-align: center; padding: 6px 12px; }}
+  tr td:first-child {{ text-align: left; font-weight: 500; }}
+  tbody tr:nth-child(even) {{ background: #333; }}
+  tbody tr:nth-child(odd) {{ background: #2b2b2b; }}
+  tbody tr:hover {{ background: rgba(104, 222, 122, 0.4) !important; }}
+  th, td {{ border: 1px solid #515151; }}
+  .hidden {{ display: none !important; }}
+</style>
+</head>
+<body>
+  <h1>Azure OpenAI Model Regional Availability</h1>
+  <div class="subtitle">
+    Auto-generated on {timestamp} via
+    <code>az cognitiveservices model list</code>
+  </div>
+
+  <div class="controls">
+    <select id="skuSelect" onchange="switchSku(this.value)">
+      {"".join(f'<option value="{s.lower()}">{SKU_LABELS.get(s, s)}</option>'
+               for s in SKU_DISPLAY_ORDER if s in matrix)}
+    </select>
+    <input type="text" id="search" placeholder="Filter models..."
+           oninput="filterModels(this.value)">
+  </div>
+
+  <div id="tables">
+    {"".join(sku_tables)}
+  </div>
+
+  <script>
+    function switchSku(sku) {{
+      document.querySelectorAll('.sku-table').forEach(
+        t => t.style.display = 'none'
+      );
+      var el = document.getElementById('table-' + sku);
+      if (el) el.style.display = '';
+      document.getElementById('search').value = '';
+      filterModels('');
+    }}
+
+    function filterModels(query) {{
+      query = query.toLowerCase();
+      document.querySelectorAll(
+        '.sku-table:not([style*="display: none"]) table'
+      ).forEach(function(table) {{
+        var headers = table.querySelectorAll('thead tr:first-child th');
+        var versionHeaders = table.querySelectorAll(
+          'thead tr:nth-child(2) th'
+        );
+        var visibleCols = [0];
+        for (var i = 1; i < headers.length; i++) {{
+          var name = headers[i].textContent.toLowerCase();
+          var ver = (versionHeaders[i] || {{}}).textContent || '';
+          if (!query || name.indexOf(query) !== -1
+              || ver.toLowerCase().indexOf(query) !== -1) {{
+            visibleCols.push(i);
+          }}
+        }}
+        table.querySelectorAll('tr').forEach(function(row) {{
+          var cells = row.querySelectorAll('th, td');
+          for (var c = 0; c < cells.length; c++) {{
+            cells[c].style.display =
+              visibleCols.indexOf(c) !== -1 ? '' : 'none';
+          }}
+        }});
+      }});
+    }}
+
+    switchSku('{first_sku}');
+  </script>
+</body>
+</html>"""
+
+    return html
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate Azure OpenAI model availability matrix"
+    )
+    parser.add_argument(
+        "--regions", nargs="*", default=None,
+        help="Specific regions to query (default: all known AOAI regions)"
+    )
+    parser.add_argument(
+        "--format", choices=["html", "md", "both"], default="both",
+        help="Output format (default: both)"
+    )
+    parser.add_argument(
+        "--output", default="output",
+        help="Output directory (default: ./output)"
+    )
+    parser.add_argument(
+        "--workers", type=int, default=8,
+        help="Parallel workers for querying regions (default: 8)"
+    )
+    args = parser.parse_args()
+
+    regions = args.regions or AOAI_REGIONS
+    os.makedirs(args.output, exist_ok=True)
+
+    print(f"🔍 Querying {len(regions)} regions with {args.workers} workers...")
+    all_data = []
+
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(fetch_models_for_region, r): r for r in regions}
+        for future in as_completed(futures):
+            all_data.append(future.result())
+
+    print(f"\n📊 Building availability matrix...")
+    matrix = build_availability_matrix(all_data)
+
+    skus_found = [s for s in SKU_DISPLAY_ORDER if s in matrix]
+    total_models = sum(len(matrix[s]["models"]) for s in skus_found)
+    total_regions = len(set().union(*(matrix[s]["regions"] for s in skus_found)))
+    print(f"   Found {total_models} unique model+version combos "
+          f"across {total_regions} regions and {len(skus_found)} SKU types")
+
+    if args.format in ("md", "both"):
+        md_outputs = generate_markdown(matrix)
+        for sku_name, md in md_outputs.items():
+            path = os.path.join(args.output, f"{sku_name}.md")
+            with open(path, "w") as f:
+                f.write(md)
+        combined = os.path.join(args.output, "all_models.md")
+        with open(combined, "w") as f:
+            for sku_name in SKU_DISPLAY_ORDER:
+                if sku_name in md_outputs:
+                    f.write(md_outputs[sku_name])
+                    f.write("\n---\n\n")
+        print(f"   ✅ Markdown: {args.output}/*.md")
+
+    if args.format in ("html", "both"):
+        html = generate_html(matrix)
+        path = os.path.join(args.output, "index.html")
+        with open(path, "w") as f:
+            f.write(html)
+        print(f"   ✅ HTML:     {args.output}/index.html")
+
+    # Dump raw JSON for downstream use
+    raw_path = os.path.join(args.output, "raw_data.json")
+    with open(raw_path, "w") as f:
+        json.dump(all_data, f, indent=2, default=str)
+    print(f"   ✅ Raw JSON: {args.output}/raw_data.json")
+
+    print(f"\n✨ Done! Open {args.output}/index.html in a browser.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scrape_model_catalog.py
+++ b/scripts/scrape_model_catalog.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""
+Azure AI Model Catalog Scraper
+
+Paginates the public Azure AI Asset Gallery API to collect model metadata,
+filters to Azure-sold ("Direct from Azure") models, normalizes into a compact
+JSON schema, validates output, and optionally merges region availability
+from `generate_model_availability.py`.
+
+Prerequisites:
+  - Python 3.11+ (uses stdlib only — no pip install needed)
+  - Optional: `az` CLI for region availability merge
+
+Usage:
+  python scrape_model_catalog.py                          # Output to stdout
+  python scrape_model_catalog.py --output docs-vnext/static/data
+  python scrape_model_catalog.py --include-partners       # Include non-Azure-direct models
+  python scrape_model_catalog.py --merge-regions output/raw_data.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger(__name__)
+
+CATALOG_API_URL = "https://ai.azure.com/api/westus2/asset-gallery/v1.0/models"
+CATALOG_HEADERS = {
+    "Content-Type": "application/json",
+    "x-ms-use-full-service-contracts": "true",
+}
+PAGE_SIZE = 100
+MAX_PAGES = 200  # Safety limit: 200 * 100 = 20,000 models
+MIN_AZURE_DIRECT_MODELS = 50  # Validation gate
+
+# Retry settings
+MAX_RETRIES = 3
+RETRY_DELAY = 5.0
+
+
+@dataclass(slots=True)
+class CatalogModel:
+    """Normalized model record for the catalog JSON output."""
+
+    id: str
+    displayName: str
+    publisher: str
+    latestVersion: str
+    versions: list[str] = field(default_factory=list)
+    summary: str = ""
+    tasks: list[str] = field(default_factory=list)
+    capabilities: list[str] = field(default_factory=list)
+    deploymentTypes: list[str] = field(default_factory=list)
+    azureOffers: list[str] = field(default_factory=list)
+    toolsSupported: list[str] = field(default_factory=list)
+    inputModalities: list[str] = field(default_factory=list)
+    outputModalities: list[str] = field(default_factory=list)
+    contextWindow: int | None = None
+    maxOutputTokens: int | None = None
+    languages: list[str] = field(default_factory=list)
+    keywords: list[str] = field(default_factory=list)
+    license: str = ""
+    pricingLink: str = ""
+    isDirectFromAzure: bool = False
+    lifecycleStatus: str = "generally-available"
+    isPreview: bool = False
+    trainingDataDate: str = ""
+    regions: dict[str, list[str]] = field(default_factory=dict)
+
+
+def _api_post(url: str, body: dict, headers: dict) -> dict:
+    """POST JSON to an API with retry logic."""
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            if e.code == 429 or e.code >= 500:
+                delay = RETRY_DELAY * attempt
+                log.warning("  ⚠ HTTP %d on attempt %d, retrying in %.0fs...", e.code, attempt, delay)
+                time.sleep(delay)
+                continue
+            raise
+        except urllib.error.URLError as e:
+            if attempt < MAX_RETRIES:
+                delay = RETRY_DELAY * attempt
+                log.warning("  ⚠ URLError on attempt %d: %s, retrying in %.0fs...", attempt, e.reason, delay)
+                time.sleep(delay)
+                continue
+            raise
+
+    raise RuntimeError(f"Failed after {MAX_RETRIES} retries: {url}")
+
+
+def fetch_all_models() -> list[dict]:
+    """Paginate through the Asset Gallery API to collect all model records."""
+    all_models = []
+    continuation_token = None
+
+    for page in range(1, MAX_PAGES + 1):
+        body: dict = {
+            "pageSize": PAGE_SIZE,
+            "filters": [],
+            "searchParameters": {},
+        }
+        if continuation_token:
+            body["continuationToken"] = continuation_token
+
+        log.info("  📄 Page %d (have %d models so far)...", page, len(all_models))
+        data = _api_post(CATALOG_API_URL, body, CATALOG_HEADERS)
+
+        items = data.get("value", [])
+        all_models.extend(items)
+
+        continuation_token = data.get("continuationToken")
+        if not continuation_token:
+            break
+
+        # Be polite
+        time.sleep(0.2)
+
+    log.info("  ✅ Fetched %d total model records across %d pages", len(all_models), page)
+    return all_models
+
+
+def _safe_str(val) -> str:
+    if val is None:
+        return ""
+    return str(val).strip()
+
+
+def _safe_list(val) -> list[str]:
+    """Normalize a value to a list of strings."""
+    if val is None:
+        return []
+    if isinstance(val, list):
+        return [str(v).strip() for v in val if v]
+    if isinstance(val, str):
+        # Handle comma-separated strings
+        return [v.strip() for v in val.split(",") if v.strip()]
+    return []
+
+
+def _safe_int(val) -> int | None:
+    if val is None:
+        return None
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return None
+
+
+def normalize_model(raw: dict) -> CatalogModel | None:
+    """Extract and normalize key fields from a raw API model record."""
+    annotations = raw.get("annotations", {})
+    tags = annotations.get("tags", {})
+    scd = annotations.get("systemCatalogData", {})
+
+    # Prefer systemCatalogData, fall back to tags
+    model_name = annotations.get("name", "")
+    display_name = scd.get("displayName") or tags.get("displayName") or model_name
+    publisher = scd.get("publisher") or tags.get("author") or ""
+    version = raw.get("version", "")
+
+    if not model_name or not publisher:
+        return None
+
+    is_direct = (
+        scd.get("isDirectFromAzure") is True
+        or _safe_str(tags.get("isDirectFromAzure")).lower() == "true"
+    )
+
+    # Detect preview/deprecated from labels and tags
+    labels = annotations.get("labels", [])
+    is_preview = "Preview" in tags or any("preview" in str(l).lower() for l in labels)
+    lifecycle = "preview" if is_preview else "generally-available"
+
+    return CatalogModel(
+        id=model_name,
+        displayName=display_name,
+        publisher=publisher,
+        latestVersion=version,
+        versions=[version],
+        summary=_safe_str(scd.get("summary") or tags.get("summary")),
+        tasks=_safe_list(scd.get("inferenceTasks") or tags.get("task")),
+        capabilities=_safe_list(scd.get("modelCapabilities") or tags.get("modelCapabilities")),
+        deploymentTypes=_safe_list(scd.get("deploymentTypes")),
+        azureOffers=_safe_list(scd.get("azureOffers")),
+        toolsSupported=_safe_list(scd.get("toolsSupported")),
+        inputModalities=_safe_list(scd.get("inputModalities") or tags.get("inputModalities")),
+        outputModalities=_safe_list(scd.get("outputModalities") or tags.get("outputModalities")),
+        contextWindow=_safe_int(scd.get("textContextWindow") or tags.get("textContextWindow")),
+        maxOutputTokens=_safe_int(scd.get("maxOutputTokens") or tags.get("maxOutputTokens")),
+        languages=_safe_list(scd.get("languages") or tags.get("languages")),
+        keywords=_safe_list(scd.get("keywords") or tags.get("keywords")),
+        license=_safe_str(scd.get("license") or tags.get("license")),
+        pricingLink=_safe_str(scd.get("pricingLink") or tags.get("pricingLink")),
+        isDirectFromAzure=is_direct,
+        lifecycleStatus=lifecycle,
+        isPreview=is_preview,
+        trainingDataDate=_safe_str(scd.get("trainingDataDate") or tags.get("trainingDataDate")),
+    )
+
+
+def deduplicate_models(models: list[CatalogModel]) -> list[CatalogModel]:
+    """Group by (publisher, model_id), keep the latest version as default, collect all versions."""
+    groups: dict[tuple[str, str], list[CatalogModel]] = defaultdict(list)
+    for m in models:
+        key = (m.publisher.lower(), m.id.lower())
+        groups[key].append(m)
+
+    deduped = []
+    for _key, versions in groups.items():
+        # Sort by version string descending (works for date-based versions)
+        versions.sort(key=lambda m: m.latestVersion, reverse=True)
+        latest = versions[0]
+        # Collect all version strings
+        all_versions = sorted({v.latestVersion for v in versions}, reverse=True)
+        latest.versions = all_versions
+        latest.latestVersion = all_versions[0]
+        # Merge capabilities across versions
+        all_caps = set()
+        all_tasks = set()
+        all_dt = set()
+        all_offers = set()
+        all_tools = set()
+        for v in versions:
+            all_caps.update(v.capabilities)
+            all_tasks.update(v.tasks)
+            all_dt.update(v.deploymentTypes)
+            all_offers.update(v.azureOffers)
+            all_tools.update(v.toolsSupported)
+        latest.capabilities = sorted(all_caps)
+        latest.tasks = sorted(all_tasks)
+        latest.deploymentTypes = sorted(all_dt)
+        latest.azureOffers = sorted(all_offers)
+        latest.toolsSupported = sorted(all_tools)
+        deduped.append(latest)
+
+    return sorted(deduped, key=lambda m: (m.publisher.lower(), m.id.lower()))
+
+
+def merge_region_data(models: list[CatalogModel], raw_data_path: str) -> None:
+    """Merge region availability from generate_model_availability.py output."""
+    if not os.path.exists(raw_data_path):
+        log.warning("  ⚠ Region data file not found: %s — skipping region merge", raw_data_path)
+        return
+
+    with open(raw_data_path) as f:
+        region_data = json.load(f)
+
+    # Build lookup: model_name -> { sku_name -> [regions] }
+    region_map: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
+    for rd in region_data:
+        region = rd.get("region", "")
+        for entry in rd.get("models", []):
+            m = entry.get("model", {})
+            name = m.get("name", "").lower()
+            lifecycle = m.get("lifecycleStatus", "")
+            if lifecycle == "Deprecated":
+                continue
+            for sku in m.get("skus", []):
+                sku_name = sku.get("name", "")
+                if sku_name and region:
+                    region_map[name][sku_name].append(region)
+
+    matched = 0
+    for model in models:
+        key = model.id.lower()
+        if key in region_map:
+            # Sort regions within each SKU
+            model.regions = {
+                sku: sorted(set(regions)) for sku, regions in region_map[key].items()
+            }
+            matched += 1
+
+    log.info("  📍 Region merge: %d/%d models matched", matched, len(models))
+    if matched < len(models):
+        unmatched = [m.id for m in models if not m.regions]
+        log.info("  ℹ  Unmatched models: %s", ", ".join(unmatched[:20]))
+        if len(unmatched) > 20:
+            log.info("     ... and %d more", len(unmatched) - 20)
+
+
+def validate_output(models: list[CatalogModel]) -> bool:
+    """Validate the output data. Returns True if valid, False otherwise."""
+    errors = []
+
+    # Check minimum count
+    azure_direct = [m for m in models if m.isDirectFromAzure]
+    if len(azure_direct) < MIN_AZURE_DIRECT_MODELS:
+        errors.append(
+            f"Only {len(azure_direct)} Azure Direct models found "
+            f"(minimum: {MIN_AZURE_DIRECT_MODELS})"
+        )
+
+    # Check required fields
+    for m in models:
+        if not m.id:
+            errors.append(f"Model missing id: {m.displayName}")
+        if not m.displayName:
+            errors.append(f"Model missing displayName: {m.id}")
+        if not m.publisher:
+            errors.append(f"Model missing publisher: {m.id}")
+        if not m.latestVersion:
+            errors.append(f"Model missing latestVersion: {m.id}")
+
+    # Check region data integrity
+    for m in models:
+        for sku, regions in m.regions.items():
+            if not isinstance(regions, list):
+                errors.append(f"Model {m.id}: regions[{sku}] is not a list")
+            elif not all(isinstance(r, str) for r in regions):
+                errors.append(f"Model {m.id}: regions[{sku}] contains non-string values")
+
+    if errors:
+        log.error("❌ Validation failed with %d errors:", len(errors))
+        for e in errors[:20]:
+            log.error("   - %s", e)
+        return False
+
+    log.info("  ✅ Validation passed: %d models (%d Azure Direct)", len(models), len(azure_direct))
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scrape Azure AI Model Catalog")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output directory (writes models.json). If omitted, prints to stdout.",
+    )
+    parser.add_argument(
+        "--include-partners",
+        action="store_true",
+        help="Include non-Azure-Direct partner models (default: Azure Direct only)",
+    )
+    parser.add_argument(
+        "--merge-regions",
+        default=None,
+        help="Path to raw_data.json from generate_model_availability.py for region merge",
+    )
+    args = parser.parse_args()
+
+    log.info("🔍 Fetching model catalog from Azure AI Asset Gallery...")
+    raw_models = fetch_all_models()
+
+    log.info("🔄 Normalizing %d raw records...", len(raw_models))
+    normalized = []
+    for raw in raw_models:
+        model = normalize_model(raw)
+        if model is not None:
+            normalized.append(model)
+    log.info("  ✅ Normalized %d models (skipped %d malformed)", len(normalized), len(raw_models) - len(normalized))
+
+    if not args.include_partners:
+        before = len(normalized)
+        normalized = [m for m in normalized if m.isDirectFromAzure]
+        log.info("  🔎 Filtered to Azure Direct: %d models (removed %d partner models)", len(normalized), before - len(normalized))
+
+    log.info("🔀 Deduplicating across versions...")
+    deduped = deduplicate_models(normalized)
+    log.info("  ✅ %d unique models after deduplication", len(deduped))
+
+    if args.merge_regions:
+        log.info("📍 Merging region availability data...")
+        merge_region_data(deduped, args.merge_regions)
+
+    log.info("✔️  Validating output...")
+    if not validate_output(deduped):
+        log.error("💥 Aborting: validation failed. No output written.")
+        sys.exit(1)
+
+    # Serialize
+    output_data = {
+        "generatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "totalModels": len(deduped),
+        "models": [asdict(m) for m in deduped],
+    }
+
+    if args.output:
+        os.makedirs(args.output, exist_ok=True)
+        path = os.path.join(args.output, "models.json")
+        with open(path, "w") as f:
+            json.dump(output_data, f, indent=2, ensure_ascii=False)
+        size_kb = os.path.getsize(path) / 1024
+        log.info("✨ Wrote %s (%.1f KB, %d models)", path, size_kb, len(deduped))
+    else:
+        json.dump(output_data, sys.stdout, indent=2, ensure_ascii=False)
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an interactive Model Explorer page to the docs-vnext Mintlify site, powered by data scraped from the public Azure AI Asset Gallery API.

### What's included

| File | Purpose |
|------|---------|
| `scripts/scrape_model_catalog.py` | Scrapes Azure AI catalog API → 103 Azure-direct models, validates, outputs JSON |
| `scripts/generate_model_availability.py` | Region availability generator (optional merge via `--merge-regions`) |
| `docs-vnext/static/data/models.json` | 136KB seed catalog data (103 models, 10 publishers) |
| `docs-vnext/snippets/model-catalog.jsx` | React component with search, faceted filters, expandable model cards |
| `docs-vnext/models/catalog/model-explorer.mdx` | MDX page importing the React component |
| `docs-vnext/docs.json` | Navigation updated — Model Explorer first in Model catalog group |
| `.github/workflows/model-catalog-sync.md` | gh-aw daily workflow to refresh data |
| `research/` | Reverse-engineering research reports |

### Features
- **Text search** across model name, publisher, summary, keywords
- **Faceted filters**: Provider, Task, Capability, Deployment Type
- **Expandable model cards** with specs: context window, max output, tools, modalities, deployment options, pricing link
- **Sort** by name, provider, or context window
- **Daily refresh** via gh-aw workflow (creates PR when data changes, fail-closed on bad data)
- **Validation gates**: schema checks, minimum record count (>50), required field assertions

### Data pipeline
1. `scrape_model_catalog.py` paginates `POST https://ai.azure.com/api/westus2/asset-gallery/v1.0/models` (public, no auth)
2. Filters to `isDirectFromAzure` models, normalizes, deduplicates across versions
3. Optionally merges region availability via `--merge-regions` from `generate_model_availability.py` output
4. Outputs `models.json` with validation gates