### PR TITLE
docs: correct hosted Mintlify site corpus label in check_mcp_discovery.py

### DIFF
--- a/scripts/check_mcp_discovery.py
+++ b/scripts/check_mcp_discovery.py
@@ -11,7 +11,10 @@ Variants covered:
   - local-fastmcp-docs        FastMCP server over docs/ (in-memory client)
   - local-fastmcp-vnext       FastMCP server over docs-vnext/ (in-memory client)
   - hosted-mintlify           Mintlify-hosted docs site's own MCP/AI-readiness
-                              endpoints (live HTTP checks, best-effort)
+                              endpoints (live HTTP checks, best-effort). The
+                              default URL below serves the primary docs/
+                              corpus, not docs-vnext/ -- confirmed by direct
+                              fetch (docs-vnext-only paths 404 on this host).
   - azure-backed-hybrid       Whether Azure AI Search hybrid retrieval mode is
                               configured for search_docs (env-var presence
                               only -- this does not make a live Azure call)
@@ -39,7 +42,11 @@ from fastmcp import Client
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-# Default hosted docs-vnext site, as configured in .mcp.json for this repo.
+# Default hosted Mintlify site for this repo. This domain serves the primary
+# docs/ corpus (not docs-vnext/), despite the "docs-vnext" naming used for it
+# elsewhere (e.g. the .mcp.json server key) -- verified by direct fetch: a
+# path that exists only in docs-vnext/ (overview/classic-vs-new) 404s here,
+# while docs/ paths resolve correctly.
 DEFAULT_HOSTED_BASE_URL = "https://hobbyist-e43fa225.mintlify.app"
 
 # Endpoints Mintlify documents as its agent-readiness/MCP-discovery surface.


### PR DESCRIPTION
## Summary

Small documentation-accuracy follow-up from the "bring Mintlify current" work in this session.

While verifying that production Mintlify (`hobbyist-e43fa225.mintlify.app`) reflects the recently-merged fixes (#513, #514, #515, #516, #519, #521), I confirmed via direct fetch that this domain serves the **primary `docs/` corpus**, not docs-vnext:

- `docs/agents/development/quickstart-hosted-agent` (deleted by #519's prune) → 404
- `docs/agent-service/quickstart-hosted-agent` (surviving path) → 200
- `overview/classic-vs-new` (exists **only** in `docs-vnext/`, never in `docs/`) → 404

That last check is decisive: if this domain served docs-vnext, that path would resolve.

`scripts/check_mcp_discovery.py` (added in #521) contained a comment/docstring claiming this was the "docs-vnext site" — inherited from the `.mcp.json` server key name (`microsoft-foundry-docs-vnext`), which is a personal/local MCP config predating this work and out of scope to change here. This PR corrects the comment and module docstring in `check_mcp_discovery.py` to state what was actually verified. No behavior change — pure documentation/comment fix.

## Verification

- `pytest tests/test_mcp_server_inspection.py` — 22 passed
- `ruff check scripts/check_mcp_discovery.py` — clean

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>