### PR TITLE
Protect durable issues from generated-report cleanup

### DIFF
--- a/.github/workflows/docs-eval-harness.yml
+++ b/.github/workflows/docs-eval-harness.yml
@@ -169,27 +169,36 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue list --repo "${{ github.repository }}" \
-            --label "eval-report" --state open --json number -q '.[].number' \
-          | while read -r num; do
-              gh issue close "$num" --repo "${{ github.repository }}" \
-                --comment "Superseded by newer evaluation run." 2>/dev/null || true
-            done
+          python scripts/generated_report_cleanup.py cleanup \
+            --repo "${{ github.repository }}" \
+            --label "eval-report" \
+            --workflow-identity "docs-eval-harness" \
+            --report-kind "docs-evaluation" \
+            --summary "$GITHUB_STEP_SUMMARY"
 
       - name: Create issue with results
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TITLE="📊 Docs Eval Report - $(date -u +%Y-%m-%d)"
+          REPORT_DATE="$(date -u +%Y-%m-%d)"
+          MARKER="$(python scripts/generated_report_cleanup.py marker \
+            --workflow-identity "docs-eval-harness" \
+            --report-kind "docs-evaluation" \
+            --report-date "$REPORT_DATE")"
+          {
+            printf '%s\n\n' "$MARKER"
+            cat tests/eval_results/report.md
+          } > tests/eval_results/issue-report.md
+          TITLE="📊 Docs Eval Report - $REPORT_DATE"
           gh issue create \
             --repo "${{ github.repository }}" \
             --title "$TITLE" \
-            --body-file tests/eval_results/report.md \
+            --body-file tests/eval_results/issue-report.md \
             --label "eval-report" --label "automation" || \
           gh issue create \
             --repo "${{ github.repository }}" \
             --title "$TITLE" \
-            --body-file tests/eval_results/report.md
+            --body-file tests/eval_results/issue-report.md
 
       - name: Check for regression
         run: |

--- a/scripts/generated_report_cleanup.py
+++ b/scripts/generated_report_cleanup.py
@@ -1,0 +1,323 @@
+"""Create and enforce machine-readable identities for generated report issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+MARKER_PREFIX = "<!-- generated-report:"
+MARKER_PATTERN = re.compile(r"^\s*<!-- generated-report:\s*(\{[^\r\n]*\})\s*-->\s*$")
+IDENTITY_PATTERN = re.compile(r"^[a-z0-9]+(?:[-_][a-z0-9]+)*$")
+REQUIRED_MARKER_KEYS = {"workflow_identity", "report_kind", "report_date"}
+
+
+class CleanupError(RuntimeError):
+    """Raised when generated-report cleanup cannot complete safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratedReportMarker:
+    workflow_identity: str
+    report_kind: str
+    report_date: str
+
+
+@dataclass(frozen=True, slots=True)
+class MarkerInspection:
+    status: str
+    marker: GeneratedReportMarker | None
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupDecision:
+    issue_number: int
+    outcome: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupResult:
+    selected: int
+    closed: int
+    skipped: int
+    invalid_markers: int
+    decisions: tuple[CleanupDecision, ...]
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "selected": self.selected,
+            "closed": self.closed,
+            "skipped": self.skipped,
+            "invalid_markers": self.invalid_markers,
+        }
+
+
+GhRunner = Callable[[list[str]], str]
+IssueCloser = Callable[[int], None]
+
+
+def _validate_identity(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not IDENTITY_PATTERN.fullmatch(value):
+        raise ValueError(f"{field_name} must be a lowercase machine identity")
+    return value
+
+
+def _validate_report_date(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError("report_date must be an ISO date")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("report_date must be an ISO date") from exc
+    if parsed.isoformat() != value:
+        raise ValueError("report_date must be an ISO date")
+    return value
+
+
+def build_marker(workflow_identity: str, report_kind: str, report_date: str) -> str:
+    """Build the canonical generated-report marker."""
+    payload = {
+        "workflow_identity": _validate_identity(workflow_identity, "workflow_identity"),
+        "report_kind": _validate_identity(report_kind, "report_kind"),
+        "report_date": _validate_report_date(report_date),
+    }
+    return f"{MARKER_PREFIX} {json.dumps(payload, separators=(',', ':'), sort_keys=True)} -->"
+
+
+def inspect_marker(body: str) -> MarkerInspection:
+    """Inspect a report body without treating a broad issue label as identity."""
+    marker_lines = [line for line in body.splitlines() if MARKER_PREFIX in line]
+    if not marker_lines:
+        return MarkerInspection(status="missing", marker=None, reason="generated-report marker is missing")
+    if len(marker_lines) != 1:
+        return MarkerInspection(status="invalid", marker=None, reason="expected exactly one generated-report marker")
+
+    match = MARKER_PATTERN.fullmatch(marker_lines[0])
+    if match is None:
+        return MarkerInspection(status="invalid", marker=None, reason="generated-report marker is malformed")
+
+    try:
+        payload = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return MarkerInspection(status="invalid", marker=None, reason="generated-report marker contains invalid JSON")
+
+    if not isinstance(payload, dict) or set(payload) != REQUIRED_MARKER_KEYS:
+        return MarkerInspection(
+            status="invalid",
+            marker=None,
+            reason="generated-report marker must contain only workflow_identity, report_kind, and report_date",
+        )
+
+    try:
+        marker = GeneratedReportMarker(
+            workflow_identity=_validate_identity(payload["workflow_identity"], "workflow_identity"),
+            report_kind=_validate_identity(payload["report_kind"], "report_kind"),
+            report_date=_validate_report_date(payload["report_date"]),
+        )
+    except ValueError as exc:
+        return MarkerInspection(status="invalid", marker=None, reason=str(exc))
+    return MarkerInspection(status="valid", marker=marker, reason="generated-report marker is valid")
+
+
+def cleanup_generated_reports(
+    issues: Iterable[dict[str, Any]],
+    *,
+    workflow_identity: str,
+    report_kind: str,
+    close_issue: IssueCloser,
+) -> CleanupResult:
+    """Close only issues with a valid marker matching the expected report identity."""
+    expected_workflow = _validate_identity(workflow_identity, "workflow_identity")
+    expected_kind = _validate_identity(report_kind, "report_kind")
+    selected = closed = skipped = invalid_markers = 0
+    decisions: list[CleanupDecision] = []
+
+    for issue in issues:
+        issue_number = issue.get("number")
+        body = issue.get("body")
+        if not isinstance(issue_number, int):
+            raise CleanupError("GitHub returned an issue without an integer number")
+        if body is None:
+            body = ""
+        if not isinstance(body, str):
+            skipped += 1
+            invalid_markers += 1
+            decisions.append(CleanupDecision(issue_number, "invalid-marker", "issue body is not text"))
+            continue
+
+        inspection = inspect_marker(body)
+        if inspection.status == "missing":
+            skipped += 1
+            decisions.append(CleanupDecision(issue_number, "skipped", inspection.reason))
+            continue
+        if inspection.status == "invalid":
+            skipped += 1
+            invalid_markers += 1
+            decisions.append(CleanupDecision(issue_number, "invalid-marker", inspection.reason))
+            continue
+
+        marker = inspection.marker
+        if marker is None:
+            raise CleanupError("valid marker inspection did not return marker data")
+        if marker.workflow_identity != expected_workflow or marker.report_kind != expected_kind:
+            skipped += 1
+            decisions.append(
+                CleanupDecision(
+                    issue_number,
+                    "skipped",
+                    "generated-report marker does not match the expected workflow identity and report kind",
+                )
+            )
+            continue
+
+        selected += 1
+        try:
+            close_issue(issue_number)
+        except CleanupError as exc:
+            skipped += 1
+            decisions.append(CleanupDecision(issue_number, "close-failed", str(exc)))
+            continue
+        closed += 1
+        decisions.append(CleanupDecision(issue_number, "closed", "matching generated report was superseded"))
+
+    return CleanupResult(
+        selected=selected,
+        closed=closed,
+        skipped=skipped,
+        invalid_markers=invalid_markers,
+        decisions=tuple(decisions),
+    )
+
+
+def run_gh(args: list[str]) -> str:
+    """Run a bounded GitHub CLI command and return stdout."""
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise CleanupError(f"GitHub CLI command failed: {' '.join(args[:3])}") from exc
+    return completed.stdout
+
+
+def _load_open_issues(repo: str, label: str, runner: GhRunner) -> list[dict[str, Any]]:
+    raw = runner(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--label",
+            label,
+            "--state",
+            "open",
+            "--limit",
+            "1000",
+            "--json",
+            "number,body",
+        ]
+    )
+    try:
+        issues = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CleanupError("GitHub CLI returned invalid issue JSON") from exc
+    if not isinstance(issues, list) or not all(isinstance(issue, dict) for issue in issues):
+        raise CleanupError("GitHub CLI returned an unexpected issue list")
+    return issues
+
+
+def _write_summary(path: Path, result: CleanupResult) -> None:
+    counts = result.counts()
+    rows = [
+        "### Generated report cleanup",
+        "",
+        "| Selected | Closed | Skipped | Invalid markers |",
+        "| ---: | ---: | ---: | ---: |",
+        (
+            f"| {counts['selected']} | {counts['closed']} | "
+            f"{counts['skipped']} | {counts['invalid_markers']} |"
+        ),
+        "",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as summary:
+        summary.write("\n".join(rows))
+
+
+def _run_cleanup(args: argparse.Namespace, runner: GhRunner = run_gh) -> CleanupResult:
+    issues = _load_open_issues(args.repo, args.label, runner)
+
+    def close_issue(issue_number: int) -> None:
+        runner(
+            [
+                "gh",
+                "issue",
+                "close",
+                str(issue_number),
+                "--repo",
+                args.repo,
+                "--comment",
+                "Superseded by a newer generated evaluation report.",
+            ]
+        )
+
+    result = cleanup_generated_reports(
+        issues,
+        workflow_identity=args.workflow_identity,
+        report_kind=args.report_kind,
+        close_issue=close_issue,
+    )
+    for decision in result.decisions:
+        print(f"#{decision.issue_number}: {decision.outcome} - {decision.reason}")
+    print(json.dumps(result.counts(), sort_keys=True))
+    if args.summary:
+        _write_summary(args.summary, result)
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    marker_parser = subparsers.add_parser("marker", help="print a canonical generated-report marker")
+    marker_parser.add_argument("--workflow-identity", required=True)
+    marker_parser.add_argument("--report-kind", required=True)
+    marker_parser.add_argument("--report-date", required=True)
+
+    cleanup_parser = subparsers.add_parser("cleanup", help="close matching generated report issues")
+    cleanup_parser.add_argument("--repo", required=True)
+    cleanup_parser.add_argument("--label", required=True)
+    cleanup_parser.add_argument("--workflow-identity", required=True)
+    cleanup_parser.add_argument("--report-kind", required=True)
+    cleanup_parser.add_argument("--summary", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    try:
+        if args.command == "marker":
+            print(build_marker(args.workflow_identity, args.report_kind, args.report_date))
+        else:
+            _run_cleanup(args)
+    except (CleanupError, ValueError) as exc:
+        print(f"generated-report cleanup failed: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generated_report_cleanup.py
+++ b/tests/test_generated_report_cleanup.py
@@ -1,0 +1,152 @@
+"""Tests for explicit generated-report identity and cleanup protection."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from generated_report_cleanup import (  # noqa: E402
+    CleanupError,
+    build_marker,
+    cleanup_generated_reports,
+    inspect_marker,
+)
+
+WORKFLOW_IDENTITY = "docs-eval-harness"
+REPORT_KIND = "docs-evaluation"
+
+
+def _body(*, workflow: str = WORKFLOW_IDENTITY, kind: str = REPORT_KIND, report_date: str = "2026-07-28") -> str:
+    marker = build_marker(workflow, kind, report_date)
+    return f"{marker}\n\n### Summary\nGenerated evaluation results."
+
+
+def test_marker_contains_complete_machine_readable_identity():
+    marker = build_marker(WORKFLOW_IDENTITY, REPORT_KIND, "2026-07-28")
+
+    inspection = inspect_marker(marker)
+
+    assert inspection.status == "valid"
+    assert inspection.marker is not None
+    assert inspection.marker.workflow_identity == WORKFLOW_IDENTITY
+    assert inspection.marker.report_kind == REPORT_KIND
+    assert inspection.marker.report_date == "2026-07-28"
+
+
+def test_cleanup_rotates_generated_report_but_preserves_durable_same_label_issue():
+    open_issues = [
+        {"number": 625, "body": _body(report_date="2026-07-20")},
+        {
+            "number": 470,
+            "body": "## Objective\nDurable evaluation harness implementation tracker without a generated-report marker.",
+        },
+    ]
+    closed: list[int] = []
+
+    first = cleanup_generated_reports(
+        open_issues,
+        workflow_identity=WORKFLOW_IDENTITY,
+        report_kind=REPORT_KIND,
+        close_issue=closed.append,
+    )
+
+    assert closed == [625]
+    assert first.counts() == {"selected": 1, "closed": 1, "skipped": 1, "invalid_markers": 0}
+    assert first.decisions[1].issue_number == 470
+    assert first.decisions[1].outcome == "skipped"
+
+    still_open = [issue for issue in open_issues if issue["number"] not in closed]
+    second = cleanup_generated_reports(
+        still_open,
+        workflow_identity=WORKFLOW_IDENTITY,
+        report_kind=REPORT_KIND,
+        close_issue=closed.append,
+    )
+
+    assert closed == [625]
+    assert second.counts() == {"selected": 0, "closed": 0, "skipped": 1, "invalid_markers": 0}
+
+
+def test_missing_malformed_and_mismatched_markers_are_reported_and_not_closed():
+    issues = [
+        {"number": 1, "body": "durable tracker with no marker"},
+        {"number": 2, "body": "<!-- generated-report: not-json -->"},
+        {"number": 3, "body": _body(workflow="other-workflow")},
+        {"number": 4, "body": _body(kind="other-report")},
+    ]
+    closed: list[int] = []
+
+    result = cleanup_generated_reports(
+        issues,
+        workflow_identity=WORKFLOW_IDENTITY,
+        report_kind=REPORT_KIND,
+        close_issue=closed.append,
+    )
+
+    assert closed == []
+    assert result.counts() == {"selected": 0, "closed": 0, "skipped": 4, "invalid_markers": 1}
+    assert [decision.outcome for decision in result.decisions] == [
+        "skipped",
+        "invalid-marker",
+        "skipped",
+        "skipped",
+    ]
+
+
+def test_close_failure_is_audited_and_remains_retryable():
+    issues = [{"number": 625, "body": _body()}]
+
+    def failing_close(_issue_number: int) -> None:
+        raise CleanupError("GitHub CLI command failed: gh issue close")
+
+    first = cleanup_generated_reports(
+        issues,
+        workflow_identity=WORKFLOW_IDENTITY,
+        report_kind=REPORT_KIND,
+        close_issue=failing_close,
+    )
+
+    assert first.counts() == {"selected": 1, "closed": 0, "skipped": 1, "invalid_markers": 0}
+    assert first.decisions[0].outcome == "close-failed"
+
+    closed: list[int] = []
+    second = cleanup_generated_reports(
+        issues,
+        workflow_identity=WORKFLOW_IDENTITY,
+        report_kind=REPORT_KIND,
+        close_issue=closed.append,
+    )
+
+    assert closed == [625]
+    assert second.counts() == {"selected": 1, "closed": 1, "skipped": 0, "invalid_markers": 0}
+
+
+def test_non_text_body_is_invalid_and_not_closed():
+    closed: list[int] = []
+
+    result = cleanup_generated_reports(
+        [{"number": 10, "body": {"unexpected": "object"}}],
+        workflow_identity=WORKFLOW_IDENTITY,
+        report_kind=REPORT_KIND,
+        close_issue=closed.append,
+    )
+
+    assert closed == []
+    assert result.counts() == {"selected": 0, "closed": 0, "skipped": 1, "invalid_markers": 1}
+
+
+def test_invalid_marker_contract_is_not_selected():
+    invalid_bodies = [
+        '<!-- generated-report: {"workflow_identity":"docs-eval-harness"} -->',
+        (
+            '<!-- generated-report: {"workflow_identity":"docs-eval-harness",'
+            '"report_kind":"docs-evaluation","report_date":"07/28/2026"} -->'
+        ),
+        f"{_body()}\n{build_marker(WORKFLOW_IDENTITY, REPORT_KIND, '2026-07-27')}",
+    ]
+
+    for body in invalid_bodies:
+        inspection = inspect_marker(body)
+        assert inspection.status == "invalid"


### PR DESCRIPTION
## Summary
- add a strict machine-readable generated-report marker containing workflow identity, report kind, and report date
- close only open `eval-report` issues whose validated marker matches the docs evaluation workflow
- record selected, closed, skipped, and invalid-marker counts while preserving retryability and idempotency
- add focused tests proving a generated report rotates while a durable same-label tracker remains open

## Validation
- `python -m pytest tests\test_generated_report_cleanup.py -q` — 6 passed
- `python -m ruff check scripts\generated_report_cleanup.py tests\test_generated_report_cleanup.py` — passed
- parsed `.github\workflows\docs-eval-harness.yml` with PyYAML
- `git diff --cached --check` — passed before commit

This changes a traditional GitHub Actions workflow, not a gh-aw source workflow, so no generated lock file is involved.

Closes #633