### PR TITLE
improve: Model Explorer UX overhaul

### DIFF
--- a/docs-vnext/models/catalog/model-explorer.mdx
+++ b/docs-vnext/models/catalog/model-explorer.mdx
@@ -5,14 +5,4 @@ description: "Search and filter all available Azure AI models by provider, capab
 
 import { ModelCatalog } from "/snippets/model-catalog.jsx"
 
-# Model Explorer
-
-Browse all models available directly from Azure in Microsoft Foundry. Use the search bar and faceted filters to find models by provider, capability, deployment type, and task.
-
-<Tip>
-This catalog is auto-generated from the Azure AI model registry and refreshed daily.
-For detailed model documentation, see [Models sold directly by Azure](/models/catalog/models-sold-directly-by-azure).
-For deployment guidance, see [Deployment types](/models/catalog/deployment-types).
-</Tip>
-
 <ModelCatalog />

--- a/docs-vnext/snippets/model-catalog.jsx
+++ b/docs-vnext/snippets/model-catalog.jsx
@@ -5,7 +5,10 @@ export const ModelCatalog = () => {
   const [searchQuery, setSearchQuery] = useState("")
   const [activeFilters, setActiveFilters] = useState({})
   const [sortBy, setSortBy] = useState("name")
+  const [groupBy, setGroupBy] = useState("none")
   const [expandedModel, setExpandedModel] = useState(null)
+  const [copiedId, setCopiedId] = useState(null)
+  const [openDropdown, setOpenDropdown] = useState(null)
 
   useEffect(() => {
     fetch("/static/data/models.json")
@@ -23,36 +26,58 @@ export const ModelCatalog = () => {
       })
   }, [])
 
-  const facetConfig = useMemo(
-    () => [
-      { key: "publisher", label: "Provider" },
-      { key: "tasks", label: "Task" },
-      { key: "capabilities", label: "Capability" },
-      { key: "deploymentTypes", label: "Deployment" },
-    ],
-    []
-  )
+  const DEPLOY_LABELS = {
+    "aoai-deployment": "Azure OpenAI",
+    "batch-enabled": "Batch",
+    "maas-inference": "Serverless API",
+    "maap-inference": "Managed Compute",
+  }
+  const TASK_LABELS = {
+    "chat-completion": "Chat",
+    responses: "Responses",
+    embeddings: "Embeddings",
+    "text-to-image": "Image Gen",
+    "image-to-image": "Image Edit",
+    "audio-generation": "Audio Gen",
+    "speech-to-text": "Speech-to-Text",
+    "text-to-speech": "Text-to-Speech",
+    "video-generation": "Video Gen",
+    "automatic-speech-recognition": "ASR",
+  }
+  const CAP_LABELS = {
+    agentsV2: "Agents",
+    agents: "Agents (v1)",
+    reasoning: "Reasoning",
+    streaming: "Streaming",
+    "tool-calling": "Tool Calling",
+    "fine-tuning": "Fine-tuning",
+    assistants: "Assistants",
+  }
+  const MODALITY_ICONS = { text: "Aa", image: "◩", audio: "♪", video: "▶" }
 
-  const facetCounts = useMemo(() => {
-    const counts = {}
-    for (const f of facetConfig) {
-      const map = {}
-      for (const m of models) {
-        const vals = Array.isArray(m[f.key]) ? m[f.key] : [m[f.key]]
-        for (const v of vals) {
-          if (v) map[v] = (map[v] || 0) + 1
-        }
-      }
-      counts[f.key] = Object.entries(map)
-        .sort((a, b) => b[1] - a[1])
-        .map(([value, count]) => ({ value, count }))
-    }
-    return counts
-  }, [models, facetConfig])
+  const facetConfig = [
+    { key: "publisher", label: "Provider" },
+    { key: "tasks", label: "Task" },
+    { key: "capabilities", label: "Capability" },
+    { key: "deploymentTypes", label: "Deployment" },
+  ]
+
+  const formatLabel = (key, value) => {
+    if (key === "deploymentTypes") return DEPLOY_LABELS[value] || value
+    if (key === "tasks") return TASK_LABELS[value] || value
+    if (key === "capabilities") return CAP_LABELS[value] || value
+    return value
+  }
+
+  const formatNumber = (n) => {
+    if (!n) return null
+    if (n >= 1000000) return `${(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)}M`
+    if (n >= 1000) return `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}K`
+    return String(n)
+  }
 
   const filteredModels = useMemo(() => {
     let result = models
-
     if (searchQuery) {
       const q = searchQuery.toLowerCase()
       result = result.filter(
@@ -64,31 +89,76 @@ export const ModelCatalog = () => {
           m.keywords?.some((k) => k.toLowerCase().includes(q))
       )
     }
-
     for (const [key, values] of Object.entries(activeFilters)) {
       if (values && values.length > 0) {
         result = result.filter((m) => {
           const mVal = m[key]
-          if (Array.isArray(mVal)) {
-            return values.some((v) => mVal.includes(v))
-          }
+          if (Array.isArray(mVal)) return values.some((v) => mVal.includes(v))
           return values.includes(mVal)
         })
       }
     }
-
     result = [...result].sort((a, b) => {
-      if (sortBy === "name")
-        return (a.displayName || "").localeCompare(b.displayName || "")
-      if (sortBy === "context")
-        return (b.contextWindow || 0) - (a.contextWindow || 0)
-      if (sortBy === "publisher")
-        return (a.publisher || "").localeCompare(b.publisher || "")
+      if (sortBy === "name") return (a.displayName || "").localeCompare(b.displayName || "")
+      if (sortBy === "context") return (b.contextWindow || 0) - (a.contextWindow || 0)
+      if (sortBy === "publisher") return (a.publisher || "").localeCompare(b.publisher || "")
       return 0
     })
-
     return result
   }, [models, searchQuery, activeFilters, sortBy])
+
+  // Facet counts computed from filtered results (excluding the facet's own filter)
+  const facetCounts = useMemo(() => {
+    const counts = {}
+    for (const f of facetConfig) {
+      const otherFilters = { ...activeFilters }
+      delete otherFilters[f.key]
+      let subset = models
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase()
+        subset = subset.filter(
+          (m) =>
+            m.displayName?.toLowerCase().includes(q) ||
+            m.publisher?.toLowerCase().includes(q) ||
+            m.summary?.toLowerCase().includes(q) ||
+            m.id?.toLowerCase().includes(q)
+        )
+      }
+      for (const [key, values] of Object.entries(otherFilters)) {
+        if (values && values.length > 0) {
+          subset = subset.filter((m) => {
+            const mVal = m[key]
+            if (Array.isArray(mVal)) return values.some((v) => mVal.includes(v))
+            return values.includes(mVal)
+          })
+        }
+      }
+      const map = {}
+      for (const m of subset) {
+        const vals = Array.isArray(m[f.key]) ? m[f.key] : [m[f.key]]
+        for (const v of vals) {
+          if (v) map[v] = (map[v] || 0) + 1
+        }
+      }
+      counts[f.key] = Object.entries(map)
+        .sort((a, b) => b[1] - a[1])
+        .map(([value, count]) => ({ value, count }))
+    }
+    return counts
+  }, [models, searchQuery, activeFilters])
+
+  const groupedModels = useMemo(() => {
+    if (groupBy === "none") return [{ label: null, models: filteredModels }]
+    const groups = {}
+    for (const m of filteredModels) {
+      const key = m.publisher || "Other"
+      if (!groups[key]) groups[key] = []
+      groups[key].push(m)
+    }
+    return Object.entries(groups)
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([label, models]) => ({ label, models }))
+  }, [filteredModels, groupBy])
 
   const toggleFilter = (facetKey, value) => {
     setActiveFilters((prev) => {
@@ -105,59 +175,31 @@ export const ModelCatalog = () => {
     setSearchQuery("")
   }
 
+  const copyModelId = (e, id) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(id).then(() => {
+      setCopiedId(id)
+      setTimeout(() => setCopiedId(null), 1500)
+    })
+  }
+
   const hasActiveFilters =
-    searchQuery ||
-    Object.values(activeFilters).some((v) => v && v.length > 0)
+    searchQuery || Object.values(activeFilters).some((v) => v && v.length > 0)
 
-  const DEPLOY_LABELS = {
-    "aoai-deployment": "Azure OpenAI",
-    "batch-enabled": "Batch",
-    "maas-inference": "Serverless API",
-    "maap-inference": "Managed Compute",
-  }
-
-  const TASK_LABELS = {
-    "chat-completion": "Chat",
-    responses: "Responses",
-    embeddings: "Embeddings",
-    "text-to-image": "Image Gen",
-    "image-to-image": "Image Edit",
-    "audio-generation": "Audio Gen",
-    "speech-to-text": "Speech-to-Text",
-    "text-to-speech": "Text-to-Speech",
-    "video-generation": "Video Gen",
-    "automatic-speech-recognition": "ASR",
-  }
-
-  const CAP_LABELS = {
-    agentsV2: "Agents",
-    agents: "Agents (v1)",
-    reasoning: "Reasoning",
-    streaming: "Streaming",
-    "tool-calling": "Tool Calling",
-    "fine-tuning": "Fine-tuning",
-    assistants: "Assistants",
-  }
-
-  const formatLabel = (key, value) => {
-    if (key === "deploymentTypes") return DEPLOY_LABELS[value] || value
-    if (key === "tasks") return TASK_LABELS[value] || value
-    if (key === "capabilities") return CAP_LABELS[value] || value
-    return value
-  }
-
-  const formatNumber = (n) => {
-    if (!n) return "—"
-    if (n >= 1000000) return `${(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)}M`
-    if (n >= 1000) return `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}K`
-    return String(n)
-  }
+  const modelKey = (m) => `${m.publisher}-${m.id}`
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-16">
-        <div className="text-zinc-500 dark:text-zinc-400 text-sm">
-          Loading model catalog…
+      <div className="not-prose">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 p-5 animate-pulse">
+              <div className="h-4 bg-zinc-200 dark:bg-zinc-700 rounded w-3/4 mb-3" />
+              <div className="h-3 bg-zinc-200 dark:bg-zinc-700 rounded w-1/2 mb-4" />
+              <div className="h-3 bg-zinc-200 dark:bg-zinc-700 rounded w-full mb-2" />
+              <div className="h-3 bg-zinc-200 dark:bg-zinc-700 rounded w-5/6" />
+            </div>
+          ))}
         </div>
       </div>
     )
@@ -165,299 +207,333 @@ export const ModelCatalog = () => {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-4">
-        <p className="text-red-700 dark:text-red-400 text-sm">
-          Failed to load model catalog: {error}
-        </p>
+      <div className="not-prose rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-5">
+        <p className="text-red-700 dark:text-red-400 text-sm">Failed to load model catalog: {error}</p>
       </div>
     )
   }
 
   return (
     <div className="not-prose">
-      {/* Search + Sort bar */}
+      {/* Search + Controls bar */}
       <div className="flex flex-col sm:flex-row gap-3 mb-4">
         <div className="relative flex-1">
           <input
             type="text"
-            placeholder="Search models by name, provider, or keyword…"
+            placeholder="Search models…"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full px-4 py-2.5 pl-10 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
+            className="w-full px-4 py-2 pl-9 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             aria-label="Search models"
           />
-          <svg
-            className="absolute left-3 top-3 h-4 w-4 text-zinc-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
+          <svg className="absolute left-3 top-2.5 h-4 w-4 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </div>
-        <select
-          value={sortBy}
-          onChange={(e) => setSortBy(e.target.value)}
-          className="px-3 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm"
-          aria-label="Sort models"
-        >
-          <option value="name">Sort: Name</option>
-          <option value="publisher">Sort: Provider</option>
-          <option value="context">Sort: Context Window</option>
-        </select>
+        <div className="flex gap-2">
+          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-xs"
+            aria-label="Sort models">
+            <option value="name">Sort: Name</option>
+            <option value="publisher">Sort: Provider</option>
+            <option value="context">Sort: Context Window</option>
+          </select>
+          <select value={groupBy} onChange={(e) => setGroupBy(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-xs"
+            aria-label="Group models">
+            <option value="none">Group: None</option>
+            <option value="publisher">Group: Provider</option>
+          </select>
+        </div>
       </div>
 
-      {/* Active filter pills + clear */}
+      {/* Horizontal filter bar */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        {facetConfig.map((facet) => {
+          const isOpen = openDropdown === facet.key
+          const activeVals = activeFilters[facet.key] || []
+          const items = facetCounts[facet.key] || []
+          return (
+            <div key={facet.key} className="relative">
+              <button
+                onClick={() => setOpenDropdown(isOpen ? null : facet.key)}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                  activeVals.length > 0
+                    ? "bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300"
+                    : "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                }`}
+              >
+                {facet.label}
+                {activeVals.length > 0 && (
+                  <span className="bg-blue-500 text-white text-[10px] rounded-full px-1.5 py-0.5 leading-none">{activeVals.length}</span>
+                )}
+                <svg className={`h-3 w-3 transition-transform ${isOpen ? "rotate-180" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {isOpen && (
+                <>
+                  <div className="fixed inset-0 z-10" onClick={() => setOpenDropdown(null)} />
+                  <div className="absolute top-full left-0 mt-1 z-20 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg p-2 min-w-[200px] max-h-[300px] overflow-y-auto">
+                    {items.map(({ value, count }) => {
+                      const isActive = activeVals.includes(value)
+                      return (
+                        <button key={value} onClick={() => toggleFilter(facet.key, value)}
+                          className={`w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors text-left ${
+                            isActive
+                              ? "bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium"
+                              : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                          }`}>
+                          <span className="truncate">{formatLabel(facet.key, value)}</span>
+                          <span className="text-zinc-400 dark:text-zinc-500 ml-3 tabular-nums">{count}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </>
+              )}
+            </div>
+          )
+        })}
+        {hasActiveFilters && (
+          <button onClick={clearFilters}
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors">
+            <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Active filter pills */}
       {hasActiveFilters && (
-        <div className="flex flex-wrap gap-2 mb-4 items-center">
+        <div className="flex flex-wrap gap-1.5 mb-4">
           {Object.entries(activeFilters).map(([key, values]) =>
             (values || []).map((v) => (
-              <button
-                key={`${key}-${v}`}
-                onClick={() => toggleFilter(key, v)}
-                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800/50 transition-colors"
-              >
+              <button key={`${key}-${v}`} onClick={() => toggleFilter(key, v)}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800/50 transition-colors">
                 {formatLabel(key, v)}
-                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
             ))
           )}
-          <button
-            onClick={clearFilters}
-            className="text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 underline"
-          >
-            Clear all
-          </button>
         </div>
       )}
 
-      <div className="flex flex-col lg:flex-row gap-6">
-        {/* Faceted sidebar */}
-        <div className="lg:w-56 shrink-0 space-y-5">
-          {facetConfig.map((facet) => (
-            <div key={facet.key}>
-              <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-                {facet.label}
-              </h4>
-              <div className="space-y-1">
-                {(facetCounts[facet.key] || []).slice(0, 12).map(({ value, count }) => {
-                  const isActive = (activeFilters[facet.key] || []).includes(value)
-                  return (
-                    <button
-                      key={value}
-                      onClick={() => toggleFilter(facet.key, value)}
-                      className={`w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors text-left ${
-                        isActive
-                          ? "bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 font-medium"
-                          : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800"
-                      }`}
-                      aria-pressed={isActive}
-                    >
-                      <span className="truncate">{formatLabel(facet.key, value)}</span>
-                      <span className="text-zinc-400 dark:text-zinc-500 ml-2 tabular-nums">
-                        {count}
-                      </span>
-                    </button>
-                  )
-                })}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* Model cards grid */}
-        <div className="flex-1 min-w-0">
-          <div className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
-            {filteredModels.length} model{filteredModels.length !== 1 ? "s" : ""}
-            {hasActiveFilters ? " matching filters" : ""}
-          </div>
-
-          {filteredModels.length === 0 ? (
-            <div className="text-center py-12 text-zinc-500 dark:text-zinc-400">
-              <p className="text-sm">No models match your filters.</p>
-              <button
-                onClick={clearFilters}
-                className="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                Clear all filters
-              </button>
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              {filteredModels.map((m) => (
-                <div
-                  key={`${m.publisher}-${m.id}`}
-                  className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-4 hover:border-zinc-300 dark:hover:border-zinc-600 transition-colors cursor-pointer"
-                  onClick={() =>
-                    setExpandedModel(
-                      expandedModel === `${m.publisher}-${m.id}`
-                        ? null
-                        : `${m.publisher}-${m.id}`
-                    )
-                  }
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault()
-                      setExpandedModel(
-                        expandedModel === `${m.publisher}-${m.id}`
-                          ? null
-                          : `${m.publisher}-${m.id}`
-                      )
-                    }
-                  }}
-                  aria-expanded={expandedModel === `${m.publisher}-${m.id}`}
-                >
-                  {/* Card header */}
-                  <div className="flex items-start justify-between gap-2 mb-2">
-                    <div className="min-w-0">
-                      <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">
-                        {m.displayName}
-                      </h3>
-                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                        {m.publisher} · v{m.latestVersion}
-                      </p>
-                    </div>
-                    {m.isPreview && (
-                      <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
-                        Preview
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Summary */}
-                  <p className="text-xs text-zinc-600 dark:text-zinc-400 line-clamp-2 mb-3">
-                    {m.summary || "No description available."}
-                  </p>
-
-                  {/* Spec row */}
-                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-zinc-500 dark:text-zinc-400 mb-2">
-                    {m.contextWindow && (
-                      <span title="Context window">
-                        📐 {formatNumber(m.contextWindow)} ctx
-                      </span>
-                    )}
-                    {m.maxOutputTokens && (
-                      <span title="Max output tokens">
-                        📝 {formatNumber(m.maxOutputTokens)} out
-                      </span>
-                    )}
-                    {m.versions && m.versions.length > 1 && (
-                      <span title="Available versions">
-                        📦 {m.versions.length} versions
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Capability tags */}
-                  <div className="flex flex-wrap gap-1">
-                    {m.tasks?.slice(0, 3).map((t) => (
-                      <span
-                        key={t}
-                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300"
-                      >
-                        {TASK_LABELS[t] || t}
-                      </span>
-                    ))}
-                    {m.capabilities?.slice(0, 3).map((c) => (
-                      <span
-                        key={c}
-                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
-                      >
-                        {CAP_LABELS[c] || c}
-                      </span>
-                    ))}
-                  </div>
-
-                  {/* Expanded details */}
-                  {expandedModel === `${m.publisher}-${m.id}` && (
-                    <div className="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800 space-y-2">
-                      {m.deploymentTypes?.length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Deployment:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {m.deploymentTypes
-                              .map((d) => DEPLOY_LABELS[d] || d)
-                              .join(", ")}
-                          </span>
-                        </div>
-                      )}
-                      {m.inputModalities?.length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Input:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {m.inputModalities.join(", ")}
-                          </span>
-                        </div>
-                      )}
-                      {m.outputModalities?.length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Output:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {m.outputModalities.join(", ")}
-                          </span>
-                        </div>
-                      )}
-                      {m.toolsSupported?.length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Tools:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {m.toolsSupported.slice(0, 8).join(", ")}
-                            {m.toolsSupported.length > 8 &&
-                              ` +${m.toolsSupported.length - 8} more`}
-                          </span>
-                        </div>
-                      )}
-                      {m.regions && Object.keys(m.regions).length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Regions:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {Object.entries(m.regions)
-                              .map(
-                                ([sku, regions]) =>
-                                  `${sku} (${regions.length} regions)`
-                              )
-                              .join(", ")}
-                          </span>
-                        </div>
-                      )}
-                      {m.pricingLink && (
-                        <a
-                          href={m.pricingLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline mt-1"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          View pricing →
-                        </a>
-                      )}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+      {/* Results count */}
+      <div className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
+        {filteredModels.length} model{filteredModels.length !== 1 ? "s" : ""}
+        {hasActiveFilters ? " matching filters" : ""}
       </div>
+
+      {/* Empty state */}
+      {filteredModels.length === 0 ? (
+        <div className="text-center py-16 text-zinc-500 dark:text-zinc-400">
+          <p className="text-sm mb-2">No models match your filters.</p>
+          <button onClick={clearFilters} className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+            Clear all filters
+          </button>
+        </div>
+      ) : (
+        /* Model cards — grouped or flat */
+        groupedModels.map((group) => (
+          <div key={group.label || "all"} className="mb-6">
+            {group.label && (
+              <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-3 pb-2 border-b border-zinc-200 dark:border-zinc-800">
+                {group.label}
+                <span className="ml-2 text-xs font-normal text-zinc-400">{group.models.length}</span>
+              </h3>
+            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {group.models.map((m) => {
+                const isExpanded = expandedModel === modelKey(m)
+                const allBadges = [
+                  ...(m.tasks || []).map((t) => ({ label: TASK_LABELS[t] || t, color: "emerald" })),
+                  ...(m.capabilities || []).map((c) => ({ label: CAP_LABELS[c] || c, color: "purple" })),
+                ]
+                const visibleBadges = allBadges.slice(0, 4)
+                const overflowCount = allBadges.length - 4
+
+                return (
+                  <div key={modelKey(m)}
+                    className={`rounded-xl border bg-white dark:bg-zinc-900 transition-all duration-200 cursor-pointer ${
+                      isExpanded
+                        ? "border-blue-300 dark:border-blue-700 shadow-sm"
+                        : "border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:shadow-sm"
+                    }`}
+                    onClick={() => setExpandedModel(isExpanded ? null : modelKey(m))}
+                    role="button" tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setExpandedModel(isExpanded ? null : modelKey(m)) } }}
+                    aria-expanded={isExpanded}>
+                    <div className="p-4">
+                      {/* Header row */}
+                      <div className="flex items-start justify-between gap-2 mb-1">
+                        <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100 leading-tight">
+                          {m.displayName}
+                        </h3>
+                        <div className="flex items-center gap-1.5 shrink-0">
+                          {m.isPreview && (
+                            <span className="px-1.5 py-0.5 rounded text-[11px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">Preview</span>
+                          )}
+                          <svg className={`h-4 w-4 text-zinc-400 transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+                            fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                          </svg>
+                        </div>
+                      </div>
+
+                      {/* Model ID + copy */}
+                      <div className="flex items-center gap-2 mb-2">
+                        <code className="text-[11px] text-zinc-500 dark:text-zinc-400 bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded font-mono">
+                          {m.id}
+                        </code>
+                        <button onClick={(e) => copyModelId(e, m.id)} title="Copy model ID"
+                          className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">
+                          {copiedId === m.id ? (
+                            <svg className="h-3.5 w-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                            </svg>
+                          ) : (
+                            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                            </svg>
+                          )}
+                        </button>
+                        <span className="text-[11px] text-zinc-400">·</span>
+                        <span className="text-[11px] text-zinc-500 dark:text-zinc-400">{m.publisher}</span>
+                      </div>
+
+                      {/* Summary */}
+                      <p className="text-xs text-zinc-600 dark:text-zinc-400 line-clamp-2 mb-3 min-h-[2rem]">
+                        {m.summary || "No description available."}
+                      </p>
+
+                      {/* Specs row */}
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400 mb-2.5">
+                        {m.contextWindow && <span>{formatNumber(m.contextWindow)} context</span>}
+                        {m.contextWindow && m.maxOutputTokens && <span className="text-zinc-300 dark:text-zinc-600">·</span>}
+                        {m.maxOutputTokens && <span>{formatNumber(m.maxOutputTokens)} output</span>}
+                        {(m.contextWindow || m.maxOutputTokens) && m.inputModalities?.length > 0 && <span className="text-zinc-300 dark:text-zinc-600">·</span>}
+                        {m.inputModalities?.map((mod) => (
+                          <span key={mod} className="inline-flex items-center gap-0.5" title={`Input: ${mod}`}>
+                            <span className="text-[10px] font-mono text-zinc-400">{MODALITY_ICONS[mod] || mod}</span>
+                          </span>
+                        ))}
+                        {m.license && m.license !== "custom" && (
+                          <>
+                            <span className="text-zinc-300 dark:text-zinc-600">·</span>
+                            <span className="uppercase tracking-wider text-[10px]">{m.license}</span>
+                          </>
+                        )}
+                      </div>
+
+                      {/* Badges */}
+                      <div className="flex flex-wrap gap-1">
+                        {visibleBadges.map((b) => (
+                          <span key={b.label}
+                            className={`px-1.5 py-0.5 rounded text-xs font-medium ${
+                              b.color === "emerald"
+                                ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300"
+                                : "bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
+                            }`}>
+                            {b.label}
+                          </span>
+                        ))}
+                        {overflowCount > 0 && (
+                          <span className="px-1.5 py-0.5 rounded text-xs text-zinc-400 dark:text-zinc-500 bg-zinc-100 dark:bg-zinc-800">
+                            +{overflowCount}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Expanded details */}
+                    {isExpanded && (
+                      <div className="px-4 pb-4 pt-0">
+                        <div className="pt-3 border-t border-zinc-100 dark:border-zinc-800">
+                          <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                            {m.deploymentTypes?.length > 0 && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Deployment</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.deploymentTypes.map((d) => DEPLOY_LABELS[d] || d).join(", ")}</span>
+                              </div>
+                            )}
+                            {m.inputModalities?.length > 0 && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Input</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.inputModalities.join(", ")}</span>
+                              </div>
+                            )}
+                            {m.outputModalities?.length > 0 && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Output</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.outputModalities.join(", ")}</span>
+                              </div>
+                            )}
+                            {m.trainingDataDate && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Training data</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.trainingDataDate}</span>
+                              </div>
+                            )}
+                            {m.languages?.length > 0 && m.languages[0] && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Languages</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.languages.join(", ")}</span>
+                              </div>
+                            )}
+                            {m.versions?.length > 1 && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Versions</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.versions.join(", ")}</span>
+                              </div>
+                            )}
+                          </div>
+                          {m.toolsSupported?.length > 0 && (
+                            <div className="mt-3">
+                              <span className="text-xs text-zinc-400 dark:text-zinc-500 block mb-1">Supported tools</span>
+                              <div className="flex flex-wrap gap-1">
+                                {m.toolsSupported.map((t) => (
+                                  <span key={t} className="px-1.5 py-0.5 rounded text-[11px] bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400">{t}</span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {m.regions && Object.keys(m.regions).length > 0 && (
+                            <div className="mt-3">
+                              <span className="text-xs text-zinc-400 dark:text-zinc-500 block mb-1">Region availability</span>
+                              <div className="flex flex-wrap gap-1">
+                                {Object.entries(m.regions).map(([sku, regions]) => (
+                                  <span key={sku} className="px-1.5 py-0.5 rounded text-[11px] bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400">
+                                    {sku}: {regions.length} region{regions.length !== 1 ? "s" : ""}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {m.pricingLink && (
+                            <a href={m.pricingLink} target="_blank" rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 mt-3 px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-800/40 transition-colors"
+                              onClick={(e) => e.stopPropagation()}>
+                              View pricing
+                              <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                              </svg>
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ))
+      )}
     </div>
   )
 }

--- a/docs/models/catalog/model-explorer.mdx
+++ b/docs/models/catalog/model-explorer.mdx
@@ -5,14 +5,4 @@ description: "Search and filter all available Azure AI models by provider, capab
 
 import { ModelCatalog } from "/snippets/model-catalog.jsx"
 
-# Model Explorer
-
-Browse all models available directly from Azure in Microsoft Foundry. Use the search bar and faceted filters to find models by provider, capability, deployment type, and task.
-
-<Tip>
-This catalog is auto-generated from the Azure AI model registry and refreshed daily.
-For detailed model documentation, see [Models sold directly by Azure](/foundry-models/models-sold-directly-by-azure).
-For deployment guidance, see [Deployment types](/foundry-models/deployment-types).
-</Tip>
-
 <ModelCatalog />

--- a/docs/snippets/model-catalog.jsx
+++ b/docs/snippets/model-catalog.jsx
@@ -5,7 +5,10 @@ export const ModelCatalog = () => {
   const [searchQuery, setSearchQuery] = useState("")
   const [activeFilters, setActiveFilters] = useState({})
   const [sortBy, setSortBy] = useState("name")
+  const [groupBy, setGroupBy] = useState("none")
   const [expandedModel, setExpandedModel] = useState(null)
+  const [copiedId, setCopiedId] = useState(null)
+  const [openDropdown, setOpenDropdown] = useState(null)
 
   useEffect(() => {
     fetch("/static/data/models.json")
@@ -23,36 +26,58 @@ export const ModelCatalog = () => {
       })
   }, [])
 
-  const facetConfig = useMemo(
-    () => [
-      { key: "publisher", label: "Provider" },
-      { key: "tasks", label: "Task" },
-      { key: "capabilities", label: "Capability" },
-      { key: "deploymentTypes", label: "Deployment" },
-    ],
-    []
-  )
+  const DEPLOY_LABELS = {
+    "aoai-deployment": "Azure OpenAI",
+    "batch-enabled": "Batch",
+    "maas-inference": "Serverless API",
+    "maap-inference": "Managed Compute",
+  }
+  const TASK_LABELS = {
+    "chat-completion": "Chat",
+    responses: "Responses",
+    embeddings: "Embeddings",
+    "text-to-image": "Image Gen",
+    "image-to-image": "Image Edit",
+    "audio-generation": "Audio Gen",
+    "speech-to-text": "Speech-to-Text",
+    "text-to-speech": "Text-to-Speech",
+    "video-generation": "Video Gen",
+    "automatic-speech-recognition": "ASR",
+  }
+  const CAP_LABELS = {
+    agentsV2: "Agents",
+    agents: "Agents (v1)",
+    reasoning: "Reasoning",
+    streaming: "Streaming",
+    "tool-calling": "Tool Calling",
+    "fine-tuning": "Fine-tuning",
+    assistants: "Assistants",
+  }
+  const MODALITY_ICONS = { text: "Aa", image: "◩", audio: "♪", video: "▶" }
 
-  const facetCounts = useMemo(() => {
-    const counts = {}
-    for (const f of facetConfig) {
-      const map = {}
-      for (const m of models) {
-        const vals = Array.isArray(m[f.key]) ? m[f.key] : [m[f.key]]
-        for (const v of vals) {
-          if (v) map[v] = (map[v] || 0) + 1
-        }
-      }
-      counts[f.key] = Object.entries(map)
-        .sort((a, b) => b[1] - a[1])
-        .map(([value, count]) => ({ value, count }))
-    }
-    return counts
-  }, [models, facetConfig])
+  const facetConfig = [
+    { key: "publisher", label: "Provider" },
+    { key: "tasks", label: "Task" },
+    { key: "capabilities", label: "Capability" },
+    { key: "deploymentTypes", label: "Deployment" },
+  ]
+
+  const formatLabel = (key, value) => {
+    if (key === "deploymentTypes") return DEPLOY_LABELS[value] || value
+    if (key === "tasks") return TASK_LABELS[value] || value
+    if (key === "capabilities") return CAP_LABELS[value] || value
+    return value
+  }
+
+  const formatNumber = (n) => {
+    if (!n) return null
+    if (n >= 1000000) return `${(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)}M`
+    if (n >= 1000) return `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}K`
+    return String(n)
+  }
 
   const filteredModels = useMemo(() => {
     let result = models
-
     if (searchQuery) {
       const q = searchQuery.toLowerCase()
       result = result.filter(
@@ -64,31 +89,76 @@ export const ModelCatalog = () => {
           m.keywords?.some((k) => k.toLowerCase().includes(q))
       )
     }
-
     for (const [key, values] of Object.entries(activeFilters)) {
       if (values && values.length > 0) {
         result = result.filter((m) => {
           const mVal = m[key]
-          if (Array.isArray(mVal)) {
-            return values.some((v) => mVal.includes(v))
-          }
+          if (Array.isArray(mVal)) return values.some((v) => mVal.includes(v))
           return values.includes(mVal)
         })
       }
     }
-
     result = [...result].sort((a, b) => {
-      if (sortBy === "name")
-        return (a.displayName || "").localeCompare(b.displayName || "")
-      if (sortBy === "context")
-        return (b.contextWindow || 0) - (a.contextWindow || 0)
-      if (sortBy === "publisher")
-        return (a.publisher || "").localeCompare(b.publisher || "")
+      if (sortBy === "name") return (a.displayName || "").localeCompare(b.displayName || "")
+      if (sortBy === "context") return (b.contextWindow || 0) - (a.contextWindow || 0)
+      if (sortBy === "publisher") return (a.publisher || "").localeCompare(b.publisher || "")
       return 0
     })
-
     return result
   }, [models, searchQuery, activeFilters, sortBy])
+
+  // Facet counts computed from filtered results (excluding the facet's own filter)
+  const facetCounts = useMemo(() => {
+    const counts = {}
+    for (const f of facetConfig) {
+      const otherFilters = { ...activeFilters }
+      delete otherFilters[f.key]
+      let subset = models
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase()
+        subset = subset.filter(
+          (m) =>
+            m.displayName?.toLowerCase().includes(q) ||
+            m.publisher?.toLowerCase().includes(q) ||
+            m.summary?.toLowerCase().includes(q) ||
+            m.id?.toLowerCase().includes(q)
+        )
+      }
+      for (const [key, values] of Object.entries(otherFilters)) {
+        if (values && values.length > 0) {
+          subset = subset.filter((m) => {
+            const mVal = m[key]
+            if (Array.isArray(mVal)) return values.some((v) => mVal.includes(v))
+            return values.includes(mVal)
+          })
+        }
+      }
+      const map = {}
+      for (const m of subset) {
+        const vals = Array.isArray(m[f.key]) ? m[f.key] : [m[f.key]]
+        for (const v of vals) {
+          if (v) map[v] = (map[v] || 0) + 1
+        }
+      }
+      counts[f.key] = Object.entries(map)
+        .sort((a, b) => b[1] - a[1])
+        .map(([value, count]) => ({ value, count }))
+    }
+    return counts
+  }, [models, searchQuery, activeFilters])
+
+  const groupedModels = useMemo(() => {
+    if (groupBy === "none") return [{ label: null, models: filteredModels }]
+    const groups = {}
+    for (const m of filteredModels) {
+      const key = m.publisher || "Other"
+      if (!groups[key]) groups[key] = []
+      groups[key].push(m)
+    }
+    return Object.entries(groups)
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([label, models]) => ({ label, models }))
+  }, [filteredModels, groupBy])
 
   const toggleFilter = (facetKey, value) => {
     setActiveFilters((prev) => {
@@ -105,59 +175,31 @@ export const ModelCatalog = () => {
     setSearchQuery("")
   }
 
+  const copyModelId = (e, id) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(id).then(() => {
+      setCopiedId(id)
+      setTimeout(() => setCopiedId(null), 1500)
+    })
+  }
+
   const hasActiveFilters =
-    searchQuery ||
-    Object.values(activeFilters).some((v) => v && v.length > 0)
+    searchQuery || Object.values(activeFilters).some((v) => v && v.length > 0)
 
-  const DEPLOY_LABELS = {
-    "aoai-deployment": "Azure OpenAI",
-    "batch-enabled": "Batch",
-    "maas-inference": "Serverless API",
-    "maap-inference": "Managed Compute",
-  }
-
-  const TASK_LABELS = {
-    "chat-completion": "Chat",
-    responses: "Responses",
-    embeddings: "Embeddings",
-    "text-to-image": "Image Gen",
-    "image-to-image": "Image Edit",
-    "audio-generation": "Audio Gen",
-    "speech-to-text": "Speech-to-Text",
-    "text-to-speech": "Text-to-Speech",
-    "video-generation": "Video Gen",
-    "automatic-speech-recognition": "ASR",
-  }
-
-  const CAP_LABELS = {
-    agentsV2: "Agents",
-    agents: "Agents (v1)",
-    reasoning: "Reasoning",
-    streaming: "Streaming",
-    "tool-calling": "Tool Calling",
-    "fine-tuning": "Fine-tuning",
-    assistants: "Assistants",
-  }
-
-  const formatLabel = (key, value) => {
-    if (key === "deploymentTypes") return DEPLOY_LABELS[value] || value
-    if (key === "tasks") return TASK_LABELS[value] || value
-    if (key === "capabilities") return CAP_LABELS[value] || value
-    return value
-  }
-
-  const formatNumber = (n) => {
-    if (!n) return "—"
-    if (n >= 1000000) return `${(n / 1000000).toFixed(n % 1000000 === 0 ? 0 : 1)}M`
-    if (n >= 1000) return `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}K`
-    return String(n)
-  }
+  const modelKey = (m) => `${m.publisher}-${m.id}`
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-16">
-        <div className="text-zinc-500 dark:text-zinc-400 text-sm">
-          Loading model catalog…
+      <div className="not-prose">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-4">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 p-5 animate-pulse">
+              <div className="h-4 bg-zinc-200 dark:bg-zinc-700 rounded w-3/4 mb-3" />
+              <div className="h-3 bg-zinc-200 dark:bg-zinc-700 rounded w-1/2 mb-4" />
+              <div className="h-3 bg-zinc-200 dark:bg-zinc-700 rounded w-full mb-2" />
+              <div className="h-3 bg-zinc-200 dark:bg-zinc-700 rounded w-5/6" />
+            </div>
+          ))}
         </div>
       </div>
     )
@@ -165,299 +207,333 @@ export const ModelCatalog = () => {
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-4">
-        <p className="text-red-700 dark:text-red-400 text-sm">
-          Failed to load model catalog: {error}
-        </p>
+      <div className="not-prose rounded-xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 p-5">
+        <p className="text-red-700 dark:text-red-400 text-sm">Failed to load model catalog: {error}</p>
       </div>
     )
   }
 
   return (
     <div className="not-prose">
-      {/* Search + Sort bar */}
+      {/* Search + Controls bar */}
       <div className="flex flex-col sm:flex-row gap-3 mb-4">
         <div className="relative flex-1">
           <input
             type="text"
-            placeholder="Search models by name, provider, or keyword…"
+            placeholder="Search models…"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full px-4 py-2.5 pl-10 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400"
+            className="w-full px-4 py-2 pl-9 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             aria-label="Search models"
           />
-          <svg
-            className="absolute left-3 top-3 h-4 w-4 text-zinc-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
+          <svg className="absolute left-3 top-2.5 h-4 w-4 text-zinc-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
           </svg>
         </div>
-        <select
-          value={sortBy}
-          onChange={(e) => setSortBy(e.target.value)}
-          className="px-3 py-2.5 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-sm"
-          aria-label="Sort models"
-        >
-          <option value="name">Sort: Name</option>
-          <option value="publisher">Sort: Provider</option>
-          <option value="context">Sort: Context Window</option>
-        </select>
+        <div className="flex gap-2">
+          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-xs"
+            aria-label="Sort models">
+            <option value="name">Sort: Name</option>
+            <option value="publisher">Sort: Provider</option>
+            <option value="context">Sort: Context Window</option>
+          </select>
+          <select value={groupBy} onChange={(e) => setGroupBy(e.target.value)}
+            className="px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 text-xs"
+            aria-label="Group models">
+            <option value="none">Group: None</option>
+            <option value="publisher">Group: Provider</option>
+          </select>
+        </div>
       </div>
 
-      {/* Active filter pills + clear */}
+      {/* Horizontal filter bar */}
+      <div className="flex flex-wrap gap-2 mb-4">
+        {facetConfig.map((facet) => {
+          const isOpen = openDropdown === facet.key
+          const activeVals = activeFilters[facet.key] || []
+          const items = facetCounts[facet.key] || []
+          return (
+            <div key={facet.key} className="relative">
+              <button
+                onClick={() => setOpenDropdown(isOpen ? null : facet.key)}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                  activeVals.length > 0
+                    ? "bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300"
+                    : "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                }`}
+              >
+                {facet.label}
+                {activeVals.length > 0 && (
+                  <span className="bg-blue-500 text-white text-[10px] rounded-full px-1.5 py-0.5 leading-none">{activeVals.length}</span>
+                )}
+                <svg className={`h-3 w-3 transition-transform ${isOpen ? "rotate-180" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+              {isOpen && (
+                <>
+                  <div className="fixed inset-0 z-10" onClick={() => setOpenDropdown(null)} />
+                  <div className="absolute top-full left-0 mt-1 z-20 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg p-2 min-w-[200px] max-h-[300px] overflow-y-auto">
+                    {items.map(({ value, count }) => {
+                      const isActive = activeVals.includes(value)
+                      return (
+                        <button key={value} onClick={() => toggleFilter(facet.key, value)}
+                          className={`w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors text-left ${
+                            isActive
+                              ? "bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 font-medium"
+                              : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                          }`}>
+                          <span className="truncate">{formatLabel(facet.key, value)}</span>
+                          <span className="text-zinc-400 dark:text-zinc-500 ml-3 tabular-nums">{count}</span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                </>
+              )}
+            </div>
+          )
+        })}
+        {hasActiveFilters && (
+          <button onClick={clearFilters}
+            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors">
+            <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {/* Active filter pills */}
       {hasActiveFilters && (
-        <div className="flex flex-wrap gap-2 mb-4 items-center">
+        <div className="flex flex-wrap gap-1.5 mb-4">
           {Object.entries(activeFilters).map(([key, values]) =>
             (values || []).map((v) => (
-              <button
-                key={`${key}-${v}`}
-                onClick={() => toggleFilter(key, v)}
-                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800/50 transition-colors"
-              >
+              <button key={`${key}-${v}`} onClick={() => toggleFilter(key, v)}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-800/50 transition-colors">
                 {formatLabel(key, v)}
-                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                <svg className="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
             ))
           )}
-          <button
-            onClick={clearFilters}
-            className="text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 underline"
-          >
-            Clear all
-          </button>
         </div>
       )}
 
-      <div className="flex flex-col lg:flex-row gap-6">
-        {/* Faceted sidebar */}
-        <div className="lg:w-56 shrink-0 space-y-5">
-          {facetConfig.map((facet) => (
-            <div key={facet.key}>
-              <h4 className="text-xs font-semibold text-zinc-500 dark:text-zinc-400 uppercase tracking-wider mb-2">
-                {facet.label}
-              </h4>
-              <div className="space-y-1">
-                {(facetCounts[facet.key] || []).slice(0, 12).map(({ value, count }) => {
-                  const isActive = (activeFilters[facet.key] || []).includes(value)
-                  return (
-                    <button
-                      key={value}
-                      onClick={() => toggleFilter(facet.key, value)}
-                      className={`w-full flex items-center justify-between px-2.5 py-1.5 rounded-md text-xs transition-colors text-left ${
-                        isActive
-                          ? "bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300 font-medium"
-                          : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-800"
-                      }`}
-                      aria-pressed={isActive}
-                    >
-                      <span className="truncate">{formatLabel(facet.key, value)}</span>
-                      <span className="text-zinc-400 dark:text-zinc-500 ml-2 tabular-nums">
-                        {count}
-                      </span>
-                    </button>
-                  )
-                })}
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* Model cards grid */}
-        <div className="flex-1 min-w-0">
-          <div className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
-            {filteredModels.length} model{filteredModels.length !== 1 ? "s" : ""}
-            {hasActiveFilters ? " matching filters" : ""}
-          </div>
-
-          {filteredModels.length === 0 ? (
-            <div className="text-center py-12 text-zinc-500 dark:text-zinc-400">
-              <p className="text-sm">No models match your filters.</p>
-              <button
-                onClick={clearFilters}
-                className="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:underline"
-              >
-                Clear all filters
-              </button>
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              {filteredModels.map((m) => (
-                <div
-                  key={`${m.publisher}-${m.id}`}
-                  className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-4 hover:border-zinc-300 dark:hover:border-zinc-600 transition-colors cursor-pointer"
-                  onClick={() =>
-                    setExpandedModel(
-                      expandedModel === `${m.publisher}-${m.id}`
-                        ? null
-                        : `${m.publisher}-${m.id}`
-                    )
-                  }
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault()
-                      setExpandedModel(
-                        expandedModel === `${m.publisher}-${m.id}`
-                          ? null
-                          : `${m.publisher}-${m.id}`
-                      )
-                    }
-                  }}
-                  aria-expanded={expandedModel === `${m.publisher}-${m.id}`}
-                >
-                  {/* Card header */}
-                  <div className="flex items-start justify-between gap-2 mb-2">
-                    <div className="min-w-0">
-                      <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 truncate">
-                        {m.displayName}
-                      </h3>
-                      <p className="text-xs text-zinc-500 dark:text-zinc-400">
-                        {m.publisher} · v{m.latestVersion}
-                      </p>
-                    </div>
-                    {m.isPreview && (
-                      <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
-                        Preview
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Summary */}
-                  <p className="text-xs text-zinc-600 dark:text-zinc-400 line-clamp-2 mb-3">
-                    {m.summary || "No description available."}
-                  </p>
-
-                  {/* Spec row */}
-                  <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-zinc-500 dark:text-zinc-400 mb-2">
-                    {m.contextWindow && (
-                      <span title="Context window">
-                        📐 {formatNumber(m.contextWindow)} ctx
-                      </span>
-                    )}
-                    {m.maxOutputTokens && (
-                      <span title="Max output tokens">
-                        📝 {formatNumber(m.maxOutputTokens)} out
-                      </span>
-                    )}
-                    {m.versions && m.versions.length > 1 && (
-                      <span title="Available versions">
-                        📦 {m.versions.length} versions
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Capability tags */}
-                  <div className="flex flex-wrap gap-1">
-                    {m.tasks?.slice(0, 3).map((t) => (
-                      <span
-                        key={t}
-                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300"
-                      >
-                        {TASK_LABELS[t] || t}
-                      </span>
-                    ))}
-                    {m.capabilities?.slice(0, 3).map((c) => (
-                      <span
-                        key={c}
-                        className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
-                      >
-                        {CAP_LABELS[c] || c}
-                      </span>
-                    ))}
-                  </div>
-
-                  {/* Expanded details */}
-                  {expandedModel === `${m.publisher}-${m.id}` && (
-                    <div className="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800 space-y-2">
-                      {m.deploymentTypes?.length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Deployment:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {m.deploymentTypes
-                              .map((d) => DEPLOY_LABELS[d] || d)
-                              .join(", ")}
-                          </span>
-                        </div>
-                      )}
-                      {m.inputModalities?.length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Input:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {m.inputModalities.join(", ")}
-                          </span>
-                        </div>
-                      )}
-                      {m.outputModalities?.length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Output:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {m.outputModalities.join(", ")}
-                          </span>
-                        </div>
-                      )}
-                      {m.toolsSupported?.length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Tools:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {m.toolsSupported.slice(0, 8).join(", ")}
-                            {m.toolsSupported.length > 8 &&
-                              ` +${m.toolsSupported.length - 8} more`}
-                          </span>
-                        </div>
-                      )}
-                      {m.regions && Object.keys(m.regions).length > 0 && (
-                        <div className="text-xs">
-                          <span className="text-zinc-500 dark:text-zinc-400 font-medium">
-                            Regions:{" "}
-                          </span>
-                          <span className="text-zinc-700 dark:text-zinc-300">
-                            {Object.entries(m.regions)
-                              .map(
-                                ([sku, regions]) =>
-                                  `${sku} (${regions.length} regions)`
-                              )
-                              .join(", ")}
-                          </span>
-                        </div>
-                      )}
-                      {m.pricingLink && (
-                        <a
-                          href={m.pricingLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline mt-1"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          View pricing →
-                        </a>
-                      )}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+      {/* Results count */}
+      <div className="text-xs text-zinc-500 dark:text-zinc-400 mb-3">
+        {filteredModels.length} model{filteredModels.length !== 1 ? "s" : ""}
+        {hasActiveFilters ? " matching filters" : ""}
       </div>
+
+      {/* Empty state */}
+      {filteredModels.length === 0 ? (
+        <div className="text-center py-16 text-zinc-500 dark:text-zinc-400">
+          <p className="text-sm mb-2">No models match your filters.</p>
+          <button onClick={clearFilters} className="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+            Clear all filters
+          </button>
+        </div>
+      ) : (
+        /* Model cards — grouped or flat */
+        groupedModels.map((group) => (
+          <div key={group.label || "all"} className="mb-6">
+            {group.label && (
+              <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-3 pb-2 border-b border-zinc-200 dark:border-zinc-800">
+                {group.label}
+                <span className="ml-2 text-xs font-normal text-zinc-400">{group.models.length}</span>
+              </h3>
+            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {group.models.map((m) => {
+                const isExpanded = expandedModel === modelKey(m)
+                const allBadges = [
+                  ...(m.tasks || []).map((t) => ({ label: TASK_LABELS[t] || t, color: "emerald" })),
+                  ...(m.capabilities || []).map((c) => ({ label: CAP_LABELS[c] || c, color: "purple" })),
+                ]
+                const visibleBadges = allBadges.slice(0, 4)
+                const overflowCount = allBadges.length - 4
+
+                return (
+                  <div key={modelKey(m)}
+                    className={`rounded-xl border bg-white dark:bg-zinc-900 transition-all duration-200 cursor-pointer ${
+                      isExpanded
+                        ? "border-blue-300 dark:border-blue-700 shadow-sm"
+                        : "border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 hover:shadow-sm"
+                    }`}
+                    onClick={() => setExpandedModel(isExpanded ? null : modelKey(m))}
+                    role="button" tabIndex={0}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setExpandedModel(isExpanded ? null : modelKey(m)) } }}
+                    aria-expanded={isExpanded}>
+                    <div className="p-4">
+                      {/* Header row */}
+                      <div className="flex items-start justify-between gap-2 mb-1">
+                        <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-100 leading-tight">
+                          {m.displayName}
+                        </h3>
+                        <div className="flex items-center gap-1.5 shrink-0">
+                          {m.isPreview && (
+                            <span className="px-1.5 py-0.5 rounded text-[11px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">Preview</span>
+                          )}
+                          <svg className={`h-4 w-4 text-zinc-400 transition-transform duration-200 ${isExpanded ? "rotate-180" : ""}`}
+                            fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                          </svg>
+                        </div>
+                      </div>
+
+                      {/* Model ID + copy */}
+                      <div className="flex items-center gap-2 mb-2">
+                        <code className="text-[11px] text-zinc-500 dark:text-zinc-400 bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded font-mono">
+                          {m.id}
+                        </code>
+                        <button onClick={(e) => copyModelId(e, m.id)} title="Copy model ID"
+                          className="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">
+                          {copiedId === m.id ? (
+                            <svg className="h-3.5 w-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                            </svg>
+                          ) : (
+                            <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                            </svg>
+                          )}
+                        </button>
+                        <span className="text-[11px] text-zinc-400">·</span>
+                        <span className="text-[11px] text-zinc-500 dark:text-zinc-400">{m.publisher}</span>
+                      </div>
+
+                      {/* Summary */}
+                      <p className="text-xs text-zinc-600 dark:text-zinc-400 line-clamp-2 mb-3 min-h-[2rem]">
+                        {m.summary || "No description available."}
+                      </p>
+
+                      {/* Specs row */}
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400 mb-2.5">
+                        {m.contextWindow && <span>{formatNumber(m.contextWindow)} context</span>}
+                        {m.contextWindow && m.maxOutputTokens && <span className="text-zinc-300 dark:text-zinc-600">·</span>}
+                        {m.maxOutputTokens && <span>{formatNumber(m.maxOutputTokens)} output</span>}
+                        {(m.contextWindow || m.maxOutputTokens) && m.inputModalities?.length > 0 && <span className="text-zinc-300 dark:text-zinc-600">·</span>}
+                        {m.inputModalities?.map((mod) => (
+                          <span key={mod} className="inline-flex items-center gap-0.5" title={`Input: ${mod}`}>
+                            <span className="text-[10px] font-mono text-zinc-400">{MODALITY_ICONS[mod] || mod}</span>
+                          </span>
+                        ))}
+                        {m.license && m.license !== "custom" && (
+                          <>
+                            <span className="text-zinc-300 dark:text-zinc-600">·</span>
+                            <span className="uppercase tracking-wider text-[10px]">{m.license}</span>
+                          </>
+                        )}
+                      </div>
+
+                      {/* Badges */}
+                      <div className="flex flex-wrap gap-1">
+                        {visibleBadges.map((b) => (
+                          <span key={b.label}
+                            className={`px-1.5 py-0.5 rounded text-xs font-medium ${
+                              b.color === "emerald"
+                                ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300"
+                                : "bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
+                            }`}>
+                            {b.label}
+                          </span>
+                        ))}
+                        {overflowCount > 0 && (
+                          <span className="px-1.5 py-0.5 rounded text-xs text-zinc-400 dark:text-zinc-500 bg-zinc-100 dark:bg-zinc-800">
+                            +{overflowCount}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Expanded details */}
+                    {isExpanded && (
+                      <div className="px-4 pb-4 pt-0">
+                        <div className="pt-3 border-t border-zinc-100 dark:border-zinc-800">
+                          <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                            {m.deploymentTypes?.length > 0 && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Deployment</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.deploymentTypes.map((d) => DEPLOY_LABELS[d] || d).join(", ")}</span>
+                              </div>
+                            )}
+                            {m.inputModalities?.length > 0 && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Input</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.inputModalities.join(", ")}</span>
+                              </div>
+                            )}
+                            {m.outputModalities?.length > 0 && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Output</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.outputModalities.join(", ")}</span>
+                              </div>
+                            )}
+                            {m.trainingDataDate && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Training data</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.trainingDataDate}</span>
+                              </div>
+                            )}
+                            {m.languages?.length > 0 && m.languages[0] && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Languages</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.languages.join(", ")}</span>
+                              </div>
+                            )}
+                            {m.versions?.length > 1 && (
+                              <div>
+                                <span className="text-zinc-400 dark:text-zinc-500 block mb-0.5">Versions</span>
+                                <span className="text-zinc-700 dark:text-zinc-300">{m.versions.join(", ")}</span>
+                              </div>
+                            )}
+                          </div>
+                          {m.toolsSupported?.length > 0 && (
+                            <div className="mt-3">
+                              <span className="text-xs text-zinc-400 dark:text-zinc-500 block mb-1">Supported tools</span>
+                              <div className="flex flex-wrap gap-1">
+                                {m.toolsSupported.map((t) => (
+                                  <span key={t} className="px-1.5 py-0.5 rounded text-[11px] bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400">{t}</span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {m.regions && Object.keys(m.regions).length > 0 && (
+                            <div className="mt-3">
+                              <span className="text-xs text-zinc-400 dark:text-zinc-500 block mb-1">Region availability</span>
+                              <div className="flex flex-wrap gap-1">
+                                {Object.entries(m.regions).map(([sku, regions]) => (
+                                  <span key={sku} className="px-1.5 py-0.5 rounded text-[11px] bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400">
+                                    {sku}: {regions.length} region{regions.length !== 1 ? "s" : ""}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                          {m.pricingLink && (
+                            <a href={m.pricingLink} target="_blank" rel="noopener noreferrer"
+                              className="inline-flex items-center gap-1 mt-3 px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-100 dark:hover:bg-blue-800/40 transition-colors"
+                              onClick={(e) => e.stopPropagation()}>
+                              View pricing
+                              <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                              </svg>
+                            </a>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ))
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## UX Improvements

Based on design review comparing against OpenAI's model catalog page.

### Layout
- **Sidebar → horizontal filter dropdowns** — cards now get full content width, 3-column grid on desktop
- **Trimmed MDX page** — removed redundant headers/prose, component fills the fold immediately

### Model Cards
- **Larger model name** (`text-base` instead of `text-sm`)
- **Monospace model ID with click-to-copy** — developers can grab `gpt-4o-mini` instantly
- **No more emoji** — replaced 📐📝📦 with clean text labels: `128K context · 16K output`
- **Modality indicators** on collapsed cards (text, image, audio)
- **License badge** shown when non-custom
- **Expand chevron** (▾) for discoverability + smooth transition
- **+N overflow** when badges are clipped
- **12px minimum badge text** (up from 10px) for accessibility

### Filtering
- **Fixed facet counts** — now computed from filtered results (excluding current facet), not the full dataset
- **Group by Provider** toggle — section headings like `OpenAI (68)`
- **Skeleton loading state** instead of text spinner

### Expanded Panel
- **Structured 2-column spec grid** (deployment, input, output, training date, languages, versions)
- **Tool badges** instead of comma-separated text
- **Prominent pricing button** with external link icon