### PR TITLE
feat(eval): wire check_mcp_discovery.py into the eval report

### DIFF
--- a/.github/workflows/docs-eval-harness.yml
+++ b/.github/workflows/docs-eval-harness.yml
@@ -145,9 +145,16 @@ jobs:
             ${{ steps.collect.outputs.files }} \
             --output tests/eval_results/scored-merged.json
 
+      - name: Check MCP/tool discovery state
+        run: |
+          python scripts/check_mcp_discovery.py \
+            --output tests/eval_results/mcp_discovery.json \
+            --skip-hosted || true
+
       - name: Generate report
         run: |
           python scripts/eval_report.py tests/eval_results/scored-merged.json \
+            --mcp-discovery tests/eval_results/mcp_discovery.json \
             --output tests/eval_results/report.md
           cat tests/eval_results/report.md
 

--- a/.github/workflows/docs-eval-harness.yml
+++ b/.github/workflows/docs-eval-harness.yml
@@ -74,7 +74,7 @@ jobs:
           destination: /opt/gh-aw/actions
 
       - name: Install Copilot CLI
-        run: /opt/gh-aw/actions/install_copilot_cli.sh 0.0.421
+        run: /opt/gh-aw/actions/install_copilot_cli.sh 1.0.65
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
 

--- a/.github/workflows/docs-eval-harness.yml
+++ b/.github/workflows/docs-eval-harness.yml
@@ -33,6 +33,14 @@ permissions:
 
 env:
   COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+  # Required so foundry-docs / foundry-docs-vnext MCP servers exercise the Azure AI Search
+  # hybrid backend instead of silently falling back to local TF-IDF (see _server_factory.py).
+  AZURE_SEARCH_ENDPOINT: ${{ secrets.AZURE_SEARCH_ENDPOINT }}
+  AZURE_SEARCH_API_KEY: ${{ secrets.AZURE_SEARCH_API_KEY }}
+  AZURE_SEARCH_INDEX_NAME: ${{ secrets.AZURE_SEARCH_INDEX_NAME }}
+  AZURE_AI_PROJECT_ENDPOINT: ${{ secrets.AZURE_AI_PROJECT_ENDPOINT }}
+  AZURE_AI_PROJECT_API_KEY: ${{ secrets.AZURE_AI_PROJECT_API_KEY }}
+  AZURE_OPENAI_EMBEDDING_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_EMBEDDING_DEPLOYMENT }}
 
 jobs:
   evaluate:

--- a/scripts/eval_report.py
+++ b/scripts/eval_report.py
@@ -227,6 +227,48 @@ def generate_mcp_discovery_section(discovery: dict[str, Any] | None) -> str:
     return "\n".join(lines) + "\n"
 
 
+def generate_operational_metrics(aggregates: dict) -> str:
+    """Generate the per-server operational metrics table (pass rate, tokens, turns,
+    tool calls, tool errors, response time) alongside the quality composite score."""
+    ops = aggregates.get("operational_metrics", {})
+    if not ops:
+        return "*No operational metrics available for this run.*\n"
+
+    def fmt(value, suffix=""):
+        return "n/a" if value is None else f"{value}{suffix}"
+
+    lines = [
+        "| Server | Evaluations | Pass Rate | Avg Turns | Avg Tool Calls | "
+        "Tool Errors | Avg Output Tokens | Avg Response Time |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+
+    server_avgs = aggregates.get("server_averages", {})
+    ranked = sorted(ops.keys(), key=lambda s: server_avgs.get(s, 0), reverse=True)
+
+    for server in ranked:
+        m = ops[server]
+        label = SERVER_LABELS.get(server, server)
+        raw_pass_rate = m.get("pass_rate")
+        pass_rate_display = (
+            f"{raw_pass_rate:.1%}" if isinstance(raw_pass_rate, (int, float)) else "n/a"
+        )
+        lines.append(
+            f"| {label} | {m.get('total_evaluations', 0)} | {pass_rate_display} | "
+            f"{fmt(m.get('avg_turns'))} | {fmt(m.get('avg_tool_calls'))} | "
+            f"{fmt(m.get('total_tool_errors'))} | {fmt(m.get('avg_output_tokens'))} | "
+            f"{fmt(m.get('avg_response_time_seconds'), 's')} |"
+        )
+
+    lines.append(
+        "\n_Pass = process exited 0, produced a non-empty response, and no tool "
+        "execution reported a failure. \"n/a\" means this run's raw results predate "
+        "operational-metrics capture._"
+    )
+
+    return "\n".join(lines) + "\n"
+
+
 def generate_report(scored_data: dict, discovery: dict[str, Any] | None = None) -> str:
     """Generate the full markdown report."""
     metadata = scored_data.get("metadata", {})
@@ -249,6 +291,12 @@ def generate_report(scored_data: dict, discovery: dict[str, Any] | None = None) 
 ## Scoreboard: Server × Model Matrix
 
 {generate_scoreboard(aggregates)}
+
+---
+
+## Operational Metrics
+
+{generate_operational_metrics(aggregates)}
 
 ---
 
@@ -282,6 +330,10 @@ providing only one MCP server's tools. Responses are scored on:
 | Doc Retrieval | 30% | Whether the model found and referenced expected documentation pages |
 
 **Composite score** = 0.4 × completeness + 0.3 × quality + 0.3 × doc_retrieval
+
+Alongside the quality composite, each run also captures **operational metrics** parsed from the
+`copilot --output-format json` event stream: pass/fail, turn count, tool-call count, tool
+execution errors, output token usage, and wall-clock response time (see Operational Metrics above).
 
 ---
 

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -82,6 +82,18 @@ def score_result(result: dict) -> dict:
     rubric = result.get("rubric", {})
     status = result.get("status", "error")
 
+    # Operational metrics captured by run_docs_eval.py's structured event-stream
+    # parsing. Older raw result files won't have these -- default to None/0 so
+    # aggregation can distinguish "known zero" from "not captured".
+    operational = {
+        "passed": result.get("passed"),
+        "turns": result.get("turns"),
+        "tool_calls": result.get("tool_calls"),
+        "tool_errors": result.get("tool_errors"),
+        "output_tokens": result.get("output_tokens"),
+        "response_time_seconds": result.get("response_time_seconds"),
+    }
+
     if status != "success" or not response:
         return {
             **result,
@@ -92,6 +104,7 @@ def score_result(result: dict) -> dict:
                 "response_length": 0,
                 "has_response": False,
             },
+            "operational": operational,
         }
 
     scores = {
@@ -115,7 +128,7 @@ def score_result(result: dict) -> dict:
         + scores["doc_retrieval"] * 0.3
     )
 
-    return {**result, "scores": scores}
+    return {**result, "scores": scores, "operational": operational}
 
 
 def aggregate_scores(scored_results: list[dict]) -> dict:
@@ -126,14 +139,47 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
     categories = defaultdict(lambda: defaultdict(list))
     # Per-server aggregates
     server_agg = defaultdict(list)
+    # Per-server operational metrics (independent of has_response, since a
+    # failed/errored run is itself an operational data point)
+    server_ops = defaultdict(lambda: {
+        "total": 0,
+        "passed": 0,
+        "passed_known": 0,
+        "turns": [],
+        "tool_calls": [],
+        "tool_errors": 0,
+        "tool_errors_known": False,
+        "output_tokens": [],
+        "response_time_seconds": [],
+    })
 
     for r in scored_results:
-        if not r.get("scores", {}).get("has_response", False):
-            continue
-
         server = r["server"]
         model = r["model"]
         category = r["category"]
+
+        ops = r.get("operational", {})
+        agg = server_ops[server]
+        agg["total"] += 1
+        if ops.get("passed") is not None:
+            agg["passed_known"] += 1
+            if ops["passed"]:
+                agg["passed"] += 1
+        if ops.get("turns") is not None:
+            agg["turns"].append(ops["turns"])
+        if ops.get("tool_calls") is not None:
+            agg["tool_calls"].append(ops["tool_calls"])
+        if ops.get("tool_errors") is not None:
+            agg["tool_errors_known"] = True
+            agg["tool_errors"] += ops["tool_errors"]
+        if ops.get("output_tokens") is not None:
+            agg["output_tokens"].append(ops["output_tokens"])
+        if ops.get("response_time_seconds") is not None:
+            agg["response_time_seconds"].append(ops["response_time_seconds"])
+
+        if not r.get("scores", {}).get("has_response", False):
+            continue
+
         composite = r["scores"]["composite"]
 
         matrix[server][model].append(composite)
@@ -156,10 +202,29 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
 
     server_avg = {server: avg(scores) for server, scores in server_agg.items()}
 
+    operational_avg = {}
+    for server, agg in server_ops.items():
+        operational_avg[server] = {
+            "total_evaluations": agg["total"],
+            "pass_rate": (
+                round(agg["passed"] / agg["passed_known"], 3)
+                if agg["passed_known"] else None
+            ),
+            "passed_known": agg["passed_known"],
+            "avg_turns": avg(agg["turns"]) if agg["turns"] else None,
+            "avg_tool_calls": avg(agg["tool_calls"]) if agg["tool_calls"] else None,
+            "total_tool_errors": agg["tool_errors"] if agg["tool_errors_known"] else None,
+            "avg_output_tokens": avg(agg["output_tokens"]) if agg["output_tokens"] else None,
+            "avg_response_time_seconds": (
+                avg(agg["response_time_seconds"]) if agg["response_time_seconds"] else None
+            ),
+        }
+
     return {
         "server_model_matrix": matrix_avg,
         "category_breakdown": category_avg,
         "server_averages": server_avg,
+        "operational_metrics": operational_avg,
     }
 
 

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -89,6 +89,72 @@ def build_prompt(question: str, server_name: str) -> str:
     )
 
 
+def parse_event_stream(stdout: str) -> dict:
+    """Parse `copilot --output-format json` JSONL output into operational metrics.
+
+    Extracts the final assistant response text plus turn count, tool-call count,
+    tool-execution failures, output token usage, and session/API duration from the
+    structured event stream. Falls back gracefully (zeroed metrics, raw stdout as
+    response) if a line fails to parse or the expected events are absent -- e.g. for
+    older copilot CLI builds or unexpected output shapes.
+    """
+    metrics = {
+        "turns": 0,
+        "tool_calls": 0,
+        "tool_errors": 0,
+        "output_tokens": 0,
+        "premium_requests": None,
+        "api_duration_ms": None,
+        "session_duration_ms": None,
+        "result_exit_code": None,
+        "parse_error": None,
+    }
+
+    last_message_content = ""
+    turn_ids: set[str] = set()
+    parsed_any = False
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        parsed_any = True
+        etype = event.get("type")
+        data = event.get("data", {})
+
+        if etype == "assistant.turn_start":
+            turn_id = data.get("turnId")
+            if turn_id is not None:
+                turn_ids.add(turn_id)
+        elif etype == "assistant.message":
+            content = data.get("content")
+            if content:
+                last_message_content = content
+            metrics["output_tokens"] += data.get("outputTokens", 0) or 0
+        elif etype == "tool.execution_complete":
+            metrics["tool_calls"] += 1
+            if data.get("success") is False:
+                metrics["tool_errors"] += 1
+        elif etype == "result":
+            metrics["result_exit_code"] = event.get("exitCode")
+            usage = event.get("usage", {}) or {}
+            metrics["premium_requests"] = usage.get("premiumRequests")
+            metrics["api_duration_ms"] = usage.get("totalApiDurationMs")
+            metrics["session_duration_ms"] = usage.get("sessionDurationMs")
+
+    metrics["turns"] = len(turn_ids)
+
+    if not parsed_any:
+        metrics["parse_error"] = "no parseable JSON events found in stdout"
+
+    return {"response": last_message_content, **metrics}
+
+
 def run_single_eval(
     scenario: dict,
     server_name: str,
@@ -117,24 +183,44 @@ def run_single_eval(
             "copilot",
             "--model", model,
             "--prompt", prompt,
+            "--output-format", "json",
         ]
 
         proc = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             cwd=str(PROJECT_ROOT),
         )
 
         elapsed = time.monotonic() - start_time
+        parsed = parse_event_stream(proc.stdout)
+
+        # If the JSON event stream didn't parse (unexpected CLI version/output),
+        # fall back to raw stdout so the response isn't silently lost.
+        response = parsed["response"] or (proc.stdout.strip() if parsed["parse_error"] else "")
+
+        tool_errors = parsed["tool_errors"]
+        clean_run = proc.returncode == 0 and tool_errors == 0 and bool(response)
 
         result.update({
-            "response": proc.stdout.strip(),
+            "response": response,
             "stderr": proc.stderr.strip() if proc.stderr else "",
             "exit_code": proc.returncode,
             "response_time_seconds": round(elapsed, 2),
             "status": "success" if proc.returncode == 0 else "error",
+            "passed": clean_run,
+            "turns": parsed["turns"],
+            "tool_calls": parsed["tool_calls"],
+            "tool_errors": tool_errors,
+            "output_tokens": parsed["output_tokens"],
+            "premium_requests": parsed["premium_requests"],
+            "api_duration_ms": parsed["api_duration_ms"],
+            "session_duration_ms": parsed["session_duration_ms"],
+            "event_parse_error": parsed["parse_error"],
         })
 
     except subprocess.TimeoutExpired:
@@ -145,6 +231,15 @@ def run_single_eval(
             "exit_code": -1,
             "response_time_seconds": round(elapsed, 2),
             "status": "timeout",
+            "passed": False,
+            "turns": 0,
+            "tool_calls": 0,
+            "tool_errors": 0,
+            "output_tokens": 0,
+            "premium_requests": None,
+            "api_duration_ms": None,
+            "session_duration_ms": None,
+            "event_parse_error": None,
         })
     except Exception as e:
         elapsed = time.monotonic() - start_time
@@ -154,6 +249,15 @@ def run_single_eval(
             "exit_code": -1,
             "response_time_seconds": round(elapsed, 2),
             "status": "error",
+            "passed": False,
+            "turns": 0,
+            "tool_calls": 0,
+            "tool_errors": 0,
+            "output_tokens": 0,
+            "premium_requests": None,
+            "api_duration_ms": None,
+            "session_duration_ms": None,
+            "event_parse_error": None,
         })
 
     return result


### PR DESCRIPTION
## Context

Follow-up to #525. The just-completed full eval rerun (issue #526) confirmed the Azure secrets/CLI-version fixes work — `gpt-5.4` now renders correctly, and the new Operational Metrics table populates with real data. But #526's "MCP & Tool Discovery State" section still says *"No MCP discovery report was supplied"*, so there's no explicit confirmation that the Azure AI Search hybrid path was actually active for the `foundry-docs`/`foundry-docs-vnext` arms during that run — `scripts/check_mcp_discovery.py` exists and supports exactly this via `--mcp-discovery`, but nothing in the workflow ever calls it.

## Change

Adds a `Check MCP/tool discovery state` step to the `merge-and-report` job (which already has the Azure secrets from #525's env-var fix) that runs `scripts/check_mcp_discovery.py --skip-hosted` and passes the result to `eval_report.py --mcp-discovery`. `--skip-hosted` avoids adding a live-network dependency on the hosted Mintlify site to report generation; the mintlify-hosted eval arm already exercises that endpoint directly.

## Verification

- Ran `scripts/check_mcp_discovery.py --skip-hosted` locally (no Azure secrets available in this session) — confirms it degrades gracefully to `"status": "not_configured"` rather than crashing, and its Local FastMCP + Azure-backed-hybrid sections render correctly.
- YAML validated.
- This will take effect starting with the next scheduled/dispatched run of `Documentation Evaluation Harness` (weekly Sunday cron, or manual dispatch) — retroactively cannot annotate #526, which is called out explicitly in that issue's follow-up comment.