### PR TITLE
Fix docs-vnext nav: add 249 missing entries (agent-service, foundry-models, and others)

### DIFF
--- a/docs-vnext/docs.json
+++ b/docs-vnext/docs.json
@@ -34,6 +34,12 @@
         "tab": "Documentation",
         "groups": [
           {
+            "group": "What is Microsoft Foundry",
+            "pages": [
+              "what-is-microsoft-foundry/what-is-foundry"
+            ]
+          },
+          {
             "group": "Overview",
             "pages": [
               "overview/what-is-foundry",
@@ -49,7 +55,8 @@
               "get-started/developer-journey-idea-to-prototype",
               "get-started/ask-ai",
               "get-started/connect-ai-tools",
-              "get-started/ai-ingestion"
+              "get-started/ai-ingestion",
+              "get-started/navigate-from-classic"
             ]
           },
           {
@@ -93,7 +100,194 @@
                   "agents/development/agent-365",
                   "agents/development/publish-responses"
                 ]
+              },
+              {
+                "group": "Prompt agents",
+                "pages": [
+                  "agents/development/prompt-agent",
+                  "agents/development/prompt-optimizer"
+                ]
               }
+            ]
+          },
+          {
+            "group": "Foundry Agent Service (new)",
+            "pages": [
+              "agent-service/overview",
+              "agent-service/faq",
+              "agent-service/limits-quotas-regions",
+              "agent-service/development-lifecycle",
+              "agent-service/runtime-components",
+              "agent-service/agent-identity",
+              "agent-service/capability-hosts",
+              "agent-service/workflow",
+              "agent-service/configure-agent",
+              "agent-service/structured-inputs",
+              "agent-service/disable-classic-agents",
+              {
+                "group": "Migrate to Foundry Agent Service",
+                "pages": [
+                  "agent-service/migrate",
+                  "agent-service/migrate-agent-applications",
+                  "agent-service/agent-applications"
+                ]
+              },
+              {
+                "group": "Quickstarts",
+                "pages": [
+                  "agent-service/quickstart",
+                  "agent-service/prompt-agent",
+                  "agent-service/responses-api",
+                  "agent-service/quickstart-multi-turn-conversations"
+                ]
+              },
+              {
+                "group": "Hosted agents",
+                "pages": [
+                  "agent-service/hosted-agents",
+                  "agent-service/quickstart-hosted-agent",
+                  "agent-service/deploy-hosted-agent",
+                  "agent-service/deploy-hosted-agent-code",
+                  "agent-service/manage-hosted-agent",
+                  "agent-service/manage-hosted-sessions",
+                  "agent-service/hosted-agent-permissions",
+                  "agent-service/migrate-hosted-agent-preview"
+                ]
+              },
+              {
+                "group": "Voice agents",
+                "pages": [
+                  "agent-service/build-voice-agent",
+                  "agent-service/how-to-voice-agent-integration",
+                  "agent-service/voice-live-agents-quickstart"
+                ]
+              },
+              {
+                "group": "System messages",
+                "pages": [
+                  "agent-service/advanced-prompt-engineering",
+                  "agent-service/system-message",
+                  "agent-service/safety-system-message-templates"
+                ]
+              },
+              {
+                "group": "Publish agents",
+                "pages": [
+                  "agent-service/publish-agent",
+                  "agent-service/publish-copilot",
+                  "agent-service/publish-responses",
+                  "agent-service/agent-365",
+                  "agent-service/agent-365-integration"
+                ]
+              },
+              {
+                "group": "Agent catalog",
+                "pages": [
+                  "agent-service/agent-catalog",
+                  "agent-service/quickstart-agent-catalog"
+                ]
+              },
+              {
+                "group": "Manage tools",
+                "pages": [
+                  "agent-service/tool-catalog",
+                  "agent-service/private-tool-catalog",
+                  "agent-service/tool-best-practice",
+                  "agent-service/tool-search",
+                  "agent-service/toolbox",
+                  "agent-service/governance"
+                ]
+              },
+              {
+                "group": "Built-in tools",
+                "pages": [
+                  "agent-service/code-interpreter",
+                  "agent-service/custom-code-interpreter",
+                  "agent-service/file-search",
+                  "agent-service/image-generation",
+                  "agent-service/web-search",
+                  "agent-service/web-overview",
+                  "agent-service/browser-automation",
+                  "agent-service/computer-use",
+                  "agent-service/azure-functions",
+                  "agent-service/azure-ai-speech",
+                  "agent-service/bing-tools",
+                  "agent-service/foundry-tools-agents"
+                ]
+              },
+              {
+                "group": "Knowledge and retrieval",
+                "pages": [
+                  "agent-service/ai-search",
+                  "agent-service/retrieval-augmented-generation",
+                  "agent-service/vector-stores",
+                  "agent-service/sharepoint",
+                  "agent-service/fabric",
+                  "agent-service/fabric-iq"
+                ]
+              },
+              {
+                "group": "Foundry IQ",
+                "pages": [
+                  "agent-service/what-is-foundry-iq",
+                  "agent-service/foundry-iq-faq",
+                  "agent-service/foundry-iq-connect"
+                ]
+              },
+              {
+                "group": "Memory",
+                "pages": [
+                  "agent-service/what-is-memory",
+                  "agent-service/memory-usage"
+                ]
+              },
+              {
+                "group": "Protocols",
+                "pages": [
+                  "agent-service/function-calling",
+                  "agent-service/openapi",
+                  "agent-service/model-context-protocol",
+                  "agent-service/mcp-authentication",
+                  "agent-service/build-your-own-mcp-server",
+                  "agent-service/agent-to-agent",
+                  "agent-service/agent-to-agent-authentication",
+                  "agent-service/enable-agent-to-agent-endpoint",
+                  "agent-service/connectors"
+                ]
+              },
+              {
+                "group": "Routines and skills",
+                "pages": [
+                  "agent-service/routines",
+                  "agent-service/use-routines",
+                  "agent-service/skills"
+                ]
+              },
+              {
+                "group": "Agent optimizer",
+                "pages": [
+                  "agent-service/agent-optimizer-overview",
+                  "agent-service/make-agent-optimizer-ready",
+                  "agent-service/optimize-agent-targets",
+                  "agent-service/create-optimizer-dataset",
+                  "agent-service/prompt-optimizer",
+                  "agent-service/quickstart-optimize-hosted-agent",
+                  "agent-service/azure-developer-cli-evaluation",
+                  "agent-service/evaluate-agent"
+                ]
+              },
+              {
+                "group": "Tracing and monitoring",
+                "pages": [
+                  "agent-service/trace-agent-concept",
+                  "agent-service/trace-agent-setup",
+                  "agent-service/trace-agent-framework",
+                  "agent-service/trace-agent-client-side",
+                  "agent-service/trace-agent-replay",
+                  "agent-service/how-to-monitor-agents-dashboard"
+                ]
+              },
+              "agent-service/work-iq"
             ]
           },
           {
@@ -102,6 +296,7 @@
               {
                 "group": "Model catalog",
                 "pages": [
+                  "models/catalog/foundry-models-overview",
                   "models/catalog/model-explorer",
                   "models/catalog/models-sold-directly-by-azure",
                   "models/catalog/models-from-partners",
@@ -239,7 +434,195 @@
                       "models/fine-tuning/reinforcement-fine-tuning",
                       "models/fine-tuning/fine-tuning-functions"
                     ]
-                  }
+                  },
+                  "models/fine-tuning/fine-tune-cli"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Foundry Models (new)",
+            "pages": [
+              "foundry-models/foundry-models-overview",
+              "foundry-models/deployments-overview",
+              {
+                "group": "Model catalog",
+                "pages": [
+                  "foundry-models/models-sold-directly-by-azure",
+                  "foundry-models/models-sold-directly-by-azure-gov",
+                  "foundry-models/models-sold-directly-by-azure-region-availability",
+                  "foundry-models/models-from-partners",
+                  "foundry-models/model-versions",
+                  "foundry-models/model-versions-gov",
+                  "foundry-models/model-choice-guide",
+                  "foundry-models/working-with-models",
+                  "foundry-models/legacy-models",
+                  "foundry-models/retired-models"
+                ]
+              },
+              {
+                "group": "Model router",
+                "pages": [
+                  "foundry-models/model-router",
+                  "foundry-models/model-router-agents",
+                  "foundry-models/model-router-how-it-works",
+                  "foundry-models/model-router-policy",
+                  "foundry-models/whats-new-model-router"
+                ]
+              },
+              {
+                "group": "Deploy models",
+                "pages": [
+                  "foundry-models/deploy-foundry-models",
+                  "foundry-models/create-model-deployments",
+                  "foundry-models/deploy-models-managed",
+                  "foundry-models/deploy-models-managed-pay-go",
+                  "foundry-models/deployment-types",
+                  "foundry-models/deployment-types-gov",
+                  "foundry-models/quickstart-github-models",
+                  "foundry-models/automate-quota-deployments",
+                  "foundry-models/instant-models",
+                  "foundry-models/managed-compute-overview",
+                  "foundry-models/endpoints"
+                ]
+              },
+              {
+                "group": "Model support",
+                "pages": [
+                  "foundry-models/supported-languages",
+                  "foundry-models/use-foundry-models-claude",
+                  "foundry-models/use-foundry-models-flux",
+                  "foundry-models/use-foundry-models-mai"
+                ]
+              },
+              {
+                "group": "Generate text",
+                "pages": [
+                  "foundry-models/chatgpt",
+                  "foundry-models/responses",
+                  "foundry-models/responses-model-routing",
+                  "foundry-models/reasoning",
+                  "foundry-models/batch",
+                  "foundry-models/deep-research",
+                  "foundry-models/function-calling",
+                  "foundry-models/structured-outputs",
+                  "foundry-models/json-mode",
+                  "foundry-models/web-search",
+                  "foundry-models/predicted-outputs",
+                  "foundry-models/prompt-caching",
+                  "foundry-models/generate-responses",
+                  "foundry-models/use-chat-reasoning",
+                  "foundry-models/use-chat-multi-modal"
+                ]
+              },
+              {
+                "group": "Embeddings",
+                "pages": [
+                  "foundry-models/embeddings",
+                  "foundry-models/use-embeddings"
+                ]
+              },
+              {
+                "group": "Vision and image",
+                "pages": [
+                  "foundry-models/gpt-with-vision",
+                  "foundry-models/gpt-4-v-prompt-engineering",
+                  "foundry-models/prompt-transformation",
+                  "foundry-models/dall-e",
+                  "foundry-models/use-image-models",
+                  "foundry-models/video-generation",
+                  "foundry-models/video-translation-get-started"
+                ]
+              },
+              {
+                "group": "Audio and speech",
+                "pages": [
+                  "foundry-models/realtime-audio",
+                  "foundry-models/realtime-audio-preview-api-migration-guide",
+                  "foundry-models/realtime-audio-sip",
+                  "foundry-models/realtime-audio-webrtc",
+                  "foundry-models/realtime-audio-websockets",
+                  "foundry-models/realtime-2",
+                  "foundry-models/gpt-realtime-translate",
+                  "foundry-models/gpt-realtime-whisper",
+                  "foundry-models/whisper-quickstart",
+                  "foundry-models/audio-completions-quickstart",
+                  "foundry-models/get-started-speech-to-text",
+                  "foundry-models/get-started-text-to-speech",
+                  "foundry-models/batch-synthesis-avatar",
+                  "foundry-models/voice-live-quickstart"
+                ]
+              },
+              {
+                "group": "Scale inference",
+                "pages": [
+                  "foundry-models/priority-processing",
+                  "foundry-models/provisioned-throughput",
+                  "foundry-models/provisioned-throughput-billing",
+                  "foundry-models/provisioned-throughput-onboarding",
+                  "foundry-models/provisioned-throughput-sizing",
+                  "foundry-models/provisioned-get-started",
+                  "foundry-models/provisioned-quickstart",
+                  "foundry-models/spillover-traffic-management"
+                ]
+              },
+              {
+                "group": "Benchmark models",
+                "pages": [
+                  "foundry-models/model-benchmarks",
+                  "foundry-models/benchmark-model-in-catalog",
+                  "foundry-models/benchmark-evaluations",
+                  "foundry-models/optimization-model-upgrade"
+                ]
+              },
+              {
+                "group": "Integrate",
+                "pages": [
+                  "foundry-models/codex",
+                  "foundry-models/webhooks",
+                  "foundry-models/websockets",
+                  "foundry-models/concept-playgrounds",
+                  "foundry-models/configure-claude-code",
+                  "foundry-models/configure-claude-desktop"
+                ]
+              },
+              {
+                "group": "Fine-tuning",
+                "pages": [
+                  "foundry-models/fine-tuning-considerations",
+                  "foundry-models/fine-tuning",
+                  "foundry-models/fine-tuning-deploy",
+                  "foundry-models/fine-tune-cli",
+                  "foundry-models/data-generation",
+                  "foundry-models/fine-tuning-safety-evaluation",
+                  "foundry-models/fine-tuning-cost-management",
+                  "foundry-models/fine-tuning-vision",
+                  "foundry-models/fine-tuning-direct-preference-optimization",
+                  "foundry-models/reinforcement-fine-tuning",
+                  "foundry-models/fine-tuning-functions"
+                ]
+              },
+              {
+                "group": "Quotas and limits",
+                "pages": [
+                  "foundry-models/quota",
+                  "foundry-models/quotas-limits",
+                  "foundry-models/quotas-limits-gov",
+                  "foundry-models/region-support"
+                ]
+              },
+              {
+                "group": "Governance and lifecycle",
+                "pages": [
+                  "foundry-models/model-lifecycle-retirement",
+                  "foundry-models/model-retirement-schedule",
+                  "foundry-models/model-retirement-schedule-gov",
+                  "foundry-models/model-retirements",
+                  "foundry-models/model-retirements-gov",
+                  "foundry-models/manage-costs",
+                  "foundry-models/data-privacy",
+                  "foundry-models/concept-data-privacy",
+                  "foundry-models/troubleshoot-deploy-and-monitor"
                 ]
               }
             ]
@@ -247,6 +630,14 @@
           {
             "group": "Foundry Tools",
             "pages": [
+              {
+                "group": "Overview and quickstarts",
+                "pages": [
+                  "agents/tools/overview",
+                  "agents/tools/quickstart",
+                  "agents/tools/quickstart-multi-turn-conversations"
+                ]
+              },
               {
                 "group": "Manage tools",
                 "pages": [
@@ -265,7 +656,8 @@
                   "agents/tools/image-generation",
                   "agents/tools/web-search",
                   "agents/tools/browser-automation",
-                  "agents/tools/computer-use"
+                  "agents/tools/computer-use",
+                  "agents/tools/foundry-tools-agents"
                 ]
               },
               {
@@ -349,7 +741,8 @@
                   "observability/risk-safety-evaluators",
                   "observability/agent-evaluators",
                   "observability/azure-openai-graders",
-                  "observability/custom-evaluators"
+                  "observability/custom-evaluators",
+                  "observability/rubric-evaluators"
                 ]
               },
               {
@@ -360,7 +753,10 @@
                   "observability/evaluate-generative-ai-app",
                   "observability/evaluate-results",
                   "observability/cluster-analysis",
-                  "observability/human-evaluation"
+                  "observability/human-evaluation",
+                  "observability/evaluation-dataset-synthetic",
+                  "observability/traces-to-dataset",
+                  "observability/log-end-user-feedback"
                 ]
               },
               {
@@ -380,12 +776,16 @@
               },
               "observability/evaluation-regions-limits-virtual-network",
               "observability/safety-evaluations-transparency-note",
+              "observability/trace-data",
+              "observability/troubleshooting",
               {
                 "group": "Govern agents",
                 "pages": [
                   "manage/monitoring-across-fleet",
                   "manage/how-to-manage-agents",
-                  "manage/register-custom-agent"
+                  "manage/register-custom-agent",
+                  "observability/register-external-agent",
+                  "manage/govern-agent-infrastructure-entra-admin"
                 ]
               },
               {
@@ -405,6 +805,7 @@
             "pages": [
               "guardrails/guardrails-overview",
               "guardrails/how-to-create-guardrails",
+              "guardrails/guided-set-up",
               "guardrails/third-party-integrations",
               {
                 "group": "Content filters",
@@ -433,6 +834,14 @@
               },
               "guardrails/content-streaming",
               "guardrails/abuse-monitoring",
+              "guardrails/safety-system-message-templates",
+              {
+                "group": "Task adherence",
+                "pages": [
+                  "guardrails/task-adherence",
+                  "guardrails/how-to-task-adherence"
+                ]
+              },
               {
                 "group": "Responsible AI",
                 "pages": [
@@ -445,7 +854,9 @@
                       "responsible-ai/transparency-note",
                       "responsible-ai/limited-access",
                       "responsible-ai/data-privacy",
-                      "responsible-ai/customer-copyright-commitment"
+                      "responsible-ai/customer-copyright-commitment",
+                      "responsible-ai/abuse-monitoring",
+                      "responsible-ai/model-specific-terms"
                     ]
                   },
                   {
@@ -466,6 +877,7 @@
                 "page": "setup/planning"
               },
               "setup/create-projects",
+              "setup/general-availability",
               {
                 "group": "Manage Foundry resources",
                 "pages": [
@@ -485,7 +897,8 @@
                   "setup/use-your-own-resources",
                   "setup/migrate",
                   "setup/virtual-networks",
-                  "setup/ai-gateway"
+                  "setup/ai-gateway",
+                  "setup/agents-networking-deep-dive"
                 ]
               },
               {
@@ -507,6 +920,7 @@
               "security/manage-costs",
               "security/architecture",
               "security/data-privacy",
+              "security/diagnostic-logging",
               {
                 "group": "Identity and access",
                 "pages": [
@@ -514,7 +928,8 @@
                   "security/disable-preview-features",
                   "security/disable-preview-features-with-rbac",
                   "security/rbac-foundry",
-                  "security/configure-entra-id"
+                  "security/configure-entra-id",
+                  "security/configure-agent-365-data-collection"
                 ]
               },
               {
@@ -522,14 +937,16 @@
                 "pages": [
                   "security/configure-private-link",
                   "security/managed-virtual-network",
-                  "security/add-foundry-to-network-security-perimeter"
+                  "security/add-foundry-to-network-security-perimeter",
+                  "security/access-on-premises-resources"
                 ]
               },
               {
                 "group": "Data protection",
                 "pages": [
                   "security/encryption-keys-portal",
-                  "security/set-up-key-vault-connection"
+                  "security/set-up-key-vault-connection",
+                  "security/rotate-keys"
                 ]
               },
               {
@@ -558,6 +975,7 @@
               "developer-experience/get-started-projects-vs-code",
               "developer-experience/configure-claude-code",
               "developer-experience/ai-template-get-started",
+              "developer-experience/use-microsoft-foundry-skill",
               {
                 "group": "Agent development tools",
                 "pages": [
@@ -582,7 +1000,28 @@
                   "best-practices/prompt-engineering",
                   "best-practices/latency",
                   "best-practices/red-teaming",
-                  "best-practices/integrate-with-other-apps"
+                  "best-practices/integrate-with-other-apps",
+                  "best-practices/advanced-prompt-engineering",
+                  "best-practices/system-message"
+                ]
+              },
+              {
+                "group": "LangChain and LangGraph",
+                "pages": [
+                  "developer-experience/langchain",
+                  "developer-experience/langchain-agents",
+                  "developer-experience/langchain-hosted-agents",
+                  "developer-experience/langchain-memory",
+                  "developer-experience/langchain-middleware",
+                  "developer-experience/langchain-models",
+                  "developer-experience/langchain-traces"
+                ]
+              },
+              {
+                "group": "Custom and partner models",
+                "pages": [
+                  "developer-experience/enable-fireworks-models",
+                  "developer-experience/import-custom-models"
                 ]
               }
             ]


### PR DESCRIPTION
## Problem

Fixes #511. `docs-vnext/docs.json` had 249/526 (47%) `.mdx` pages missing a navigation entry, concentrated in `agent-service/` (95/95, 100% missing) and `foundry-models/` (112 missing), with smaller gaps in `developer-experience/`, `observability/`, `agents/`, `guardrails/`, `security/`, `best-practices/`, `models/`, `responsible-ai/`, `setup/`, `get-started/`, `manage/`, and `what-is-microsoft-foundry/`.

## Approach

Per the issue's guidance, this does **not** rerun `scripts/build_navigation.py` against `docs-vnext/` (that generator builds from the upstream `manifest.json` TOC and would risk clobbering or missing docs-vnext-only structure). Instead, `docs-vnext/docs.json` was hand-edited via a small script that inserts new nav entries in place, preserving all existing entries and ordering.

### Additions

- New group **"What is Microsoft Foundry"** — 1 page for the new `what-is-microsoft-foundry/` directory.
- New group **"Foundry Agent Service (new)"** — all 95 `agent-service/*` pages, organized into themed subgroups (Quickstarts, Hosted agents, Voice agents, System messages, Publish agents, Agent catalog, Manage/Built-in tools, Knowledge and retrieval, Foundry IQ, Memory, Protocols, Routines and skills, Agent optimizer, Tracing and monitoring).
- New group **"Foundry Models (new)"** — all 112 `foundry-models/*` pages, organized into subgroups mirroring the existing "Foundry Models" group's themes (Model catalog, Model router, Deploy models, Model support, Generate text, Embeddings, Vision and image, Audio and speech, Scale inference, Benchmark models, Integrate, Fine-tuning, Quotas and limits, Governance and lifecycle).
- The remaining 26 orphaned pages (across 11 smaller directories) were folded into their existing corresponding groups/subgroups (e.g. `agents/development/prompt-agent` → new "Prompt agents" subgroup under "Foundry Agent Service"; new "Task adherence" subgroup under guardrails; etc.).

### Exceptions respected

- `docs-vnext/reference/glossary.mdx` already had a nav entry — untouched.
- `docs-vnext/slides/**` does not currently exist under `docs-vnext/` (there's an unrelated top-level `slides/` dir for slide-deck generation) — no action needed.

## Verification

- From-scratch audit (walk all `.mdx` files, excluding `snippets/`, `openapi/`, `static/`, `.mintlify/`, `images/`, diff against all page paths reachable from `navigation` in `docs.json`): **526/526 pages now have a nav entry, 0 orphans, 0 broken nav references** (previously 249 orphans).
- `python -m json.tool docs-vnext/docs.json` — valid JSON.
- `git diff --stat` — only `docs-vnext/docs.json` changed; canonical `docs/docs.json` untouched.
- `pytest` — 115 passed.

Closes #511.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>