### PR TITLE
Mintlify and FastMCP agent-readiness surface update

### DIFF
--- a/.github/agent-harness-map.md
+++ b/.github/agent-harness-map.md
@@ -48,8 +48,10 @@ Confidence: High for repo-local inventory and harness recommendations; Medium fo
 | `fastmcp.json` | FastMCP packaging metadata | Server name, version, description, entrypoint, and deployment transport for the primary server. |
 | `foundry_docs_mcp/_server_factory.py` | MCP server implementation | Source of truth for primary/vnext FastMCP tools, resources, prompts, lifespan search indexes, and Azure hybrid fallback behavior. |
 | `scripts/*.py` | Deterministic automation | Source of truth for model catalog scrape, docs sync/conversion, indexing, retrieval testbench, A/B/C/D eval, and answer-quality eval. |
-| `tests/*.py` and `tests/*.json` | Deterministic validation | Unit tests plus retrieval and answer-quality fixtures; dependent tranches should extend these before relying on reports. |
-| `README.md` | Human setup reference | Installation, MCP tools, Azure configuration, pipeline scripts, and ongoing automation summary. |
+| `tests/*.py` and `tests/*.json` | Deterministic validation | Unit tests plus retrieval and answer-quality fixtures; dependent tranches should extend these before relying on reports. Includes `tests/test_mcp_server_inspection.py` (#474): deterministic FastMCP in-memory client tests for both servers. |
+| `scripts/check_mcp_discovery.py` | Deterministic MCP/Mintlify readiness report | #474: local FastMCP inventory (in-memory, verified live), hosted Mintlify MCP/skill/llms endpoint checks (live HTTP, best-effort), and Azure-backed hybrid config presence. Consumed by `scripts/eval_report.py --mcp-discovery`. |
+| `.github/workflows/mintlify-fastmcp-readiness.yml` | Deterministic (non-gh-aw) GitHub Actions workflow | #474: hard-gates on `tests/test_mcp_server_inspection.py`; reports (non-blocking) `mint validate`/`broken-links`/`a11y` per docs directory and hosted MCP discovery state. |
+| `README.md` | Human setup reference | Installation, MCP tools/resources/prompts, Azure configuration, pipeline scripts, agent-readiness (MCP + Mintlify discovery), and ongoing automation summary. |
 
 ## Workflow and automation inventory
 
@@ -104,15 +106,24 @@ The gh-aw fleet-upgrade tranche (#477-#481) is intentionally scoped to **mechani
 
 | Gap | Impact | Recommended route |
 | --- | --- | --- |
-| No committed FastMCP inspection tests for both servers | MCP readiness can regress without failing CI. | Use existing FastMCP client and pytest patterns; add targeted tests in #474. |
+| No committed FastMCP inspection tests for both servers | MCP readiness can regress without failing CI. | ~~Use existing FastMCP client and pytest patterns; add targeted tests in #474.~~ **Resolved in #474**: `tests/test_mcp_server_inspection.py` (22 deterministic in-memory `Client(server)` assertions covering both servers) is a hard gate in `.github/workflows/mintlify-fastmcp-readiness.yml`. |
 | Eval harness does not enforce selected MCP/server source per row | Answer-quality matrix can claim a source without actually constraining the agent to it. | Keep deterministic; repair `scripts/run_docs_eval.py` in #470 before final rerun. |
 | Azure hybrid mode can fall back to local in server/runtime paths | Final evidence could omit the required Azure-backed variant. | Add explicit required mode/setup diagnostics in #470; keep local fallback only for non-final dev mode. |
 | gh-aw report prompts perform unbounded shell work | Scheduled agents can time out or produce inconsistent reports. | Move collection to deterministic scripts/custom prep steps; agent summarizes bounded artifacts in #469 and #471. |
-| Mintlify dashboard CI/readiness settings are not represented in repo | Agents cannot distinguish missing setup from passing readiness. | In #474, inspect hosted endpoints and document dashboard-dependent checks as "not configured" unless verifiable. |
+| Mintlify dashboard CI/readiness settings are not represented in repo | Agents cannot distinguish missing setup from passing readiness. | ~~In #474, inspect hosted endpoints and document dashboard-dependent checks as "not configured" unless verifiable.~~ **Resolved in #474**: `scripts/check_mcp_discovery.py` live-checks hosted `/mcp`, `/.well-known/mcp`, `/.well-known/mcp/server-card.json`, `/skill.md`, `/llms.txt`, `/llms-full.txt`; `mint score <url>` is reported as **not configured** since it requires an authenticated Mintlify account (`mint login`), not fabricated. |
 | No reusable committed skill for this repo's evaluation rerun | Future agents may repeat context-heavy setup from issues. | After #470/#474 stabilize, consider `skill-creator` for a repo skill only if the workflow repeats. |
 | Protected workflow-file PR behavior is unclear for automation | Agents could attempt unsafe workflow-file edits or PRs. | Keep gh-aw workflow mutations in human-owned implementation sessions; use safe-output fallback issue/report paths for scheduled agents. |
+| `mint validate`/`mint broken-links` surfaced real, pre-existing content debt (#474 finding) | `docs/broken-links` found dangling relative links across `docs/`; `docs-vnext validate` currently fails (OpenAPI page generation produces an invalid overlong filename from a spec description). | Do not fix as part of #474 (MCP/readiness surface only). Track as follow-on docs-content work; `.github/workflows/mintlify-fastmcp-readiness.yml` reports these non-blockingly (`continue-on-error`) so they are visible without gating merges. |
 
-## Human-gated actions
+### #474 implementation evidence
+
+- `tests/test_mcp_server_inspection.py` — 22 deterministic FastMCP in-memory `Client(server)` tests (no LLM) asserting server name/version/instructions, `ping`, the exact tool/prompt name sets, tool input schemas + `readOnlyHint` annotations, and resource/resource-template URIs for both `foundry-docs` and `foundry-docs-vnext`.
+- `scripts/check_mcp_discovery.py` — deterministic report distinguishing local FastMCP (verified live via in-memory client), hosted Mintlify MCP (live HTTP checks against `/mcp`, `/.well-known/mcp`, `/.well-known/mcp/server-card.json`, `/skill.md`, `/llms.txt`, `/llms-full.txt`), and Azure-backed hybrid search (env-var configuration presence only, never a fabricated live-call result). Verified live against `hobbyist-e43fa225.mintlify.app` during implementation: `/mcp` → `405` (present, POST-only streamable-HTTP transport); the other five endpoints → `200`; `mint score <url>` → requires `mint login` (reported not configured, not guessed).
+- `scripts/eval_report.py --mcp-discovery <path>` — new "MCP & Tool Discovery State" report section; explicitly states "no report supplied" rather than fabricating pass/fail when the discovery JSON is absent.
+- `.github/workflows/mintlify-fastmcp-readiness.yml` — new deterministic (non-gh-aw) GitHub Actions workflow: FastMCP inspection tests as a hard gate; MCP discovery report and Mintlify CLI (`mint validate`/`broken-links`/`a11y`, pinned `mint@4.2.513`) as non-blocking, always-reported job-summary output, run per-directory (`docs/`, `docs-vnext/`) since invoking `mint` from the repo root incorrectly globs `raw_docs/`/`research/` via the root `docs.json`.
+- `README.md` — documents the full tool/resource/prompt inventory (shared by both servers via `_server_factory.build_server()`), how to run the deterministic tests and discovery script, and current live-checked hosted-discovery state.
+
+
 
 These actions require explicit human approval or an already-approved gh-aw safe-output path with bounded payloads:
 

--- a/.github/workflows/mintlify-fastmcp-readiness.yml
+++ b/.github/workflows/mintlify-fastmcp-readiness.yml
@@ -1,0 +1,158 @@
+name: Mintlify & FastMCP Agent Readiness
+
+# Deterministic MCP inspection tests plus docs/readiness workflow guidance for
+# issue #474. This workflow has two kinds of jobs:
+#
+#   - fastmcp-inspection: a hard gate. Runs the deterministic FastMCP in-memory
+#     client tests (tests/test_mcp_server_inspection.py) that assert real tool/
+#     resource/prompt/schema/metadata facts for both servers -- no LLM involved.
+#
+#   - mcp-discovery-report / mintlify-cli-checks: reporting jobs. They surface
+#     current Mintlify CLI readiness (validate/broken-links/a11y) and hosted
+#     MCP discovery state (docs://mcp, /.well-known/mcp, skill.md, llms.txt) as
+#     job summaries and artifacts. These are informational (continue-on-error)
+#     because docs/ and docs-vnext/ content quality is owned by separate
+#     tranches (see .github/agent-harness-map.md); this workflow reports
+#     current state rather than gating merges on pre-existing content debt.
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'docs-vnext/**'
+      - 'docs.json'
+      - 'foundry_docs_mcp/**'
+      - 'foundry_docs_vnext_mcp/**'
+      - 'tests/test_mcp_server_inspection.py'
+      - 'scripts/check_mcp_discovery.py'
+      - '.github/workflows/mintlify-fastmcp-readiness.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - 'docs-vnext/**'
+      - 'docs.json'
+      - 'foundry_docs_mcp/**'
+      - 'foundry_docs_vnext_mcp/**'
+  schedule:
+    - cron: "0 8 * * 1" # Weekly Monday 08:00 UTC -- catches hosted-site drift
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fastmcp-inspection:
+    name: FastMCP in-memory client inspection (hard gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run deterministic MCP server inspection tests
+        run: python -m pytest tests/test_mcp_server_inspection.py -v
+
+  mcp-discovery-report:
+    name: MCP & tool discovery state report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -e .
+
+      - name: Run MCP discovery report
+        run: |
+          python scripts/check_mcp_discovery.py \
+            --output tests/eval_results/mcp_discovery.json \
+            --summary-output tests/eval_results/mcp_discovery.md
+
+      - name: Publish discovery summary
+        if: always()
+        run: cat tests/eval_results/mcp_discovery.md >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+
+      - name: Upload discovery report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: mcp-discovery-report
+          path: tests/eval_results/mcp_discovery.*
+          retention-days: 30
+
+  mintlify-cli-checks:
+    name: Mintlify CLI readiness (${{ matrix.docs_dir }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        docs_dir: [ docs, docs-vnext ]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      # Pinned for deterministic output; bump intentionally alongside a
+      # re-check of docs/ and docs-vnext/ readiness state.
+      - name: Mint validate (build validation, strict mode)
+        working-directory: ${{ matrix.docs_dir }}
+        continue-on-error: true
+        run: npx --yes mint@4.2.513 validate | tee "$GITHUB_WORKSPACE/mint-validate-${{ matrix.docs_dir }}.log"
+
+      - name: Mint broken-links
+        working-directory: ${{ matrix.docs_dir }}
+        continue-on-error: true
+        run: npx --yes mint@4.2.513 broken-links | tee "$GITHUB_WORKSPACE/mint-broken-links-${{ matrix.docs_dir }}.log"
+
+      - name: Mint accessibility check
+        working-directory: ${{ matrix.docs_dir }}
+        continue-on-error: true
+        run: npx --yes mint@4.2.513 a11y | tee "$GITHUB_WORKSPACE/mint-a11y-${{ matrix.docs_dir }}.log"
+
+      - name: Publish readiness summary
+        if: always()
+        run: |
+          {
+            echo "### Mintlify CLI readiness — ${{ matrix.docs_dir }}/"
+            echo
+            echo "_Reported as-is; pre-existing content issues are tracked separately"
+            echo "and are not gated by this workflow. See .github/agent-harness-map.md._"
+            echo
+            for check in validate broken-links a11y; do
+              echo "<details><summary><code>mint $check</code></summary>"
+              echo
+              echo '```'
+              tail -n 40 "mint-$check-${{ matrix.docs_dir }}.log" 2>/dev/null || echo "(no output captured)"
+              echo '```'
+              echo "</details>"
+              echo
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload readiness logs
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: mintlify-cli-readiness-${{ matrix.docs_dir }}
+          path: mint-*-${{ matrix.docs_dir }}.log
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -29,6 +29,85 @@ foundry-docs
 When Azure Search variables are configured, `search_docs` uses hybrid retrieval
 (keyword + vector + semantic reranking). Otherwise it falls back to local TF-IDF.
 
+Both servers (`foundry_docs_mcp` over `docs/`, `foundry_docs_vnext_mcp` over
+`docs-vnext/`) expose the same tool/resource/prompt surface — they differ only
+in the content set and URI prefix, since both are built by
+`foundry_docs_mcp._server_factory.build_server()`.
+
+| Resource / template | Description |
+|---|---|
+| `docs://navigation` (`docs://vnext/navigation`) | Full Mintlify navigation JSON |
+| `docs://page/{section}/{page}` | Read a page by section/page |
+| `docs://page/{section}/{subsection}/{page}` | Read a nested page |
+
+| Prompt | Description |
+|---|---|
+| `explain_foundry_concept(concept)` | Ground an explanation of a Foundry concept in the docs |
+| `build_foundry_agent(agent_type, tools)` | Step-by-step agent-building guidance |
+| `compare_foundry_options(option_a, option_b, context)` | Compare two Foundry options |
+
+## Agent Readiness: MCP & Mintlify Discovery
+
+This repo verifies its own agent-readiness surface deterministically instead of
+relying on an LLM to "vibe-check" it. See `.github/agent-harness-map.md` for the
+full harness routing and current known gaps.
+
+**FastMCP server inspection (deterministic, in-memory, no LLM):**
+
+```bash
+pytest tests/test_mcp_server_inspection.py -v
+```
+
+Uses FastMCP's standard in-memory `Client(server)` testing pattern
+(<https://gofastmcp.com/development/tests>) to assert tool/resource/prompt
+inventories, schemas, and server metadata for both `foundry-docs` and
+`foundry-docs-vnext`. This is the hard gate in
+[`.github/workflows/mintlify-fastmcp-readiness.yml`](.github/workflows/mintlify-fastmcp-readiness.yml).
+
+**MCP/tool discovery state report (local + hosted + Azure-backed):**
+
+```bash
+python scripts/check_mcp_discovery.py --output tests/eval_results/mcp_discovery.json
+```
+
+Reports, for each variant, only what was actually verified — it never
+fabricates a "pass":
+
+- **Local FastMCP** (`foundry-docs`, `foundry-docs-vnext`) — verified live via
+  an in-memory client.
+- **Hosted Mintlify MCP** (the docs-vnext site configured in `.mcp.json`) —
+  live HTTP checks against `/mcp`, `/.well-known/mcp`,
+  `/.well-known/mcp/server-card.json`, `/skill.md`, `/llms.txt`, and
+  `/llms-full.txt`. As of this writing: `/mcp` responds `405` to a plain `GET`
+  (present, POST-only streamable-HTTP transport); the other five endpoints
+  return `200`. `mint score <url>` (Mintlify's hosted agent-readiness scoring)
+  requires an authenticated Mintlify account (`mint login`) and is reported as
+  **not configured** rather than guessed.
+- **Azure-backed hybrid search** — reports whether `AZURE_SEARCH_ENDPOINT` /
+  `AZURE_AI_PROJECT_ENDPOINT` are configured (env-var presence only; this does
+  not make a live Azure call).
+
+Pass a discovery JSON to `scripts/eval_report.py --mcp-discovery <path>` to
+include an "MCP & Tool Discovery State" section in the eval report, alongside
+the existing local/hosted-Mintlify/FastMCP/Azure-backed comparison rows.
+
+**Mintlify CLI readiness (`mint validate`, `mint broken-links`, `mint a11y`):**
+
+These must be run with `docs/` or `docs-vnext/` as the working directory —
+running from the repo root picks up unrelated content (`raw_docs/`, `research/`,
+etc.) via the root `docs.json`.
+
+```bash
+cd docs && npx --yes mint validate && npx --yes mint broken-links && npx --yes mint a11y
+cd docs-vnext && npx --yes mint validate && npx --yes mint broken-links && npx --yes mint a11y
+```
+
+These run as informational (non-blocking) checks in
+[`.github/workflows/mintlify-fastmcp-readiness.yml`](.github/workflows/mintlify-fastmcp-readiness.yml)
+on docs changes and weekly — they report current state rather than gate merges,
+since `docs/`/`docs-vnext/` content quality is owned by separate tranches. See
+`.github/agent-harness-map.md` for currently known content gaps this surfaced.
+
 ## Azure Configuration
 
 The server uses Azure AI Foundry project endpoints and the OpenAI Responses API

--- a/scripts/check_mcp_discovery.py
+++ b/scripts/check_mcp_discovery.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Report current MCP/tool discovery state across all docs-serving variants.
+
+This is a deterministic inspection script -- no LLM is involved. It answers
+"what MCP surface does an agent actually see right now?" for each variant
+this repository serves documentation through, and is careful to distinguish
+what was *verified live* from what could not be reached or is simply not
+configured. It never fabricates a "pass" for a check it could not run.
+
+Variants covered:
+  - local-fastmcp-docs        FastMCP server over docs/ (in-memory client)
+  - local-fastmcp-vnext       FastMCP server over docs-vnext/ (in-memory client)
+  - hosted-mintlify           Mintlify-hosted docs site's own MCP/AI-readiness
+                              endpoints (live HTTP checks, best-effort)
+  - azure-backed-hybrid       Whether Azure AI Search hybrid retrieval mode is
+                              configured for search_docs (env-var presence
+                              only -- this does not make a live Azure call)
+
+Usage:
+    python scripts/check_mcp_discovery.py
+    python scripts/check_mcp_discovery.py --output tests/eval_results/mcp_discovery.json
+    python scripts/check_mcp_discovery.py --hosted-base-url https://example.mintlify.app
+    python scripts/check_mcp_discovery.py --skip-hosted   # local-only, no network
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+from fastmcp import Client
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Default hosted docs-vnext site, as configured in .mcp.json for this repo.
+DEFAULT_HOSTED_BASE_URL = "https://hobbyist-e43fa225.mintlify.app"
+
+# Endpoints Mintlify documents as its agent-readiness/MCP-discovery surface.
+# Source: https://www.mintlify.com/docs/ai/model-context-protocol,
+#         https://www.mintlify.com/docs/ai/skillmd,
+#         https://www.mintlify.com/docs/ai/llmstxt
+HOSTED_ENDPOINTS = [
+    "/mcp",
+    "/.well-known/mcp",
+    "/.well-known/mcp/server-card.json",
+    "/skill.md",
+    "/llms.txt",
+    "/llms-full.txt",
+]
+
+
+async def _discover_local_server(server, expected_name: str) -> dict[str, Any]:
+    """Inspect one FastMCP server in-memory. Never raises -- errors are captured."""
+    try:
+        async with Client(server) as client:
+            info = client.initialize_result.serverInfo
+            tools = await client.list_tools()
+            resources = await client.list_resources()
+            templates = await client.list_resource_templates()
+            prompts = await client.list_prompts()
+            return {
+                "status": "verified",
+                "server_name": info.name,
+                "server_version": info.version,
+                "instructions_present": bool(client.initialize_result.instructions),
+                "ping_ok": await client.ping(),
+                "tools": sorted(t.name for t in tools),
+                "resources": sorted(str(r.uri) for r in resources),
+                "resource_templates": sorted(t.uriTemplate for t in templates),
+                "prompts": sorted(p.name for p in prompts),
+            }
+    except Exception as exc:  # noqa: BLE001 - report, don't crash the whole run
+        return {
+            "status": "error",
+            "server_name": expected_name,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def _classify_http(status_code: int) -> str:
+    if 200 <= status_code < 300:
+        return "available"
+    if status_code == 404:
+        return "not_found"
+    if status_code == 405:
+        # Streamable-HTTP MCP transports only accept POST/initialize; a 405 on a
+        # plain GET means the endpoint exists and is routed, just not GET-able.
+        return "present_method_not_allowed"
+    if status_code == 401 or status_code == 403:
+        return "present_requires_auth"
+    return f"http_{status_code}"
+
+
+async def _check_hosted_endpoints(base_url: str, timeout_s: float) -> dict[str, Any]:
+    """Best-effort live HTTP checks against a hosted Mintlify docs site.
+
+    Every result is either a real HTTP status classification or an explicit
+    'unreachable' -- this function never guesses that an endpoint is present.
+    """
+    results: dict[str, Any] = {}
+    async with httpx.AsyncClient(timeout=timeout_s, follow_redirects=True) as http_client:
+        for path in HOSTED_ENDPOINTS:
+            url = base_url.rstrip("/") + path
+            # The streamable-HTTP MCP transport expects this Accept header on /mcp;
+            # other endpoints are plain JSON/text and must not be given it, since
+            # some Mintlify edge routing 404s a JSON endpoint when it's present.
+            headers = {"Accept": "application/json, text/event-stream"} if path == "/mcp" else {}
+            try:
+                resp = await http_client.get(url, headers=headers)
+                entry: dict[str, Any] = {
+                    "http_status": resp.status_code,
+                    "status": _classify_http(resp.status_code),
+                    "content_type": resp.headers.get("content-type", ""),
+                }
+                if path == "/.well-known/mcp/server-card.json" and resp.status_code == 200:
+                    try:
+                        card = resp.json()
+                        entry["server_card_name"] = card.get("name")
+                        entry["server_card_tools"] = sorted(
+                            t.get("name", "") for t in card.get("tools", [])
+                        )
+                    except (ValueError, json.JSONDecodeError):
+                        entry["note"] = "200 response was not valid JSON"
+                results[path] = entry
+            except httpx.RequestError as exc:
+                results[path] = {
+                    "status": "unreachable",
+                    "note": f"{type(exc).__name__}: network unreachable in this environment",
+                }
+    return results
+
+
+def _azure_hybrid_config_state() -> dict[str, Any]:
+    """Report whether Azure AI Search hybrid mode is *configured*.
+
+    This intentionally checks environment variables only. It does not attempt
+    a live Azure Search/OpenAI call, so it cannot claim the hybrid path is
+    verified working -- only that credentials/endpoints are present.
+    """
+    endpoint_configured = bool(os.environ.get("AZURE_SEARCH_ENDPOINT"))
+    project_configured = bool(os.environ.get("AZURE_AI_PROJECT_ENDPOINT"))
+    return {
+        "status": "configured" if (endpoint_configured and project_configured) else "not_configured",
+        "azure_search_endpoint_set": endpoint_configured,
+        "azure_ai_project_endpoint_set": project_configured,
+        "index_name_docs": os.environ.get("AZURE_SEARCH_INDEX_NAME", "foundry-docs (default)"),
+        "index_name_vnext": os.environ.get("AZURE_SEARCH_VNEXT_INDEX_NAME", "foundry-docs-vnext (default)"),
+        "note": (
+            "Presence of endpoint env vars only -- this does not verify a live Azure "
+            "call succeeds. Run scripts/run_testbench.py against a configured environment "
+            "for a verified-live check."
+        ),
+    }
+
+
+async def run_discovery(hosted_base_url: str | None, timeout_s: float) -> dict[str, Any]:
+    from foundry_docs_mcp.server import mcp as docs_mcp
+    from foundry_docs_vnext_mcp.server import mcp as vnext_mcp
+
+    report: dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "local_fastmcp": {
+            "foundry-docs": await _discover_local_server(docs_mcp, "foundry-docs"),
+            "foundry-docs-vnext": await _discover_local_server(vnext_mcp, "foundry-docs-vnext"),
+        },
+        "azure_backed_hybrid": _azure_hybrid_config_state(),
+    }
+
+    if hosted_base_url:
+        report["hosted_mintlify"] = {
+            "base_url": hosted_base_url,
+            "endpoints": await _check_hosted_endpoints(hosted_base_url, timeout_s),
+            "note": (
+                "'mint score <url>' (Mintlify agent-readiness scoring) requires an "
+                "authenticated Mintlify account (`mint login`) and is not run here -- "
+                "report as not configured/unavailable rather than fabricating a score."
+            ),
+        }
+    else:
+        report["hosted_mintlify"] = {"status": "skipped", "note": "hosted checks disabled via --skip-hosted"}
+
+    return report
+
+
+def render_summary(report: dict[str, Any]) -> str:
+    """Render a short human-readable summary distinguishing each variant."""
+    lines = ["# MCP & Tool Discovery State", "", f"_Generated: {report['generated_at']}_", ""]
+
+    lines.append("## Local FastMCP servers (in-memory, verified live)")
+    for name, data in report["local_fastmcp"].items():
+        if data["status"] == "verified":
+            lines.append(
+                f"- **{name}** v{data['server_version']}: {len(data['tools'])} tools, "
+                f"{len(data['resources'])} resources, {len(data['resource_templates'])} resource templates, "
+                f"{len(data['prompts'])} prompts. Tools: {', '.join(data['tools'])}"
+            )
+        else:
+            lines.append(f"- **{name}**: ERROR -- {data.get('error', 'unknown error')}")
+
+    lines.append("")
+    lines.append("## Hosted Mintlify docs site")
+    hosted = report["hosted_mintlify"]
+    if hosted.get("status") == "skipped":
+        lines.append(f"- Skipped: {hosted['note']}")
+    else:
+        lines.append(f"- Base URL: {hosted['base_url']}")
+        for path, entry in hosted["endpoints"].items():
+            extra = ""
+            if "server_card_tools" in entry:
+                extra = f" (tools: {', '.join(entry['server_card_tools'])})"
+            lines.append(f"  - `{path}` -> {entry['status']}{extra}")
+        lines.append(f"- {hosted['note']}")
+
+    lines.append("")
+    lines.append("## Azure-backed hybrid search")
+    azure = report["azure_backed_hybrid"]
+    lines.append(f"- Status: **{azure['status']}**")
+    lines.append(f"- {azure['note']}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--output", default=None, help="Write JSON report to this path")
+    parser.add_argument("--summary-output", default=None, help="Write markdown summary to this path")
+    parser.add_argument(
+        "--hosted-base-url", default=DEFAULT_HOSTED_BASE_URL,
+        help="Base URL of the hosted Mintlify docs site to check (default: repo's configured site)",
+    )
+    parser.add_argument("--skip-hosted", action="store_true", help="Skip live hosted-site HTTP checks")
+    parser.add_argument("--timeout", type=float, default=20.0, help="Per-request timeout for hosted checks")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    hosted_base_url = None if args.skip_hosted else args.hosted_base_url
+
+    report = asyncio.run(run_discovery(hosted_base_url, args.timeout))
+    summary = render_summary(report)
+
+    print(summary)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"JSON report saved to {output_path}", file=sys.stderr)
+
+    if args.summary_output:
+        summary_path = Path(args.summary_output)
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(summary, encoding="utf-8")
+        print(f"Summary saved to {summary_path}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/eval_report.py
+++ b/scripts/eval_report.py
@@ -7,6 +7,8 @@ Produces a report comparing 4 MCP servers across 2 models with:
 - Category breakdown
 - Model agreement analysis
 - Regression detection vs. previous runs
+- MCP/tool discovery state (local FastMCP, hosted Mintlify, Azure-backed hybrid)
+  when a scripts/check_mcp_discovery.py report is available
 """
 
 import argparse
@@ -14,9 +16,11 @@ import json
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 RESULTS_DIR = PROJECT_ROOT / "tests" / "eval_results"
+DEFAULT_MCP_DISCOVERY_FILE = RESULTS_DIR / "mcp_discovery.json"
 
 SERVER_LABELS = {
     "microsoft-learn": "MS Learn (Control A)",
@@ -170,7 +174,60 @@ def generate_category_breakdown(aggregates: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def generate_report(scored_data: dict) -> str:
+def generate_mcp_discovery_section(discovery: dict[str, Any] | None) -> str:
+    """Render the MCP/tool discovery state section.
+
+    `discovery` is the JSON produced by scripts/check_mcp_discovery.py. If it
+    is missing, this section says so explicitly rather than fabricating any
+    discovery state -- absence of data is reported as absence, not as pass.
+    """
+    if discovery is None:
+        return (
+            "*No MCP discovery report was supplied for this run.* "
+            "Run `python scripts/check_mcp_discovery.py --output "
+            "tests/eval_results/mcp_discovery.json` and pass `--mcp-discovery` "
+            "to this script to include current MCP/tool discovery state.\n"
+        )
+
+    lines: list[str] = [f"_Discovery generated: {discovery.get('generated_at', 'unknown')}_\n"]
+
+    lines.append("**Local FastMCP servers** (in-memory client, verified live):\n")
+    for name, data in discovery.get("local_fastmcp", {}).items():
+        if data.get("status") == "verified":
+            lines.append(
+                f"- `{name}` v{data.get('server_version')}: "
+                f"{len(data.get('tools', []))} tools, "
+                f"{len(data.get('resources', []))} resources, "
+                f"{len(data.get('resource_templates', []))} resource templates, "
+                f"{len(data.get('prompts', []))} prompts"
+            )
+        else:
+            lines.append(f"- `{name}`: **error** -- {data.get('error', 'unknown error')}")
+    lines.append("")
+
+    lines.append("**Hosted Mintlify docs site**:\n")
+    hosted = discovery.get("hosted_mintlify", {})
+    if hosted.get("status") == "skipped":
+        lines.append(f"- Not checked: {hosted.get('note', 'skipped')}")
+    elif "endpoints" in hosted:
+        lines.append(f"- Base URL: {hosted.get('base_url')}")
+        for path, entry in hosted["endpoints"].items():
+            lines.append(f"  - `{path}` → {entry.get('status')}")
+        lines.append(f"- {hosted.get('note', '')}")
+    else:
+        lines.append("- Not configured/unavailable (no hosted discovery data in this report).")
+    lines.append("")
+
+    lines.append("**Azure-backed hybrid search**:\n")
+    azure = discovery.get("azure_backed_hybrid", {})
+    lines.append(f"- Status: **{azure.get('status', 'unknown')}**")
+    if azure.get("note"):
+        lines.append(f"- {azure['note']}")
+
+    return "\n".join(lines) + "\n"
+
+
+def generate_report(scored_data: dict, discovery: dict[str, Any] | None = None) -> str:
     """Generate the full markdown report."""
     metadata = scored_data.get("metadata", {})
     aggregates = scored_data.get("aggregates", {})
@@ -207,6 +264,12 @@ def generate_report(scored_data: dict) -> str:
 
 ---
 
+## MCP & Tool Discovery State
+
+{generate_mcp_discovery_section(discovery)}
+
+---
+
 ## Methodology
 
 Each evaluation scenario poses a real-world Microsoft Foundry documentation question to a frontier model,
@@ -236,6 +299,13 @@ def _parse_args() -> argparse.Namespace:
         "--output", default=None,
         help="Output file path (default: stdout)"
     )
+    parser.add_argument(
+        "--mcp-discovery", default=None,
+        help=(
+            "Path to a JSON report from scripts/check_mcp_discovery.py to include "
+            f"as an MCP/tool discovery section (default: {DEFAULT_MCP_DISCOVERY_FILE} if present)"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -250,14 +320,22 @@ def main():
     with open(input_path) as f:
         scored_data = json.load(f)
 
-    report = generate_report(scored_data)
+    discovery_path = Path(args.mcp_discovery) if args.mcp_discovery else DEFAULT_MCP_DISCOVERY_FILE
+    discovery = None
+    if discovery_path.exists():
+        with open(discovery_path) as f:
+            discovery = json.load(f)
+    elif args.mcp_discovery:
+        print(f"Warning: MCP discovery file not found: {discovery_path}", file=sys.stderr)
+
+    report = generate_report(scored_data, discovery=discovery)
 
     if args.output:
         output_path = Path(args.output)
-        output_path.write_text(report)
+        output_path.write_text(report, encoding="utf-8")
         print(f"Report saved to {output_path}", file=sys.stderr)
     else:
-        print(report)
+        sys.stdout.buffer.write(report.encode("utf-8"))
 
 
 if __name__ == "__main__":

--- a/tests/test_mcp_server_inspection.py
+++ b/tests/test_mcp_server_inspection.py
@@ -1,0 +1,204 @@
+"""Deterministic FastMCP in-memory client tests for both foundry-docs servers.
+
+Uses FastMCP's standard in-memory testing pattern (`Client(server)` connected
+directly to the server object, no network/process boundary) to assert real
+MCP protocol facts for the primary (docs/) and vnext (docs-vnext/) servers:
+server metadata, tool/resource/prompt inventories, and tool schemas.
+
+These are deterministic protocol-level assertions, not LLM "vibe tests" --
+every check calls the real MCP client methods (list_tools, list_resources,
+list_resource_templates, list_prompts, get_prompt, ping) and asserts on their
+structured results. See https://gofastmcp.com/development/tests for the
+upstream in-memory testing pattern this follows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any, TypeVar
+
+import pytest
+from fastmcp import Client, FastMCP
+
+from foundry_docs_mcp.server import mcp as docs_mcp
+from foundry_docs_vnext_mcp.server import mcp as vnext_mcp
+
+T = TypeVar("T")
+
+# Tool/prompt inventories are the deterministic regression gate: if a tool,
+# resource, or prompt is added/removed/renamed, these tests fail and force an
+# explicit update, keeping MCP discovery state truthful for agents.
+EXPECTED_TOOL_NAMES = {
+    "search_docs",
+    "submit_search_feedback",
+    "get_doc",
+    "list_sections",
+    "get_section",
+}
+
+EXPECTED_PROMPT_NAMES = {
+    "explain_foundry_concept",
+    "build_foundry_agent",
+    "compare_foundry_options",
+}
+
+# server object, resource URI prefix, expected server name/version
+SERVERS: dict[str, tuple[FastMCP, str, str]] = {
+    "foundry-docs": (docs_mcp, "docs://", "0.1.0"),
+    "foundry-docs-vnext": (vnext_mcp, "docs://vnext/", "0.1.0"),
+}
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    """Run an async coroutine from a synchronous pytest test function.
+
+    Avoids requiring pytest-asyncio configuration/marks for this module.
+    """
+    return asyncio.run(coro)
+
+
+async def _with_client(server: FastMCP, fn: Callable[[Client], Awaitable[T]]) -> T:
+    async with Client(server) as client:
+        return await fn(client)
+
+
+@pytest.mark.parametrize("server_name", sorted(SERVERS))
+class TestServerMetadata:
+    """Server identity/instructions must be inspectable without calling any tool."""
+
+    def test_server_name_and_version(self, server_name: str) -> None:
+        server, _prefix, expected_version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            info = client.initialize_result.serverInfo
+            assert info.name == server_name
+            assert info.version == expected_version
+
+        _run(_with_client(server, check))
+
+    def test_instructions_describe_workflow(self, server_name: str) -> None:
+        server, _prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            instructions = client.initialize_result.instructions
+            assert instructions
+            # Instructions must name the discovery tool so agents know where to start.
+            assert "search_docs" in instructions
+
+        _run(_with_client(server, check))
+
+    def test_ping(self, server_name: str) -> None:
+        server, _prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            assert await client.ping() is True
+
+        _run(_with_client(server, check))
+
+
+@pytest.mark.parametrize("server_name", sorted(SERVERS))
+class TestTools:
+    """Tool inventory and schemas are the deterministic MCP contract for agents."""
+
+    def test_expected_tools_present(self, server_name: str) -> None:
+        server, _prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            tools = await client.list_tools()
+            names = {t.name for t in tools}
+            assert names == EXPECTED_TOOL_NAMES
+
+        _run(_with_client(server, check))
+
+    def test_search_docs_schema_and_annotations(self, server_name: str) -> None:
+        server, _prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            tools = {t.name: t for t in await client.list_tools()}
+            search_docs = tools["search_docs"]
+            schema = search_docs.inputSchema
+            assert schema["required"] == ["query"]
+            assert schema["properties"]["query"]["type"] == "string"
+            assert schema["properties"]["limit"]["default"] == 10
+            # Read-only vs. mutating tools must be distinguishable via annotations
+            # so agents can tell discovery calls from feedback-recording calls.
+            assert search_docs.annotations.readOnlyHint is True
+            assert tools["submit_search_feedback"].annotations.readOnlyHint is False
+
+        _run(_with_client(server, check))
+
+    def test_get_doc_schema_requires_path(self, server_name: str) -> None:
+        server, _prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            tools = {t.name: t for t in await client.list_tools()}
+            schema = tools["get_doc"].inputSchema
+            assert schema["required"] == ["path"]
+            assert schema["properties"]["path"]["type"] == "string"
+
+        _run(_with_client(server, check))
+
+    def test_get_section_schema_requires_section(self, server_name: str) -> None:
+        server, _prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            tools = {t.name: t for t in await client.list_tools()}
+            schema = tools["get_section"].inputSchema
+            assert schema["required"] == ["section"]
+
+        _run(_with_client(server, check))
+
+
+@pytest.mark.parametrize("server_name", sorted(SERVERS))
+class TestResources:
+    """Resource/resource-template discovery, scoped to this server's URI prefix."""
+
+    def test_navigation_resource_present(self, server_name: str) -> None:
+        server, prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            resources = await client.list_resources()
+            uris = {str(r.uri) for r in resources}
+            assert f"{prefix}navigation" in uris
+
+        _run(_with_client(server, check))
+
+    def test_page_resource_templates_present(self, server_name: str) -> None:
+        server, prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            templates = await client.list_resource_templates()
+            uri_templates = {t.uriTemplate for t in templates}
+            assert f"{prefix}page/{{section}}/{{page}}" in uri_templates
+            assert f"{prefix}page/{{section}}/{{subsection}}/{{page}}" in uri_templates
+
+        _run(_with_client(server, check))
+
+
+@pytest.mark.parametrize("server_name", sorted(SERVERS))
+class TestPrompts:
+    """Prompt inventory and a live render of one prompt template."""
+
+    def test_expected_prompts_present(self, server_name: str) -> None:
+        server, _prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            prompts = await client.list_prompts()
+            names = {p.name for p in prompts}
+            assert names == EXPECTED_PROMPT_NAMES
+
+        _run(_with_client(server, check))
+
+    def test_explain_foundry_concept_renders(self, server_name: str) -> None:
+        server, _prefix, _version = SERVERS[server_name]
+
+        async def check(client: Client) -> None:
+            result = await client.get_prompt("explain_foundry_concept", {"concept": "RAG"})
+            assert len(result.messages) == 2
+            combined = " ".join(
+                m.content.text for m in result.messages if hasattr(m.content, "text")
+            )
+            assert "RAG" in combined
+
+        _run(_with_client(server, check))


### PR DESCRIPTION
## Summary

Implements #474: connects docs validation, MCP discovery/readiness, FastMCP server/client inspection, and eval harness reporting into a deterministic agent-readiness surface, per the routing in `.github/agent-harness-map.md` (#474 row).

## What's added

- **`tests/test_mcp_server_inspection.py`** — 22 deterministic FastMCP in-memory `Client(server)` tests (no LLM) asserting server name/version/instructions, `ping`, exact tool/prompt name sets, tool input schemas + `readOnlyHint` annotations, and resource/resource-template URIs for **both** `foundry-docs` and `foundry-docs-vnext` servers. Follows the standard FastMCP in-memory testing pattern (https://gofastmcp.com/development/tests).
- **`scripts/check_mcp_discovery.py`** — deterministic report distinguishing:
  - **Local FastMCP** (both servers) — verified live via in-memory client
  - **Hosted Mintlify MCP** — live HTTP checks against `/mcp`, `/.well-known/mcp`, `/.well-known/mcp/server-card.json`, `/skill.md`, `/llms.txt`, `/llms-full.txt`. Verified during implementation against `hobbyist-e43fa225.mintlify.app`: `/mcp` → `405` (present, POST-only streamable transport); the other 5 → `200`. `mint score <url>` requires `mint login` — reported as **not configured**, never guessed.
  - **Azure-backed hybrid search** — env-var configuration presence only (no fabricated live-call result)
- **`scripts/eval_report.py`** — new "MCP & Tool Discovery State" section, wired to the discovery script's JSON; explicitly states "no report supplied" rather than fabricating pass/fail when absent.
- **`.github/workflows/mintlify-fastmcp-readiness.yml`** — new deterministic (non-gh-aw) GitHub Actions workflow:
  - Hard gate: `tests/test_mcp_server_inspection.py`
  - Non-blocking reports: MCP discovery, and `mint validate`/`broken-links`/`a11y` (pinned `mint@4.2.513`) per docs directory — run scoped to `docs/`/`docs-vnext/` since invoking `mint` from repo root incorrectly globs `raw_docs/`/`research/` via the root `docs.json`
- **`README.md`** — documents the full tool/resource/prompt inventory (shared by both servers via `_server_factory.build_server()`) and the new readiness tooling
- **`.github/agent-harness-map.md`** — implementation evidence, resolved capability-gap rows, and real findings surfaced (pre-existing `docs/` broken links, a `docs-vnext` OpenAPI-generation `mint validate` failure, `mint score` auth requirement) — tracked as follow-on content work, not fixed here per #474's MCP/readiness-only scope.

## Verification

- `pytest` — 137 passed
- `ruff check .` — all checks passed
- `git diff --check` — clean
- Manually verified hosted Mintlify endpoints and `mint` CLI behavior live during implementation (see harness map evidence section)

Closes #474.