### PR TITLE
feat: add Model Explorer to docs/ for live Mintlify site

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -198,6 +198,7 @@
               {
                 "group": "Explore Foundry Models",
                 "pages": [
+                  "foundry-models/model-explorer",
                   "foundry-models/models-sold-directly-by-azure",
                   "foundry-models/models-from-partners",
                   "foundry-models/data-privacy",

--- a/docs/foundry-models/model-explorer.mdx
+++ b/docs/foundry-models/model-explorer.mdx
@@ -1,0 +1,18 @@
+---
+title: "Model Explorer"
+description: "Search and filter all available Azure AI models by provider, capability, deployment type, and more"
+---
+
+import { ModelCatalog } from "/snippets/model-catalog.jsx"
+
+# Model Explorer
+
+Browse all models available directly from Azure in Microsoft Foundry. Use the search bar and faceted filters to find models by provider, capability, deployment type, and task.
+
+<Tip>
+This catalog is auto-generated from the Azure AI model registry and refreshed daily.
+For detailed model documentation, see [Models sold directly by Azure](/foundry-models/models-sold-directly-by-azure).
+For deployment guidance, see [Deployment types](/foundry-models/deployment-types).
+</Tip>
+
+<ModelCatalog />

--- a/docs/snippets/model-catalog.jsx
+++ b/docs/snippets/model-catalog.jsx
@@ -1,0 +1,463 @@
+export const ModelCatalog = () => {
+  const [models, setModels] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [activeFilters, setActiveFilters] = useState({})
+  const [sortBy, setSortBy] = useState("name")
+  const [expandedModel, setExpandedModel] = useState(null)
+
+  useEffect(() => {
+    fetch("/static/data/models.json")
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`)
+        return r.json()
+      })
+      .then((data) => {
+        setModels(data.models || [])
+        setLoading(false)
+      })
+      .catch((err) => {
+        setError(err.message)
+        setLoading(false)
+      })
+  }, [])
+
+  const facetConfig = useMemo(
+    () => [
+      { key: "publisher", label: "Provider" },
+      { key: "tasks", label: "Task" },
+      { key: "capabilities", label: "Capability" },
+      { key: "deploymentTypes", label: "Deployment" },
+    ],
+    []
+  )
+
+  const facetCounts = useMemo(() => {
+    const counts = {}
+    for (const f of facetConfig) {
+      const map = {}
+      for (const m of models) {
+        const vals = Array.isArray(m[f.key]) ? m[f.key] : [m[f.key]]
+        for (const v of vals) {
+          if (v) map[v] = (map[v] || 0) + 1
+        }
+      }
+      counts[f.key] = Object.entries(map)
+        .sort((a, b) => b[1] - a[1])
+        .map(([value, count]) => ({ value, count }))
+    }
+    return counts
+  }, [models, facetConfig])
+
+  const filteredModels = useMemo(() => {
+    let result = models
+
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      result = result.filter(
+        (m) =>
+          m.displayName?.toLowerCase().includes(q) ||
+          m.publisher?.toLowerCase().includes(q) ||
+          m.summary?.toLowerCase().includes(q) ||
+          m.id?.toLowerCase().includes(q) ||
+          m.keywords?.some((k) => k.toLowerCase().includes(q))
+      )
+    }
+
+    for (const [key, values] of Object.entries(activeFilters)) {
+      if (values && values.length > 0) {
+        result = result.filter((m) => {
+          const mVal = m[key]
+          if (Array.isArray(mVal)) {
+            return values.some((v) => mVal.includes(v))
+          }
+          return values.includes(mVal)
+        })
+      }
+    }
+
+    result = [...result].sort((a, b) => {
+      if (sortBy === "name")
+        return (a.displayName || "").localeCompare(b.displayName || "")
+      if (sortBy === "context")
+        return (b.contextWindow || 0) - (a.contextWindow || 0)
+      if (sortBy === "publisher")
+        return (a.publisher || "").localeCompare(b.publisher || "")
+      return 0
+    })
+
+    return result
+  }, [models, searchQuery, activeFilters, sortBy])
+
+  const toggleFilter = (facetKey, value) => {
+    setActiveFilters((prev) => {
+      const current = prev[facetKey] || []
+      const next = current.includes(value)
+        ? current.filter((v) => v !== value)
+        : [...current, value]
+      return { ...prev, [facetKey]: next }
+    })
+  }
+
+  const clearFilters = () => {
+    setActiveFilters({})
+    setSearchQuery("")
+  }
+
+  const hasActiveFilters =
+    searchQuery ||
+    Object.values(activeFilters).some((v) => v && v.length > 0)
+
+  const DEPLOY_LABELS = {
+    "aoai-deployment": "Azure OpenAI",
+    "batch-enabled": "Batch",
+    "maas-inference": "Serverless API",
+    "maap-inference": "Managed Compute",
+  }
+
+  const TASK_LABELS = {
+    "chat-completion": "Chat",
+    responses: "Responses",
+    embeddings: "Embeddings",
+    "text-to-image": "Image Gen",
+    "image-to-image": "Image Edit",
+    "audio-generation": "Audio Gen",
+    "speech-to-text": "Speech-to-Text",
+    "text-to-speech": "Text-to-Speech",
+    "video-generation": "Video Gen",
+    "automatic-speech-recognition": "ASR",
+  }
+
+  const CAP_LABELS = {
+    agentsV2: "Agents",
+    agents: "Agents (v1)",
+    reasoning: "Reasoning",
+    streaming: "Streaming",
+    "tool-calling": "Tool Calling",
+    "fine-tuning": "Fine-tuning",
+    assistants: "Assistants",
+  }
+
+  const formatLabel = (key, value) => {
+    if (key === "deploymentTypes") return DEPLOY_LABELS[value] || value
+    if (key === "tasks") return TASK_LABELS[value] || value
+    if (key === "capabilities") return CAP_LABELS[value] || value
+    return value
+  }
+
+  const formatNumber = (n) => {
+    if (!n) return "—"
+    if (n >= 1000000) return `${(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)}M`
+    if (n >= 1000) return `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}K`
+    return String(n)
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="text-zinc-500 dark:text-zinc-400 text-sm">
+          Loading model catalog…
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-4">
+        <p className="text-red-700 dark:text-red-400 text-sm">
+          Failed to load model catalog: {error}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="not-prose">
+      {/* Search + Sort bar */}
+      <div className="flex flex-col sm:flex-row gap-3 mb-4">
+        <div className="relative flex-1">
+          <input
+            type="text"
+            placeholder="Search models by name, provider, or keyword…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full px-4 py-2.5 pl-10 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
+            aria-label="Search models"
+          />
+          <svg
+            className="absolute left-3 top-3 h-4 w-4 text-zinc-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value)}
+          className="px-3 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm"
+          aria-label="Sort models"
+        >
+          <option value="name">Sort: Name</option>
+          <option value="publisher">Sort: Provider</option>
+          <option value="context">Sort: Context Window</option>
+        </select>
+      </div>
+
+      {/* Active filter pills + clear */}
+      {hasActiveFilters && (
+        <div className="flex flex-wrap gap-2 mb-4 items-center">
+          {Object.entries(activeFilters).map(([key, values]) =>
+            (values || []).map((v) => (
+              <button
+                key={`${key}-${v}`}
+                onClick={() => toggleFilter(key, v)}
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800/50 transition-colors"
+              >
+                {formatLabel(key, v)}
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            ))
+          )}
+          <button
+            onClick={clearFilters}
+            className="text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 underline"
+          >
+            Clear all
+          </button>
+        </div>
+      )}
+
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Faceted sidebar */}
+        <div className="lg:w-56 shrink-0 space-y-5">
+          {facetConfig.map((facet) => (
+            <div key={facet.key}>
+              <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
+                {facet.label}
+              </h4>
+              <div className="space-y-1">
+                {(facetCounts[facet.key] || []).slice(0, 12).map(({ value, count }) => {
+                  const isActive = (activeFilters[facet.key] || []).includes(value)
+                  return (
+                    <button
+                      key={value}
+                      onClick={() => toggleFilter(facet.key, value)}
+                      className={`w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors text-left ${
+                        isActive
+                          ? "bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 font-medium"
+                          : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                      }`}
+                      aria-pressed={isActive}
+                    >
+                      <span className="truncate">{formatLabel(facet.key, value)}</span>
+                      <span className="text-zinc-400 dark:text-zinc-500 ml-2 tabular-nums">
+                        {count}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Model cards grid */}
+        <div className="flex-1 min-w-0">
+          <div className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
+            {filteredModels.length} model{filteredModels.length !== 1 ? "s" : ""}
+            {hasActiveFilters ? " matching filters" : ""}
+          </div>
+
+          {filteredModels.length === 0 ? (
+            <div className="text-center py-12 text-zinc-500 dark:text-zinc-400">
+              <p className="text-sm">No models match your filters.</p>
+              <button
+                onClick={clearFilters}
+                className="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Clear all filters
+              </button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {filteredModels.map((m) => (
+                <div
+                  key={`${m.publisher}-${m.id}`}
+                  className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-4 hover:border-zinc-300 dark:hover:border-zinc-600 transition-colors cursor-pointer"
+                  onClick={() =>
+                    setExpandedModel(
+                      expandedModel === `${m.publisher}-${m.id}`
+                        ? null
+                        : `${m.publisher}-${m.id}`
+                    )
+                  }
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      setExpandedModel(
+                        expandedModel === `${m.publisher}-${m.id}`
+                          ? null
+                          : `${m.publisher}-${m.id}`
+                      )
+                    }
+                  }}
+                  aria-expanded={expandedModel === `${m.publisher}-${m.id}`}
+                >
+                  {/* Card header */}
+                  <div className="flex items-start justify-between gap-2 mb-2">
+                    <div className="min-w-0">
+                      <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">
+                        {m.displayName}
+                      </h3>
+                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                        {m.publisher} · v{m.latestVersion}
+                      </p>
+                    </div>
+                    {m.isPreview && (
+                      <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
+                        Preview
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Summary */}
+                  <p className="text-xs text-zinc-600 dark:text-zinc-400 line-clamp-2 mb-3">
+                    {m.summary || "No description available."}
+                  </p>
+
+                  {/* Spec row */}
+                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-zinc-500 dark:text-zinc-400 mb-2">
+                    {m.contextWindow && (
+                      <span title="Context window">
+                        📐 {formatNumber(m.contextWindow)} ctx
+                      </span>
+                    )}
+                    {m.maxOutputTokens && (
+                      <span title="Max output tokens">
+                        📝 {formatNumber(m.maxOutputTokens)} out
+                      </span>
+                    )}
+                    {m.versions && m.versions.length > 1 && (
+                      <span title="Available versions">
+                        📦 {m.versions.length} versions
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Capability tags */}
+                  <div className="flex flex-wrap gap-1">
+                    {m.tasks?.slice(0, 3).map((t) => (
+                      <span
+                        key={t}
+                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300"
+                      >
+                        {TASK_LABELS[t] || t}
+                      </span>
+                    ))}
+                    {m.capabilities?.slice(0, 3).map((c) => (
+                      <span
+                        key={c}
+                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
+                      >
+                        {CAP_LABELS[c] || c}
+                      </span>
+                    ))}
+                  </div>
+
+                  {/* Expanded details */}
+                  {expandedModel === `${m.publisher}-${m.id}` && (
+                    <div className="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800 space-y-2">
+                      {m.deploymentTypes?.length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Deployment:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {m.deploymentTypes
+                              .map((d) => DEPLOY_LABELS[d] || d)
+                              .join(", ")}
+                          </span>
+                        </div>
+                      )}
+                      {m.inputModalities?.length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Input:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {m.inputModalities.join(", ")}
+                          </span>
+                        </div>
+                      )}
+                      {m.outputModalities?.length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Output:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {m.outputModalities.join(", ")}
+                          </span>
+                        </div>
+                      )}
+                      {m.toolsSupported?.length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Tools:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {m.toolsSupported.slice(0, 8).join(", ")}
+                            {m.toolsSupported.length > 8 &&
+                              ` +${m.toolsSupported.length - 8} more`}
+                          </span>
+                        </div>
+                      )}
+                      {m.regions && Object.keys(m.regions).length > 0 && (
+                        <div className="text-xs">
+                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
+                            Regions:{" "}
+                          </span>
+                          <span className="text-zinc-700 dark:text-zinc-300">
+                            {Object.entries(m.regions)
+                              .map(
+                                ([sku, regions]) =>
+                                  `${sku} (${regions.length} regions)`
+                              )
+                              .join(", ")}
+                          </span>
+                        </div>
+                      )}
+                      {m.pricingLink && (
+                        <a
+                          href={m.pricingLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline mt-1"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          View pricing →
+                        </a>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/docs/static/data/models.json
+++ b/docs/static/data/models.json
@@ -1,0 +1,6140 @@
+{
+  "generatedAt": "2026-04-08T17:36:11Z",
+  "totalModels": 103,
+  "models": [
+    {
+      "id": "qwen3-32b",
+      "displayName": "qwen3-32b",
+      "publisher": "Alibaba",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Flux-1.1-Pro",
+      "displayName": "FLUX1.1 [pro]",
+      "publisher": "Black Forest Labs",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Generate images with amazing image quality, prompt adherence, and diversity at blazing fast speeds. FLUX1.1 [pro] delivers six times faster image generation and achieved the highest Elo score on Artificial Analysis benchmarks when launched, surpassing all",
+      "tasks": [
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Flux.1-Kontext-pro",
+      "displayName": "FLUX.1 Kontext [pro]",
+      "publisher": "Black Forest Labs",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Generate and edit images through both text and image prompts. FLUX.1 Kontext is a multimodal flow matching model that enables both text-to-image generation and in-context image editing. Modify images while maintaining character consistency and performing l",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "FLUX.2-flex",
+      "displayName": "FLUX.2-flex",
+      "publisher": "Black Forest Labs",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Professional text-to-image generation with adjustable inference steps and guidance scale for fine-tuned control. Features superior typography and text rendering, supports up to 4MP resolution, 32K prompt tokens, and up to 8 reference images. Ideal for deve",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 32768,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "FLUX.2-pro",
+      "displayName": "FLUX.2 [pro]",
+      "publisher": "Black Forest Labs",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Generate and edit images through both text and image prompts. FLUX.2-pro is a multimodal flow matching model that enables both text-to-image generation and in-context image editing. Modify images while maintaining character consistency and performing local",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "cohere-command-a",
+      "displayName": "Cohere Command A",
+      "publisher": "Cohere",
+      "latestVersion": "4",
+      "versions": [
+        "4"
+      ],
+      "summary": "Command A is a highly efficient generative model that excels at agentic and multilingual use cases.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "VM-withSurcharge",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "pt-br",
+        "ja",
+        "ko",
+        "zh-cn",
+        "ar"
+      ],
+      "keywords": [
+        "RAG",
+        "Multilingual"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Cohere-rerank-v4.0-fast",
+      "displayName": "Cohere Rerank v4.0 Fast",
+      "publisher": "Cohere",
+      "latestVersion": "2",
+      "versions": [
+        "2",
+        "1"
+      ],
+      "summary": "Rerank improves search systems by sorting documents based on their semantic similarity to a query",
+      "tasks": [
+        "text-classification"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "VM-withSurcharge",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text",
+        "image"
+      ],
+      "contextWindow": 4096,
+      "maxOutputTokens": 2048,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "pt-br",
+        "ja",
+        "zh-cn",
+        "ar",
+        "vi",
+        "hi",
+        "ru",
+        "id",
+        "nl"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/CohereRerank4Blog",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Cohere-rerank-v4.0-pro",
+      "displayName": "Cohere Rerank v4.0 Pro",
+      "publisher": "Cohere",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Rerank improves search systems by sorting documents based on their semantic similarity to a query",
+      "tasks": [
+        "text-classification"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text",
+        "image"
+      ],
+      "contextWindow": 4096,
+      "maxOutputTokens": 2048,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "pt-br",
+        "ja",
+        "zh-cn",
+        "ar",
+        "vi",
+        "hi",
+        "ru",
+        "id",
+        "nl"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/CohereRerank4Blog",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "embed-v-4-0",
+      "displayName": "Cohere Embed 4",
+      "publisher": "Cohere",
+      "latestVersion": "6",
+      "versions": [
+        "6"
+      ],
+      "summary": "Embed 4 transforms texts and images into numerical vectors",
+      "tasks": [
+        "embeddings",
+        "summarization"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "VM-withSurcharge",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "image",
+        "text"
+      ],
+      "outputModalities": [
+        "image",
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "it",
+        "de",
+        "pt-br",
+        "ja",
+        "ko",
+        "zh-cn",
+        "ar"
+      ],
+      "keywords": [
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-R1",
+      "displayName": "DeepSeek-R1",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-R1 excels at reasoning tasks using a step-by-step training process, such as language, scientific reasoning, and coding tasks.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "reasoning"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Coding",
+        "Agents"
+      ],
+      "license": "MIT",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-R1-0528",
+      "displayName": "DeepSeek-R1-0528",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "The DeepSeek R1 0528 model has improved reasoning capabilities, this version also offers a reduced hallucination rate, enhanced support for function calling, and better experience for vibe coding.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Coding",
+        "Agents"
+      ],
+      "license": "MIT",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-V3-0324",
+      "displayName": "DeepSeek-V3-0324",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-V3-0324 demonstrates notable improvements over its predecessor, DeepSeek-V3, in several key aspects, including enhanced reasoning, improved function calling, and superior code generation capabilities.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents"
+      ],
+      "license": "MIT",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-V3.1",
+      "displayName": "DeepSeek-V3.1",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-V3.1 is a hybrid model that enhances tool usage, thinking efficiency, and supports both thinking and non-thinking modes via chat template switching",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-V3.2",
+      "displayName": "DeepSeek-V3.2",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-V3.2, a model that harmonizes high computational efficiency with superior reasoning and agent performance",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "DeepSeek-V3.2-Speciale",
+      "displayName": "DeepSeek-V3.2-Speciale",
+      "publisher": "DeepSeek",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "DeepSeek-V3.2 Speciale, a model that harmonizes high computational efficiency with superior reasoning and agent performance",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/DeepSeekModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Llama-3.3-70B-Instruct",
+      "displayName": "Llama-3.3-70B-Instruct",
+      "publisher": "Meta",
+      "latestVersion": "9",
+      "versions": [
+        "9",
+        "8",
+        "7"
+      ],
+      "summary": "Llama 3.3 70B Instruct offers enhanced reasoning, math, and instruction following with performance comparable to Llama 3.1 405B.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maap-inference",
+        "maas-finetuning",
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "de",
+        "fr",
+        "it",
+        "pt",
+        "hi",
+        "es",
+        "th"
+      ],
+      "keywords": [
+        "Conversation"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/meta-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "December 2023",
+      "regions": {}
+    },
+    {
+      "id": "Llama-4-Maverick-17B-128E-Instruct-FP8",
+      "displayName": "Llama 4 Maverick 17B 128E Instruct FP8",
+      "publisher": "Meta",
+      "latestVersion": "3",
+      "versions": [
+        "3",
+        "2",
+        "1"
+      ],
+      "summary": "Llama 4 Maverick 17B 128E Instruct FP8 is great at precise image understanding and creative writing, offering high quality at a lower price compared to Llama 3.3 70B",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "assistants",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maap-inference",
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1000000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "ar",
+        "en",
+        "fr",
+        "de",
+        "hi",
+        "id",
+        "it",
+        "pt",
+        "es",
+        "tl",
+        "th",
+        "vi"
+      ],
+      "keywords": [
+        "Multimodal",
+        "Conversation",
+        "Multilingual"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/meta-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "August 2024",
+      "regions": {}
+    },
+    {
+      "id": "MAI-DS-R1",
+      "displayName": "MAI-DS-R1",
+      "publisher": "Microsoft",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "MAI-DS-R1 is a DeepSeek-R1 reasoning model that has been post-trained by the Microsoft AI team to fill in information gaps in the previous version of the model and improve its harm protections while maintaining R1 reasoning capabilities.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "browser_automation",
+        "code_interpreter",
+        "function",
+        "mcp"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "zh"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Coding",
+        "Agents"
+      ],
+      "license": "MIT",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "MAI-Image-2",
+      "displayName": "MAI-Image-2",
+      "publisher": "Microsoft",
+      "latestVersion": "2026-02-20",
+      "versions": [
+        "2026-02-20"
+      ],
+      "summary": "Built for creatives, delivering enhanced photorealism at scale.",
+      "tasks": [
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/MAIModelPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "model-router",
+      "displayName": "Model router",
+      "publisher": "Microsoft",
+      "latestVersion": "2025-11-18",
+      "versions": [
+        "2025-11-18",
+        "2025-08-07"
+      ],
+      "summary": "Model router is a deployable AI model that is trained to select the most suitable large language model (LLM) for a given prompt.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled",
+        "maap-inference"
+      ],
+      "azureOffers": [
+        "VM"
+      ],
+      "toolsSupported": [
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "fabric_dataagent",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1048576,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "November 2025",
+      "regions": {}
+    },
+    {
+      "id": "mistral-document-ai-2505",
+      "displayName": "Mistral Document AI (25.05)",
+      "publisher": "Mistral AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Document conversion to markdown with interleaved images and text",
+      "tasks": [
+        "image-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "pdf",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Vision",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "mistral-document-ai-2512",
+      "displayName": "Mistral Document AI (25.12)",
+      "publisher": "Mistral AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Document conversion to markdown with interleaved images and text",
+      "tasks": [
+        "image-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "pdf",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "de",
+        "fr",
+        "es",
+        "nl",
+        "it",
+        "pt",
+        "hu",
+        "pl",
+        "cs",
+        "da",
+        "ro",
+        "no",
+        "sv",
+        "id",
+        "th",
+        "vi",
+        "tl",
+        "ar",
+        "he",
+        "hi",
+        "bn",
+        "gu",
+        "kn",
+        "ta",
+        "te",
+        "ml",
+        "en",
+        "ru",
+        "uk",
+        "ko",
+        "ja",
+        "zh",
+        "tr",
+        "hy",
+        "ka"
+      ],
+      "keywords": [
+        "Vision",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/mistral-document-ai-2512",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Mistral-Large-3",
+      "displayName": "Mistral Large 3",
+      "publisher": "Mistral AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Mistral Large 3 is a state-of-the-art General-purpose Multimodal granular Mixture-of-Experts model with 39B active parameters, 673B total parameters featuring 128 experts per layer and Multi-Latent attention.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "fr",
+        "es",
+        "de",
+        "it",
+        "pt",
+        "nl",
+        "zh",
+        "ja",
+        "ko",
+        "ar"
+      ],
+      "keywords": [
+        "Multimodal",
+        "Vision",
+        "Multipurpose"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/MistralLarge3blog",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Kimi-K2-Thinking",
+      "displayName": "Kimi-K2-Thinking",
+      "publisher": "Moonshot AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Kimi K2 Thinking is the latest, most capable version of open-source thinking model",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 262144,
+      "maxOutputTokens": 262144,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual"
+      ],
+      "license": "other",
+      "pricingLink": "https://aka.ms/MoonshotAIPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "Kimi-K2.5",
+      "displayName": "Kimi-K2.5",
+      "publisher": "Moonshot AI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Kimi K2.5 is an open-source, native multimodal agentic model built through continual pretraining on approximately 15 trillion mixed visual and text tokens atop Kimi-K2-Base.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 262144,
+      "maxOutputTokens": 262144,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual"
+      ],
+      "license": "other",
+      "pricingLink": "https://aka.ms/MoonshotAIPricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "codex-mini",
+      "displayName": "codex-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-05-16",
+      "versions": [
+        "2025-05-16"
+      ],
+      "summary": "codex-mini is a fine-tuned variant of the o4-mini model, designed to deliver rapid, instruction-following performance for developers working in CLI workflows. Whether you're automating shell commands, editing scripts, or refactoring repositories, Codex-Min",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "dall-e-3",
+      "displayName": "dall-e-3",
+      "publisher": "OpenAI",
+      "latestVersion": "3.0",
+      "versions": [
+        "3.0"
+      ],
+      "summary": "",
+      "tasks": [
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "davinci-002",
+      "displayName": "davinci-002",
+      "publisher": "OpenAI",
+      "latestVersion": "3",
+      "versions": [
+        "3"
+      ],
+      "summary": "",
+      "tasks": [
+        "completions"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": 16384,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2021",
+      "regions": {}
+    },
+    {
+      "id": "gpt-35-turbo",
+      "displayName": "gpt-35-turbo",
+      "publisher": "OpenAI",
+      "latestVersion": "0125",
+      "versions": [
+        "0125"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agents",
+        "assistants",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-35-turbo-16k",
+      "displayName": "gpt-35-turbo-16k",
+      "publisher": "OpenAI",
+      "latestVersion": "0613",
+      "versions": [
+        "0613"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-35-turbo-instruct",
+      "displayName": "gpt-35-turbo-instruct",
+      "publisher": "OpenAI",
+      "latestVersion": "0914",
+      "versions": [
+        "0914"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4",
+      "displayName": "gpt-4",
+      "publisher": "OpenAI",
+      "latestVersion": "turbo-2024-04-09",
+      "versions": [
+        "turbo-2024-04-09"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "assistants",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "batch-paygo",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "code_interpreter",
+        "file_search"
+      ],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": 128000,
+      "maxOutputTokens": 4096,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "December 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4-32k",
+      "displayName": "gpt-4-32k",
+      "publisher": "OpenAI",
+      "latestVersion": "0613",
+      "versions": [
+        "0613"
+      ],
+      "summary": "",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2021",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4.1",
+      "displayName": "OpenAI GPT-4.1",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-14",
+      "versions": [
+        "2025-04-14"
+      ],
+      "summary": "gpt-4.1 outperforms gpt-4o across the board, with major gains in coding, instruction following, and long-context understanding",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1048576,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4.1-mini",
+      "displayName": "OpenAI GPT-4.1-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-14",
+      "versions": [
+        "2025-04-14"
+      ],
+      "summary": "gpt-4.1-mini outperform gpt-4o-mini across the board, with major gains in coding, instruction following, and long-context handling",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1048576,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4.1-nano",
+      "displayName": "OpenAI GPT-4.1-nano",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-14",
+      "versions": [
+        "2025-04-14"
+      ],
+      "summary": "gpt-4.1-nano provides gains in coding, instruction following, and long-context handling along with lower latency and cost",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 1048576,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4.5-preview",
+      "displayName": "GPT-4.5 Preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-02-27",
+      "versions": [
+        "2025-02-27"
+      ],
+      "summary": "the largest and strongest general purpose model in the gpt model family up to date, best suited for diverse text and image tasks.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o",
+      "displayName": "OpenAI GPT-4o",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-11-20",
+      "versions": [
+        "2024-11-20"
+      ],
+      "summary": "OpenAI's most advanced multimodal model in the gpt-4o family. Can handle both text and image inputs.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "assistants",
+        "fine-tuning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "batch-paygo",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-audio-preview",
+      "displayName": "OpenAI gpt-4o-audio-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini",
+      "displayName": "OpenAI GPT-4o mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-07-18",
+      "versions": [
+        "2024-07-18"
+      ],
+      "summary": "An affordable, efficient AI solution for diverse text and image tasks.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "assistants",
+        "fine-tuning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "batch-paygo",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "fabric_dataagent",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini-audio-preview",
+      "displayName": "OpenAI gpt-4o-mini-audio-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini-realtime-preview",
+      "displayName": "OpenAI gpt-4o-mini-realtime-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2023",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini-transcribe",
+      "displayName": "gpt-4o-mini-transcribe",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-15",
+      "versions": [
+        "2025-12-15",
+        "2025-03-20"
+      ],
+      "summary": "A highly efficient and cost effective speech-to-text solution that deliverables reliable and accurate transcripts.",
+      "tasks": [
+        "speech-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 16000,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "af",
+        "ar",
+        "hy",
+        "az",
+        "be",
+        "bs",
+        "bg",
+        "ca",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "gl",
+        "de",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "is",
+        "id",
+        "it",
+        "ja",
+        "kn",
+        "kk",
+        "ko",
+        "lv",
+        "lt",
+        "mk",
+        "ms",
+        "mr",
+        "mi",
+        "ne",
+        "no",
+        "fa",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sr",
+        "sk",
+        "sl",
+        "es",
+        "sw",
+        "sv",
+        "tl",
+        "ta",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "vi",
+        "cy"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-mini-tts",
+      "displayName": "gpt-4o-mini-tts",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-15",
+      "versions": [
+        "2025-12-15",
+        "2025-03-20"
+      ],
+      "summary": "An advanced text-to-speech solution designed to convert written text into natural-sounding speech.",
+      "tasks": [
+        "text-to-speech"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment",
+        "batch-enabled",
+        "maap-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "audio"
+      ],
+      "outputModalities": [
+        "text",
+        "audio"
+      ],
+      "contextWindow": 2000,
+      "maxOutputTokens": 2000,
+      "languages": [
+        "af",
+        "ar",
+        "hy",
+        "az",
+        "be",
+        "bs",
+        "bg",
+        "ca",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "gl",
+        "de",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "is",
+        "id",
+        "it",
+        "ja",
+        "kn",
+        "kk",
+        "ko",
+        "lv",
+        "lt",
+        "mk",
+        "ms",
+        "mr",
+        "mi",
+        "ne",
+        "no",
+        "fa",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sr",
+        "sk",
+        "sl",
+        "es",
+        "sw",
+        "sv",
+        "tl",
+        "ta",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "vi",
+        "cy"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-realtime-preview",
+      "displayName": "OpenAI gpt-4o-realtime-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-transcribe",
+      "displayName": "gpt-4o-transcribe",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-03-20",
+      "versions": [
+        "2025-03-20"
+      ],
+      "summary": "A cutting-edge speech-to-text solution that deliverables reliable and accurate transcripts.",
+      "tasks": [
+        "speech-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 16000,
+      "maxOutputTokens": 2000,
+      "languages": [
+        "af",
+        "ar",
+        "hy",
+        "az",
+        "be",
+        "bs",
+        "bg",
+        "ca",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "gl",
+        "de",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "is",
+        "id",
+        "it",
+        "ja",
+        "kn",
+        "kk",
+        "ko",
+        "lv",
+        "lt",
+        "mk",
+        "ms",
+        "mr",
+        "mi",
+        "ne",
+        "no",
+        "fa",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sr",
+        "sk",
+        "sl",
+        "es",
+        "sw",
+        "sv",
+        "tl",
+        "ta",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "vi",
+        "cy"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-4o-transcribe-diarize",
+      "displayName": "OpenAI gpt-4o-transcribe-diarize",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-15",
+      "versions": [
+        "2025-10-15"
+      ],
+      "summary": "A cutting-edge speech-to-text solution that deliverables reliable and accurate transcripts; now equipped with diarization support aka identifying different speakers through the transcription.",
+      "tasks": [
+        "speech-to-text"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "audio"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 16000,
+      "maxOutputTokens": 2000,
+      "languages": [
+        "af",
+        "ar",
+        "hy",
+        "az",
+        "be",
+        "bs",
+        "bg",
+        "ca",
+        "zh",
+        "hr",
+        "cs",
+        "da",
+        "nl",
+        "en",
+        "et",
+        "fi",
+        "fr",
+        "gl",
+        "de",
+        "el",
+        "he",
+        "hi",
+        "hu",
+        "is",
+        "id",
+        "it",
+        "ja",
+        "kn",
+        "kk",
+        "ko",
+        "lv",
+        "lt",
+        "mk",
+        "ms",
+        "mr",
+        "mi",
+        "ne",
+        "no",
+        "fa",
+        "pl",
+        "pt",
+        "ro",
+        "ru",
+        "sr",
+        "sk",
+        "sl",
+        "es",
+        "sw",
+        "sv",
+        "tl",
+        "ta",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "vi",
+        "cy"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "July 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5",
+      "displayName": "OpenAI gpt-5",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-07",
+      "versions": [
+        "2025-08-07"
+      ],
+      "summary": "gpt-5 is designed for logic-heavy and multi-step tasks.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "image_generation",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-chat",
+      "displayName": "OpenAI gpt-5-chat (preview)",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-03",
+      "versions": [
+        "2025-10-03",
+        "2025-08-07"
+      ],
+      "summary": "gpt-5-chat (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "code_interpreter",
+        "file_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-codex",
+      "displayName": "gpt-5-codex",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-09-15",
+      "versions": [
+        "2025-09-15"
+      ],
+      "summary": "gpt-5-codex is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "mcp"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-mini",
+      "displayName": "OpenAI gpt-5-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-07",
+      "versions": [
+        "2025-08-07"
+      ],
+      "summary": "gpt-5-mini is a lightweight version for cost-sensitive applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "code_interpreter",
+        "file_search",
+        "mcp",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "June 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-nano",
+      "displayName": "OpenAI gpt-5-nano",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-07",
+      "versions": [
+        "2025-08-07"
+      ],
+      "summary": "gpt-5-nano is optimized for speed, ideal for applications requiring low latency.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "code_interpreter",
+        "file_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5-pro",
+      "displayName": "OpenAI gpt-5-pro",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-06",
+      "versions": [
+        "2025-10-06"
+      ],
+      "summary": "gpt-5-pro uses more compute to think harder and provide consistently better answers.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 400000,
+      "maxOutputTokens": 2720000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1",
+      "displayName": "OpenAI gpt-5.1",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-11-13",
+      "versions": [
+        "2025-11-13"
+      ],
+      "summary": "gpt-5.1 is designed for logic-heavy and multi-step tasks.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "azure_ai_search",
+        "azure_function",
+        "bing_grounding",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1-chat",
+      "displayName": "OpenAI gpt-5.1-chat (preview)",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-11-13",
+      "versions": [
+        "2025-11-13"
+      ],
+      "summary": "gpt-5.1-chat (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1-codex",
+      "displayName": "gpt-5.1-codex",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-11-13",
+      "versions": [
+        "2025-11-13"
+      ],
+      "summary": "gpt-5.1-codex is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "mcp"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1-codex-max",
+      "displayName": "gpt-5.1-codex-max",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-04",
+      "versions": [
+        "2025-12-04"
+      ],
+      "summary": "gpt-5.1-codex-max is agentic coding model designed to streamline complex development workflows with advanced efficiency",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/codexmax-blog",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.1-codex-mini",
+      "displayName": "gpt-5.1-codex-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-11-13",
+      "versions": [
+        "2025-11-13"
+      ],
+      "summary": "gpt-5.1-codex-mini is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.2",
+      "displayName": "OpenAI gpt-5.2",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-11",
+      "versions": [
+        "2025-12-11"
+      ],
+      "summary": "GPT-5.2 is engineered for enterprise agent scenarios—delivering structured, auditable outputs, reliable tool use, and governed integrations.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "azure_ai_search",
+        "azure_function",
+        "bing_grounding",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.2-chat",
+      "displayName": "OpenAI gpt-5.2-chat (preview)",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-02-10",
+      "versions": [
+        "2026-02-10",
+        "2025-12-11"
+      ],
+      "summary": "gpt-5.2-chat (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.2-codex",
+      "displayName": "gpt-5.2-codex",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-01-14",
+      "versions": [
+        "2026-01-14"
+      ],
+      "summary": "gpt-5.2-codex is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "mcp"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 228000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/gpt5.2codex",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.3-chat",
+      "displayName": "OpenAI gpt-5.3-chat (preview)",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-03",
+      "versions": [
+        "2026-03-03"
+      ],
+      "summary": "gpt-5.3-chat (preview) is an advanced, natural, multimodal, and context-aware conversations for enterprise applications.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/gpt5.3chat",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.3-codex",
+      "displayName": "gpt-5.3-codex",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-02-24",
+      "versions": [
+        "2026-02-24"
+      ],
+      "summary": "gpt-5.3-codex is designed for steerability, front end development, and interactivity.",
+      "tasks": [
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 272000,
+      "maxOutputTokens": 228000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AOAI/NewReleases/Feb24",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2024",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.4",
+      "displayName": "OpenAI gpt-5.4",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-05",
+      "versions": [
+        "2026-03-05"
+      ],
+      "summary": "GPT‑5.4 is OpenAI’s most capable frontier model, built to deliver faster, more reliable results for complex professional work.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "displayName": "OpenAI gpt-5.4-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-17",
+      "versions": [
+        "2026-03-17"
+      ],
+      "summary": "GPT‑5.4‑mini is a compact, cost‑efficient model designed for reliable performance across high‑volume, everyday AI workloads.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 400000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.4-nano",
+      "displayName": "OpenAI gpt-5.4-nano",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-17",
+      "versions": [
+        "2026-03-17"
+      ],
+      "summary": "GPT‑5.4‑nano is a lightweight, ultra‑efficient model designed for low‑latency, cost‑effective tasks at massive scale.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 400000,
+      "maxOutputTokens": 128000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-5.4-pro",
+      "displayName": "OpenAI gpt-5.4",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-03-05",
+      "versions": [
+        "2026-03-05"
+      ],
+      "summary": "GPT‑5.4-Pro is OpenAI’s most capable frontier model, built to deliver faster, more reliable results for complex professional work.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/AzureOAIpricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-audio",
+      "displayName": "OpenAI gpt-audio",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-28",
+      "versions": [
+        "2025-08-28"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-audio-1.5",
+      "displayName": "OpenAI gpt-audio",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-02-23",
+      "versions": [
+        "2026-02-23"
+      ],
+      "summary": "A new S2S (speech to speech) model with improved instruction following.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-audio-mini",
+      "displayName": "OpenAI gpt-audio-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-06",
+      "versions": [
+        "2025-10-06"
+      ],
+      "summary": "Best suited for rich, asynchronous audio input/output interactions, such as creating spoken summaries from text.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-image-1",
+      "displayName": "Gpt-image-1",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-15",
+      "versions": [
+        "2025-04-15"
+      ],
+      "summary": "An efficient AI solution for diverse text and image tasks, including text to image, image to image, inpainting, and prompt transformation.",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text",
+        "image"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-image-1-mini",
+      "displayName": "GPT-image-1-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-06",
+      "versions": [
+        "2025-10-06"
+      ],
+      "summary": "An efficient AI solution for diverse text and image tasks, including high quality, cheap text to image generation",
+      "tasks": [
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-image-1.5",
+      "displayName": "GPT-image-1.5",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-16",
+      "versions": [
+        "2025-12-16"
+      ],
+      "summary": "An efficient AI solution for diverse text and image tasks, including high quality, and editing scenarios",
+      "tasks": [
+        "image-to-image",
+        "text-to-image"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled",
+        "maap-inference"
+      ],
+      "azureOffers": [
+        "VM"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "image"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-oss-120B",
+      "displayName": "gpt-oss-120b",
+      "publisher": "OpenAI",
+      "latestVersion": "4",
+      "versions": [
+        "4",
+        "3",
+        "2",
+        "1"
+      ],
+      "summary": "Push the open model frontier with GPT-OSS models, released under the permissive Apache 2.0 license, allowing anyone to use, modify, and deploy them freely.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "maap-inference",
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "function",
+        "mcp"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 131072,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "gpt-realtime",
+      "displayName": "OpenAI gpt-realtime",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-08-28",
+      "versions": [
+        "2025-08-28"
+      ],
+      "summary": "A new S2S (speech to speech) model with improved instruction following.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-realtime-1.5",
+      "displayName": "OpenAI gpt-realtime",
+      "publisher": "OpenAI",
+      "latestVersion": "2026-02-23",
+      "versions": [
+        "2026-02-23"
+      ],
+      "summary": "A new S2S (speech to speech) model with improved instruction following.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio",
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "audio",
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "August 2025",
+      "regions": {}
+    },
+    {
+      "id": "gpt-realtime-mini",
+      "displayName": "OpenAI gpt-realtime-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-12-15",
+      "versions": [
+        "2025-12-15",
+        "2025-10-06"
+      ],
+      "summary": "gpt-realtime-mini is a smaller version of gpt-realtime S2S (speech to speech) model built on chive architecture. This model excels at instruction following and is optimized for cost efficiency.",
+      "tasks": [
+        "audio-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "audio"
+      ],
+      "outputModalities": [
+        "audio"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 16384,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "October 2025",
+      "regions": {}
+    },
+    {
+      "id": "o1",
+      "displayName": "OpenAI o1",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-12-17",
+      "versions": [
+        "2024-12-17"
+      ],
+      "summary": "Focused on advanced reasoning and solving complex problems, including math and science tasks. Ideal for applications that require deep contextual understanding and agentic workflows.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "PTU",
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "browser_automation",
+        "file_search",
+        "function",
+        "mcp",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "o1-mini",
+      "displayName": "OpenAI o1-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2024-09-12",
+      "versions": [
+        "2024-09-12"
+      ],
+      "summary": "Smaller, faster, and 80% cheaper than o1-preview, performs well at code generation and small context operations.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 65536,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "o1-preview",
+      "displayName": "OpenAI o1-preview",
+      "publisher": "OpenAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Focused on advanced reasoning and solving complex problems, including math and science tasks. Ideal for applications that require deep contextual understanding and agentic workflows.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "reasoning",
+        "streaming"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 32768,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "o3",
+      "displayName": "OpenAI o3",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-16",
+      "versions": [
+        "2025-04-16"
+      ],
+      "summary": "o3 includes significant improvements on quality and safety while supporting the existing features of o1 and delivering comparable or better performance.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "azure_ai_search",
+        "bing_custom_search",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "o3-deep-research",
+      "displayName": "o3-deep-research",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-06-26",
+      "versions": [
+        "2025-06-26"
+      ],
+      "summary": "The o3 series of models are trained with reinforcement learning to think before they answer and perform complex reasoning. The o1-pro model uses more compute to think harder and provide consistently better answers.",
+      "tasks": [
+        "data-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "mcp",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Agents"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "o3-mini",
+      "displayName": "OpenAI o3-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-01-31",
+      "versions": [
+        "2025-01-31"
+      ],
+      "summary": "o3-mini includes the o1 features with significant cost-efficiencies for scenarios requiring high performance.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "reasoning",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "batch-paygo",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "fabric_dataagent"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2023",
+      "regions": {}
+    },
+    {
+      "id": "o3-pro",
+      "displayName": "o3-pro",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-06-10",
+      "versions": [
+        "2025-06-10"
+      ],
+      "summary": "The o3 series of models are trained with reinforcement learning to think before they answer and perform complex reasoning. The o1-pro model uses more compute to think harder and provide consistently better answers.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en",
+        "it",
+        "af",
+        "es",
+        "de",
+        "fr",
+        "id",
+        "ru",
+        "pl",
+        "uk",
+        "el",
+        "lv",
+        "zh",
+        "ar",
+        "tr",
+        "ja",
+        "sw",
+        "cy",
+        "ko",
+        "is",
+        "bn",
+        "ur",
+        "ne",
+        "th",
+        "pa",
+        "mr",
+        "te"
+      ],
+      "keywords": [
+        "Reasoning",
+        "Multilingual",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "o4-mini",
+      "displayName": "OpenAI o4-mini",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-04-16",
+      "versions": [
+        "2025-04-16"
+      ],
+      "summary": "o4-mini includes significant improvements on quality and safety while supporting the existing features of o3-mini and delivering comparable or better performance.",
+      "tasks": [
+        "chat-completion",
+        "responses"
+      ],
+      "capabilities": [
+        "agents",
+        "agentsV2",
+        "fine-tuning",
+        "reasoning",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "a2a_preview",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 200000,
+      "maxOutputTokens": 100000,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multipurpose",
+        "Multilingual",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "May 2024",
+      "regions": {}
+    },
+    {
+      "id": "sora",
+      "displayName": "sora",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-05-02",
+      "versions": [
+        "2025-05-02"
+      ],
+      "summary": "An efficient AI solution to generate videos",
+      "tasks": [
+        "video-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "video"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "sora-2",
+      "displayName": "OpenAI Sora-2",
+      "publisher": "OpenAI",
+      "latestVersion": "2025-10-06",
+      "versions": [
+        "2025-10-06"
+      ],
+      "summary": "Sora 2 in Azure AI Foundry isn't just another video generation tool; it's a creative powerhouse, seamlessly integrated into a platform built for innovation, trust, and scale.",
+      "tasks": [
+        "video-generation"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "batch-enabled"
+      ],
+      "azureOffers": [],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text",
+        "image",
+        "video"
+      ],
+      "outputModalities": [
+        "video",
+        "audio"
+      ],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Vision"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/oai/pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "text-embedding-3-large",
+      "displayName": "OpenAI Text Embedding 3 (large)",
+      "publisher": "OpenAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Text-embedding-3 series models are the latest and most capable embedding model from OpenAI.",
+      "tasks": [
+        "embeddings"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "embeddings"
+      ],
+      "contextWindow": 8191,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "RAG"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2021",
+      "regions": {}
+    },
+    {
+      "id": "text-embedding-3-small",
+      "displayName": "OpenAI Text Embedding 3 (small)",
+      "publisher": "OpenAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Text-embedding-3 series models are the latest and most capable embedding model from OpenAI.",
+      "tasks": [
+        "embeddings"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "embeddings"
+      ],
+      "contextWindow": 8191,
+      "maxOutputTokens": null,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "RAG"
+      ],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "September 2021",
+      "regions": {}
+    },
+    {
+      "id": "text-embedding-ada-002",
+      "displayName": "text-embedding-ada-002",
+      "publisher": "OpenAI",
+      "latestVersion": "2",
+      "versions": [
+        "2"
+      ],
+      "summary": "",
+      "tasks": [
+        "embeddings"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "custom",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "tts",
+      "displayName": "tts",
+      "publisher": "OpenAI",
+      "latestVersion": "001",
+      "versions": [
+        "001"
+      ],
+      "summary": "",
+      "tasks": [
+        "text-to-speech"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "tts-hd",
+      "displayName": "tts-hd",
+      "publisher": "OpenAI",
+      "latestVersion": "001",
+      "versions": [
+        "001"
+      ],
+      "summary": "",
+      "tasks": [
+        "text-to-speech"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "whisper",
+      "displayName": "whisper",
+      "publisher": "OpenAI",
+      "latestVersion": "001",
+      "versions": [
+        "001"
+      ],
+      "summary": "",
+      "tasks": [
+        "automatic-speech-recognition"
+      ],
+      "capabilities": [],
+      "deploymentTypes": [
+        "aoai-deployment"
+      ],
+      "azureOffers": [
+        "VM",
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [],
+      "outputModalities": [],
+      "contextWindow": null,
+      "maxOutputTokens": null,
+      "languages": [],
+      "keywords": [],
+      "license": "",
+      "pricingLink": "",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "grok-3",
+      "displayName": "Grok 3",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 3 is xAI's debut model, pretrained by Colossus at supermassive scale to excel in specialized domains like finance, healthcare, and the law.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "fabric_dataagent",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "es",
+        "fr",
+        "af",
+        "ar",
+        "bn",
+        "cy",
+        "de",
+        "el",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ko",
+        "lv",
+        "mr",
+        "ne",
+        "pa",
+        "pl",
+        "ru",
+        "sw",
+        "te",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "zh"
+      ],
+      "keywords": [
+        "Understanding",
+        "Instruction",
+        "Summarization"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "grok-3-mini",
+      "displayName": "Grok 3 Mini",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 3 Mini is a lightweight model that thinks before responding. Trained on mathematic and scientific problems, it is great for logic-based tasks.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 131072,
+      "maxOutputTokens": 4096,
+      "languages": [
+        "en",
+        "es",
+        "fr",
+        "af",
+        "ar",
+        "bn",
+        "cy",
+        "de",
+        "el",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ko",
+        "lv",
+        "mr",
+        "ne",
+        "pa",
+        "pl",
+        "ru",
+        "sw",
+        "te",
+        "th",
+        "tr",
+        "uk",
+        "ur",
+        "zh"
+      ],
+      "keywords": [
+        "Agents",
+        "Reasoning",
+        "Coding"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    },
+    {
+      "id": "grok-4",
+      "displayName": "Grok 4",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4 is the latest reasoning model from xAI with advanced reasoning and tool-use capabilities, enabling it to achieve new state-of-the-art performance across challenging academic and industry benchmarks.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 256000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "generally-available",
+      "isPreview": false,
+      "trainingDataDate": "December 2024",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-1-fast-non-reasoning",
+      "displayName": "Grok 4.1 Fast Non Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4.1 Fast Non‑Reasoning is designed for low‑latency, near‑instant responses, emphasizing speed, high‑quality outputs, and smooth tool‑calling in agentic workflows, making it well‑suited for high‑throughput, real‑time scenarios where immediate responses",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Low latency",
+        "Agents",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-1-fast-reasoning",
+      "displayName": "Grok 4.1 Fast Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4.1 Fast Reasoning is a frontier multimodal model built for high‑performance, agentic execution—combining strong reasoning, advanced tool calling, and agentic search to handle complex tasks with speed and precision. It delivers natural, fluid dialogue",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 128000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Low latency",
+        "Agents",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-20-non-reasoning",
+      "displayName": "Grok 4.2 Non-Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4.2 is xAI’s latest large language model, built for strong reasoning, multimodal understanding, and enterprise use. It improves instruction following, honesty, and calibration over earlier Grok versions, while supporting both single‑agent and multi‑ag",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 262144,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Low latency",
+        "Agents",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-20-reasoning",
+      "displayName": "Grok 4.2 Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4.2 is xAI’s latest large language model, built for strong reasoning, multimodal understanding, and enterprise use. It improves instruction following, honesty, and calibration over earlier Grok versions, while supporting both single‑agent and multi‑ag",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 262144,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Low latency",
+        "Agents",
+        "Multimodal"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-fast-non-reasoning",
+      "displayName": "Grok 4 Fast Non Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4 Fast is an efficiency-focused large language model developed by xAI, pre-trained on general-purpose data and post-trained on task demonstrations and tool use, with built-in safety features including refusal behaviors, a fixed system prompt enforcing",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 2000000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-4-fast-reasoning",
+      "displayName": "Grok 4 Fast Reasoning",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok 4 Fast is an efficiency-focused large language model developed by xAI, pre-trained on general-purpose data and post-trained on task demonstrations and tool use, with built-in safety features including refusal behaviors, a fixed system prompt enforcing",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "agentsV2",
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [
+        "azure_ai_search",
+        "bing_custom_search",
+        "bing_grounding",
+        "browser_automation",
+        "code_interpreter",
+        "fabric_dataagent",
+        "file_search",
+        "function",
+        "mcp",
+        "openapi",
+        "sharepoint_grounding",
+        "web_search"
+      ],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 2000000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "September 2025",
+      "regions": {}
+    },
+    {
+      "id": "grok-code-fast-1",
+      "displayName": "Grok Code Fast 1",
+      "publisher": "xAI",
+      "latestVersion": "1",
+      "versions": [
+        "1"
+      ],
+      "summary": "Grok Code Fast 1 is a fast, economical AI model for agentic coding, built from scratch with a new architecture, trained on programming-rich data, and fine-tuned for real-world coding tasks like bug fixes and project setup.",
+      "tasks": [
+        "chat-completion"
+      ],
+      "capabilities": [
+        "streaming",
+        "tool-calling"
+      ],
+      "deploymentTypes": [
+        "maas-inference"
+      ],
+      "azureOffers": [
+        "standard-paygo"
+      ],
+      "toolsSupported": [],
+      "inputModalities": [
+        "text"
+      ],
+      "outputModalities": [
+        "text"
+      ],
+      "contextWindow": 256000,
+      "maxOutputTokens": 8192,
+      "languages": [
+        "en"
+      ],
+      "keywords": [
+        "Coding",
+        "Agents",
+        "Low latency"
+      ],
+      "license": "custom",
+      "pricingLink": "https://aka.ms/xai-pricing",
+      "isDirectFromAzure": true,
+      "lifecycleStatus": "preview",
+      "isPreview": true,
+      "trainingDataDate": "",
+      "regions": {}
+    }
+  ]
+}


### PR DESCRIPTION
Copies the Model Explorer (from #196) into `docs/` which powers the live Mintlify site at hobbyist-e43fa225.mintlify.app.

- `docs/foundry-models/model-explorer.mdx` — MDX page
- `docs/snippets/model-catalog.jsx` — React component (search, filters, cards)
- `docs/static/data/models.json` — 136KB catalog data (103 models)
- `docs/docs.json` — nav updated (Model Explorer in Explore Foundry Models group)

Page will be at: `/foundry-models/model-explorer`