### PR TITLE
Add deterministic docs-vnext baseline sync manifest

### DIFF
--- a/.github/docs-vnext-sync-preserve.json
+++ b/.github/docs-vnext-sync-preserve.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "./docs-vnext-sync-preserve.schema.json",
+  "schemaVersion": 1,
+  "preserve": [
+    {
+      "kind": "directory",
+      "path": ".mintlify"
+    },
+    {
+      "kind": "file",
+      "path": "README.md"
+    },
+    {
+      "kind": "file",
+      "path": "RFC-navigation-reflow.md"
+    },
+    {
+      "kind": "file",
+      "path": "docs.json"
+    },
+    {
+      "kind": "file",
+      "path": "reference/glossary.mdx"
+    },
+    {
+      "kind": "directory",
+      "path": "slides"
+    }
+  ]
+}

--- a/.github/docs-vnext-sync-preserve.schema.json
+++ b/.github/docs-vnext-sync-preserve.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/nicholasdbrady/foundry-docs/blob/main/.github/docs-vnext-sync-preserve.schema.json",
+  "title": "Docs-vnext baseline sync preserve allowlist",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "preserve"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "const": 1
+    },
+    "preserve": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "path"
+        ],
+        "properties": {
+          "kind": {
+            "enum": [
+              "directory",
+              "file"
+            ]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(?!/)(?!.*\\\\)(?!.*//)(?!.*(?:^|/)\\.{1,2}(?:/|$)).*[^/]$"
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/docs-vnext-sync.lock.yml
+++ b/.github/workflows/docs-vnext-sync.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"4334f4262ae34376112aa0a72f61edbf100464e12502aee2dc9d0db59f534b9a","body_hash":"63813acbf2b0c93197bddb7e670305abf8fc2e59c17644e2ee5d0122315d27f4","compiler_version":"v0.81.6","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.65"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/restore","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/save","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba6380cc6e5be5d21677bebe04d52fb48e3abec7","version":"v0.81.6"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11","digest":"sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11@sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11","digest":"sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11@sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11","digest":"sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11@sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.30","digest":"sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.30@sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"1be3ce6f06497e668e1804fe426eb25a5a63064dccd54f7bf3f33149c1612f19","body_hash":"c393fb0a7c0cabbad3f6e7d1fc2f5ce05f48a831589072b991fc9afc064ccf51","compiler_version":"v0.81.6","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.65"}}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/restore","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/save","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba6380cc6e5be5d21677bebe04d52fb48e3abec7","version":"v0.81.6"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11","digest":"sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11@sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11","digest":"sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11@sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11","digest":"sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11@sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.30","digest":"sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.30@sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
 # This file was automatically generated by gh-aw (v0.81.6). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -23,15 +23,10 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Refreshes docs-vnext from canonical docs as a weekly baseline
-#
-# Resolved workflow manifest:
-#   Imports:
-#     - shared/mcp/mintlify-docs.md
+# Produces a deterministic dry-run manifest for the docs-vnext baseline
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
-#   - GH_AW_CI_TRIGGER_TOKEN
 #   - GH_AW_GITHUB_MCP_SERVER_TOKEN
 #   - GH_AW_GITHUB_TOKEN
 #   - GITHUB_TOKEN
@@ -61,7 +56,6 @@ on:
   schedule:
   - cron: "24 4 * * 0"
     # Friendly format: weekly on sunday (scattered)
-  # skip-if-match: is:pr is:open in:title "[docs-vnext-sync]" # Skip-if-match processed as search check in pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -80,8 +74,6 @@ run-name: "Docs-vnext Baseline Sync"
 
 jobs:
   activation:
-    needs: pre_activation
-    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -110,8 +102,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
-          parent-span-id: ${{ needs.pre_activation.outputs.setup-parent-span-id || needs.pre_activation.outputs.setup-span-id }}
           safe-output-artifact-client: ${{ env.GH_AW_MAX_DAILY_AI_CREDITS != '' }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Docs-vnext Baseline Sync"
@@ -257,23 +247,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_251f71d41c475afe_EOF'
+          cat << 'GH_AW_PROMPT_677f12d231a5c53a_EOF'
           <system>
-          GH_AW_PROMPT_251f71d41c475afe_EOF
+          GH_AW_PROMPT_677f12d231a5c53a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_251f71d41c475afe_EOF'
+          cat << 'GH_AW_PROMPT_677f12d231a5c53a_EOF'
           <safe-output-tools>
-          Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_251f71d41c475afe_EOF
-          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_251f71d41c475afe_EOF'
+          Tools: create_issue, missing_tool, missing_data, noop
+          GH_AW_PROMPT_677f12d231a5c53a_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
+          cat << 'GH_AW_PROMPT_677f12d231a5c53a_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_251f71d41c475afe_EOF
+          GH_AW_PROMPT_677f12d231a5c53a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_251f71d41c475afe_EOF'
+          cat << 'GH_AW_PROMPT_677f12d231a5c53a_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -302,13 +292,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_251f71d41c475afe_EOF
+          GH_AW_PROMPT_677f12d231a5c53a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_251f71d41c475afe_EOF'
+          cat << 'GH_AW_PROMPT_677f12d231a5c53a_EOF'
           </system>
-          {{#runtime-import .github/workflows/shared/mcp/mintlify-docs.md}}
           {{#runtime-import .github/workflows/docs-vnext-sync.md}}
-          GH_AW_PROMPT_251f71d41c475afe_EOF
+          GH_AW_PROMPT_677f12d231a5c53a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -334,7 +323,6 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -354,8 +342,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
       - name: Validate prompt placeholders
@@ -455,6 +442,16 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Generate deterministic docs-vnext sync manifest
+        run: "set -euo pipefail\nmkdir -p /tmp/gh-aw/agent\npython3 scripts/generate_docs_vnext_sync_manifest.py \\\n  --source-dir docs \\\n  --target-dir docs-vnext \\\n  --allowlist .github/docs-vnext-sync-preserve.json \\\n  --output /tmp/gh-aw/agent/docs-vnext-sync-manifest.json\n"
+      - name: Retain docs-vnext sync manifest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: error
+          name: docs-vnext-sync-manifest-${{ github.run_id }}
+          path: /tmp/gh-aw/agent/docs-vnext-sync-manifest.json
+          retention-days: 30
+
       - name: Configure Git credentials
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -518,43 +515,33 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4e31ec4cdd4a21f8_EOF'
-          {"create_pull_request":{"auto_merge":true,"draft":false,"expires":168,"labels":["documentation","docs-vnext","sync"],"max":1,"max_patch_files":500,"max_patch_size":10240,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"request_review","title_prefix":"[docs-vnext-sync] "},"create_report_incomplete_issue":{"title-prefix":"[incomplete]"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4e31ec4cdd4a21f8_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9fca272344703494_EOF'
+          {"create_issue":{"labels":["docs-vnext-sync"],"max":1,"title_prefix":"[docs-vnext-sync]"},"create_report_incomplete_issue":{"title-prefix":"[incomplete]"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_9fca272344703494_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[docs-vnext-sync] \". Labels [\"documentation\" \"docs-vnext\" \"sync\"] will be automatically added."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[docs-vnext-sync]\". Labels [\"docs-vnext-sync\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
             }
           GH_AW_VALIDATION_JSON: |
             {
-              "create_pull_request": {
+              "create_issue": {
                 "defaultMax": 1,
                 "fields": {
-                  "base": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 128
-                  },
                   "body": {
                     "required": true,
                     "type": "string",
                     "sanitize": true,
-                    "maxLength": 65000
+                    "maxLength": 65000,
+                    "minLength": 20
                   },
-                  "branch": {
-                    "required": true,
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 256
-                  },
-                  "draft": {
-                    "type": "boolean"
+                  "fields": {
+                    "type": "array"
                   },
                   "labels": {
                     "type": "array",
@@ -562,9 +549,15 @@ jobs:
                     "itemSanitize": true,
                     "itemMaxLength": 128
                   },
+                  "parent": {
+                    "issueOrPRNumber": true
+                  },
                   "repo": {
                     "type": "string",
                     "maxLength": 256
+                  },
+                  "temporary_id": {
+                    "type": "string"
                   },
                   "title": {
                     "required": true,
@@ -695,7 +688,7 @@ jobs:
           
           mkdir -p "$HOME/.copilot"
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_4d7afc5e625cc05f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f014db59cae17bc3_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -711,20 +704,6 @@ jobs:
                   "allow-only": {
                     "min-integrity": "$GITHUB_MCP_GUARD_MIN_INTEGRITY",
                     "repos": "$GITHUB_MCP_GUARD_REPOS"
-                  }
-                }
-              },
-              "mintlify-docs": {
-                "type": "http",
-                "url": "https://mintlify.com/docs/mcp",
-                "tools": [
-                  "*"
-                ],
-                "guard-policies": {
-                  "write-sink": {
-                    "accept": [
-                      "*"
-                    ]
                   }
                 }
               },
@@ -767,7 +746,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_4d7afc5e625cc05f_EOF
+          GH_AW_MCP_CONFIG_f014db59cae17bc3_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -793,24 +772,11 @@ jobs:
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
         # --allow-tool github
-        # --allow-tool mintlify-docs
-        # --allow-tool mintlify-docs(*)
         # --allow-tool safeoutputs
+        # --allow-tool shell(cat /tmp/gh-aw/agent/docs-vnext-sync-manifest.json)
         # --allow-tool shell(cat)
-        # --allow-tool shell(cp)
         # --allow-tool shell(date)
-        # --allow-tool shell(diff)
         # --allow-tool shell(echo)
-        # --allow-tool shell(find)
-        # --allow-tool shell(git add:*)
-        # --allow-tool shell(git branch:*)
-        # --allow-tool shell(git checkout:*)
-        # --allow-tool shell(git commit:*)
-        # --allow-tool shell(git merge:*)
-        # --allow-tool shell(git rm:*)
-        # --allow-tool shell(git status)
-        # --allow-tool shell(git switch:*)
-        # --allow-tool shell(git:*)
         # --allow-tool shell(grep)
         # --allow-tool shell(head)
         # --allow-tool shell(ls)
@@ -823,7 +789,7 @@ jobs:
         # --allow-tool shell(wc)
         # --allow-tool shell(yq)
         # --allow-tool write
-        timeout-minutes: 30
+        timeout-minutes: 10
         run: |
           set -o pipefail
           printf '%s' "$(date +%s%3N)" > /tmp/gh-aw/agent_cli_start_ms.txt
@@ -838,7 +804,7 @@ jobs:
           export COPILOT_API_KEY="$COPILOT_DUMMY_BYOK"
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
           GH_AW_MAX_AI_CREDITS="${GH_AW_MAX_AI_CREDITS:-1000}"
-          printf '%s\n' "{\"\$schema\":\"https://github.com/github/gh-aw-firewall/releases/download/v0.27.11/awf-config.schema.json\",\"network\":{\"allowDomains\":[\"api.business.githubcopilot.com\",\"api.enterprise.githubcopilot.com\",\"api.github.com\",\"api.githubcopilot.com\",\"api.individual.githubcopilot.com\",\"api.snapcraft.io\",\"archive.ubuntu.com\",\"azure.archive.ubuntu.com\",\"crl.geotrust.com\",\"crl.globalsign.com\",\"crl.identrust.com\",\"crl.sectigo.com\",\"crl.thawte.com\",\"crl.usertrust.com\",\"crl.verisign.com\",\"crl3.digicert.com\",\"crl4.digicert.com\",\"crls.ssl.com\",\"github.com\",\"host.docker.internal\",\"json-schema.org\",\"json.schemastore.org\",\"keyserver.ubuntu.com\",\"mintlify.com\",\"ocsp.digicert.com\",\"ocsp.geotrust.com\",\"ocsp.globalsign.com\",\"ocsp.identrust.com\",\"ocsp.sectigo.com\",\"ocsp.ssl.com\",\"ocsp.thawte.com\",\"ocsp.usertrust.com\",\"ocsp.verisign.com\",\"packagecloud.io\",\"packages.cloud.google.com\",\"packages.microsoft.com\",\"ppa.launchpad.net\",\"raw.githubusercontent.com\",\"registry.npmjs.org\",\"s.symcb.com\",\"s.symcd.com\",\"security.ubuntu.com\",\"telemetry.enterprise.githubcopilot.com\",\"ts-crl.ws.symantec.com\",\"ts-ocsp.ws.symantec.com\",\"www.googleapis.com\"]},\"apiProxy\":{\"enabled\":true,\"enableTokenSteering\":true,\"maxRuns\":500,\"maxAiCredits\":${GH_AW_MAX_AI_CREDITS},\"maxCacheMisses\":5,\"models\":{\"agent\":[\"sonnet-6x\",\"gpt-5.5\",\"gpt-5.4\",\"gpt-5.3\",\"gemini-pro\",\"any\"],\"antigravity\":[\"copilot/antigravity*\",\"google/antigravity*\",\"gemini/antigravity*\"],\"any\":[\"copilot/*\",\"anthropic/*\",\"openai/*\",\"google/*\",\"gemini/*\"],\"claude\":[\"agent\"],\"codex\":[\"agent\"],\"coding\":[\"copilot/gpt-5*codex*\",\"openai/gpt-5*codex*\",\"gpt-5-codex\"],\"computer-use\":[\"copilot/*computer-use*\",\"google/*computer-use*\",\"gemini/*computer-use*\",\"openai/*computer-use*\"],\"copilot\":[\"agent\"],\"deep-research\":[\"copilot/deep-research*\",\"copilot/o3-deep-research*\",\"copilot/o4-mini-deep-research*\",\"google/deep-research*\",\"gemini/deep-research*\",\"openai/o3-deep-research*\",\"openai/o4-mini-deep-research*\"],\"gemini\":[\"agent\"],\"gemini-3-flash\":[\"copilot/gemini-3*flash*\",\"google/gemini-3*flash*\",\"gemini/gemini-3*flash*\"],\"gemini-3-pro\":[\"copilot/gemini-3*pro*\",\"google/gemini-3*pro*\",\"google/nano-banana*\",\"gemini/gemini-3*pro*\"],\"gemini-3.1-flash\":[\"copilot/gemini-3.1*flash*\",\"google/gemini-3.1*flash*\",\"gemini/gemini-3.1*flash*\"],\"gemini-3.1-pro\":[\"copilot/gemini-3.1*pro*\",\"google/gemini-3.1*pro*\",\"gemini/gemini-3.1*pro*\"],\"gemini-3.5-flash\":[\"copilot/gemini-3.5*flash*\",\"google/gemini-3.5*flash*\",\"gemini/gemini-3.5*flash*\"],\"gemini-flash\":[\"copilot/gemini-*flash*\",\"google/gemini-*flash*\",\"gemini/gemini-*flash*\"],\"gemini-flash-lite\":[\"copilot/gemini-*flash*lite*\",\"google/gemini-*flash*lite*\",\"gemini/gemini-*flash*lite*\"],\"gemini-pro\":[\"copilot/gemini-*pro*\",\"google/gemini-*pro*\",\"gemini/gemini-*pro*\"],\"gemma\":[\"copilot/gemma*\",\"google/gemma*\",\"gemini/gemma*\"],\"gpt-5\":[\"copilot/gpt-5*\",\"openai/gpt-5*\"],\"gpt-5-codex\":[\"copilot/gpt-5*codex*\",\"openai/gpt-5*codex*\"],\"gpt-5-mini\":[\"copilot/gpt-5*mini*\",\"openai/gpt-5*mini*\"],\"gpt-5-nano\":[\"copilot/gpt-5*nano*\",\"openai/gpt-5*nano*\"],\"gpt-5-pro\":[\"copilot/gpt-5*pro*\",\"openai/gpt-5*pro*\"],\"gpt-5.1\":[\"copilot/gpt-5.1*\",\"openai/gpt-5.1*\"],\"gpt-5.2\":[\"copilot/gpt-5.2*\",\"openai/gpt-5.2*\"],\"gpt-5.3\":[\"copilot/gpt-5.3*\",\"openai/gpt-5.3*\"],\"gpt-5.4\":[\"copilot/gpt-5.4*\",\"openai/gpt-5.4*\"],\"gpt-5.5\":[\"copilot/gpt-5.5*\",\"openai/gpt-5.5*\"],\"haiku\":[\"copilot/*haiku*\",\"anthropic/*haiku*\"],\"image-generation\":[\"copilot/gpt-image*\",\"openai/gpt-image*\",\"openai/chatgpt-image*\",\"copilot/gemini-*image*\",\"google/gemini-*image*\",\"gemini/gemini-*image*\",\"google/imagen*\"],\"large\":[\"sonnet\",\"gpt-5-pro\",\"gpt-5\",\"gemini-pro\"],\"mai-code\":[\"copilot/MAI-Code*\",\"copilot/mai-code*\",\"openai/MAI-Code*\"],\"mini\":[\"haiku\",\"gpt-5-mini\",\"gpt-5-nano\",\"gemini-flash-lite\"],\"nano-banana\":[\"copilot/nano-banana*\",\"google/nano-banana*\",\"gemini/nano-banana*\"],\"opus\":[\"copilot/*opus*\",\"anthropic/*opus*\"],\"opusplan\":[\"opus?effort=high\"],\"reasoning\":[\"copilot/o1*\",\"copilot/o3*\",\"copilot/o4*\",\"openai/o1*\",\"openai/o3*\",\"openai/o4*\"],\"robotics\":[\"copilot/*robotics*\",\"google/*robotics*\",\"gemini/*robotics*\"],\"small\":[\"mini\"],\"small-agent\":[\"haiku\",\"gpt-5-mini\",\"gemini-flash\"],\"sonnet\":[\"copilot/*sonnet*\",\"anthropic/*sonnet*\"],\"sonnet-6x\":[\"copilot/*sonnet-4.5*\",\"copilot/*sonnet-4.6*\",\"copilot/*sonnet-4-5-*\",\"anthropic/*sonnet-4-5-*\",\"copilot/*sonnet-4-6*\",\"anthropic/*sonnet-4-6*\"],\"summarization\":[\"haiku\",\"gpt-5-mini\",\"gemini-flash-lite\",\"mini\"],\"vision\":[\"copilot/gemini-*image*\",\"google/gemini-*image*\",\"gemini/gemini-*image*\",\"copilot/gemini-*flash*\",\"google/gemini-*flash*\",\"gemini/gemini-*flash*\"]}},\"container\":{\"imageTag\":\"0.27.11,squid=sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d,agent=sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7,api-proxy=sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d\"}}" > "${RUNNER_TEMP}/gh-aw/awf-config.json"
+          printf '%s\n' "{\"\$schema\":\"https://github.com/github/gh-aw-firewall/releases/download/v0.27.11/awf-config.schema.json\",\"network\":{\"allowDomains\":[\"api.business.githubcopilot.com\",\"api.enterprise.githubcopilot.com\",\"api.github.com\",\"api.githubcopilot.com\",\"api.individual.githubcopilot.com\",\"api.snapcraft.io\",\"archive.ubuntu.com\",\"azure.archive.ubuntu.com\",\"crl.geotrust.com\",\"crl.globalsign.com\",\"crl.identrust.com\",\"crl.sectigo.com\",\"crl.thawte.com\",\"crl.usertrust.com\",\"crl.verisign.com\",\"crl3.digicert.com\",\"crl4.digicert.com\",\"crls.ssl.com\",\"github.com\",\"host.docker.internal\",\"json-schema.org\",\"json.schemastore.org\",\"keyserver.ubuntu.com\",\"ocsp.digicert.com\",\"ocsp.geotrust.com\",\"ocsp.globalsign.com\",\"ocsp.identrust.com\",\"ocsp.sectigo.com\",\"ocsp.ssl.com\",\"ocsp.thawte.com\",\"ocsp.usertrust.com\",\"ocsp.verisign.com\",\"packagecloud.io\",\"packages.cloud.google.com\",\"packages.microsoft.com\",\"ppa.launchpad.net\",\"raw.githubusercontent.com\",\"registry.npmjs.org\",\"s.symcb.com\",\"s.symcd.com\",\"security.ubuntu.com\",\"telemetry.enterprise.githubcopilot.com\",\"ts-crl.ws.symantec.com\",\"ts-ocsp.ws.symantec.com\",\"www.googleapis.com\"]},\"apiProxy\":{\"enabled\":true,\"enableTokenSteering\":true,\"maxRuns\":500,\"maxAiCredits\":${GH_AW_MAX_AI_CREDITS},\"maxCacheMisses\":5,\"models\":{\"agent\":[\"sonnet-6x\",\"gpt-5.5\",\"gpt-5.4\",\"gpt-5.3\",\"gemini-pro\",\"any\"],\"antigravity\":[\"copilot/antigravity*\",\"google/antigravity*\",\"gemini/antigravity*\"],\"any\":[\"copilot/*\",\"anthropic/*\",\"openai/*\",\"google/*\",\"gemini/*\"],\"claude\":[\"agent\"],\"codex\":[\"agent\"],\"coding\":[\"copilot/gpt-5*codex*\",\"openai/gpt-5*codex*\",\"gpt-5-codex\"],\"computer-use\":[\"copilot/*computer-use*\",\"google/*computer-use*\",\"gemini/*computer-use*\",\"openai/*computer-use*\"],\"copilot\":[\"agent\"],\"deep-research\":[\"copilot/deep-research*\",\"copilot/o3-deep-research*\",\"copilot/o4-mini-deep-research*\",\"google/deep-research*\",\"gemini/deep-research*\",\"openai/o3-deep-research*\",\"openai/o4-mini-deep-research*\"],\"gemini\":[\"agent\"],\"gemini-3-flash\":[\"copilot/gemini-3*flash*\",\"google/gemini-3*flash*\",\"gemini/gemini-3*flash*\"],\"gemini-3-pro\":[\"copilot/gemini-3*pro*\",\"google/gemini-3*pro*\",\"google/nano-banana*\",\"gemini/gemini-3*pro*\"],\"gemini-3.1-flash\":[\"copilot/gemini-3.1*flash*\",\"google/gemini-3.1*flash*\",\"gemini/gemini-3.1*flash*\"],\"gemini-3.1-pro\":[\"copilot/gemini-3.1*pro*\",\"google/gemini-3.1*pro*\",\"gemini/gemini-3.1*pro*\"],\"gemini-3.5-flash\":[\"copilot/gemini-3.5*flash*\",\"google/gemini-3.5*flash*\",\"gemini/gemini-3.5*flash*\"],\"gemini-flash\":[\"copilot/gemini-*flash*\",\"google/gemini-*flash*\",\"gemini/gemini-*flash*\"],\"gemini-flash-lite\":[\"copilot/gemini-*flash*lite*\",\"google/gemini-*flash*lite*\",\"gemini/gemini-*flash*lite*\"],\"gemini-pro\":[\"copilot/gemini-*pro*\",\"google/gemini-*pro*\",\"gemini/gemini-*pro*\"],\"gemma\":[\"copilot/gemma*\",\"google/gemma*\",\"gemini/gemma*\"],\"gpt-5\":[\"copilot/gpt-5*\",\"openai/gpt-5*\"],\"gpt-5-codex\":[\"copilot/gpt-5*codex*\",\"openai/gpt-5*codex*\"],\"gpt-5-mini\":[\"copilot/gpt-5*mini*\",\"openai/gpt-5*mini*\"],\"gpt-5-nano\":[\"copilot/gpt-5*nano*\",\"openai/gpt-5*nano*\"],\"gpt-5-pro\":[\"copilot/gpt-5*pro*\",\"openai/gpt-5*pro*\"],\"gpt-5.1\":[\"copilot/gpt-5.1*\",\"openai/gpt-5.1*\"],\"gpt-5.2\":[\"copilot/gpt-5.2*\",\"openai/gpt-5.2*\"],\"gpt-5.3\":[\"copilot/gpt-5.3*\",\"openai/gpt-5.3*\"],\"gpt-5.4\":[\"copilot/gpt-5.4*\",\"openai/gpt-5.4*\"],\"gpt-5.5\":[\"copilot/gpt-5.5*\",\"openai/gpt-5.5*\"],\"haiku\":[\"copilot/*haiku*\",\"anthropic/*haiku*\"],\"image-generation\":[\"copilot/gpt-image*\",\"openai/gpt-image*\",\"openai/chatgpt-image*\",\"copilot/gemini-*image*\",\"google/gemini-*image*\",\"gemini/gemini-*image*\",\"google/imagen*\"],\"large\":[\"sonnet\",\"gpt-5-pro\",\"gpt-5\",\"gemini-pro\"],\"mai-code\":[\"copilot/MAI-Code*\",\"copilot/mai-code*\",\"openai/MAI-Code*\"],\"mini\":[\"haiku\",\"gpt-5-mini\",\"gpt-5-nano\",\"gemini-flash-lite\"],\"nano-banana\":[\"copilot/nano-banana*\",\"google/nano-banana*\",\"gemini/nano-banana*\"],\"opus\":[\"copilot/*opus*\",\"anthropic/*opus*\"],\"opusplan\":[\"opus?effort=high\"],\"reasoning\":[\"copilot/o1*\",\"copilot/o3*\",\"copilot/o4*\",\"openai/o1*\",\"openai/o3*\",\"openai/o4*\"],\"robotics\":[\"copilot/*robotics*\",\"google/*robotics*\",\"gemini/*robotics*\"],\"small\":[\"mini\"],\"small-agent\":[\"haiku\",\"gpt-5-mini\",\"gemini-flash\"],\"sonnet\":[\"copilot/*sonnet*\",\"anthropic/*sonnet*\"],\"sonnet-6x\":[\"copilot/*sonnet-4.5*\",\"copilot/*sonnet-4.6*\",\"copilot/*sonnet-4-5-*\",\"anthropic/*sonnet-4-5-*\",\"copilot/*sonnet-4-6*\",\"anthropic/*sonnet-4-6*\"],\"summarization\":[\"haiku\",\"gpt-5-mini\",\"gemini-flash-lite\",\"mini\"],\"vision\":[\"copilot/gemini-*image*\",\"google/gemini-*image*\",\"gemini/gemini-*image*\",\"copilot/gemini-*flash*\",\"google/gemini-*flash*\",\"gemini/gemini-*flash*\"]}},\"container\":{\"imageTag\":\"0.27.11,squid=sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d,agent=sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7,api-proxy=sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d\"}}" > "${RUNNER_TEMP}/gh-aw/awf-config.json"
           cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           export GH_AW_MODELS_JSON_PATH="/tmp/gh-aw/models.json"
           GH_AW_DOCKER_HOST=""
@@ -859,7 +825,7 @@ jobs:
           fi
           # shellcheck disable=SC1003,SC2086
           sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" ${GH_AW_TOOL_CACHE_MOUNT:+--mount "$GH_AW_TOOL_CACHE_MOUNT"} ${GH_AW_DOCKER_HOST:+--docker-host "$GH_AW_DOCKER_HOST"} ${GH_AW_DOCKER_HOST_PATH_PREFIX_ARGS} --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
-            -- /bin/bash -c 'set +o histexpand; export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && : "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}"; GH_AW_TOOL_CACHE="$RUNNER_TOOL_CACHE"; export PATH="$(find "$GH_AW_TOOL_CACHE" -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; GH_AW_NPM_GLOBAL_ROOT="$(npm root -g 2>/dev/null || true)"; if [ -n "$GH_AW_NPM_GLOBAL_ROOT" ]; then export NODE_PATH="${GH_AW_NPM_GLOBAL_ROOT}${NODE_PATH:+:${NODE_PATH}}"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool mintlify-docs --allow-tool '\''mintlify-docs(*)'\'' --allow-tool safeoutputs --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(cp)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(diff)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(find)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(git:*)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(printf)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'set +o histexpand; export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && : "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}"; GH_AW_TOOL_CACHE="$RUNNER_TOOL_CACHE"; export PATH="$(find "$GH_AW_TOOL_CACHE" -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; GH_AW_NPM_GLOBAL_ROOT="$(npm root -g 2>/dev/null || true)"; if [ -n "$GH_AW_NPM_GLOBAL_ROOT" ]; then export NODE_PATH="${GH_AW_NPM_GLOBAL_ROOT}${NODE_PATH:+:${NODE_PATH}}"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat /tmp/gh-aw/agent/docs-vnext-sync-manifest.json)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(printf)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
@@ -872,7 +838,7 @@ jobs:
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_TIMEOUT_MINUTES: 30
+          GH_AW_TIMEOUT_MINUTES: 10
           GH_AW_VERSION: v0.81.6
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_AW: true
@@ -944,7 +910,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,mintlify.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
+          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
         with:
@@ -1052,9 +1018,8 @@ jobs:
       needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
       issues: write
-      pull-requests: write
     concurrency:
       group: "gh-aw-conclusion-docs-vnext-sync"
       cancel-in-progress: false
@@ -1273,8 +1238,6 @@ jobs:
           GH_AW_AGENTIC_ENGINE_TIMEOUT: ${{ needs.agent.outputs.agentic_engine_timeout }}
           GH_AW_MODEL_NOT_SUPPORTED_ERROR: ${{ needs.agent.outputs.model_not_supported_error }}
           GH_AW_ENGINE_API_HOSTS: "api.enterprise.githubcopilot.com,api.githubcopilot.com,api.business.githubcopilot.com,api.individual.githubcopilot.com"
-          GH_AW_CODE_PUSH_FAILURE_ERRORS: ${{ needs.safe_outputs.outputs.code_push_failure_errors }}
-          GH_AW_CODE_PUSH_FAILURE_COUNT: ${{ needs.safe_outputs.outputs.code_push_failure_count }}
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_DAILY_AI_CREDITS_EXCEEDED: ${{ needs.activation.outputs.daily_ai_credits_exceeded }}
@@ -1284,7 +1247,7 @@ jobs:
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
-          GH_AW_TIMEOUT_MINUTES: "30"
+          GH_AW_TIMEOUT_MINUTES: "10"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -1392,7 +1355,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "Docs-vnext Baseline Sync"
-          WORKFLOW_DESCRIPTION: "Refreshes docs-vnext from canonical docs as a weekly baseline"
+          WORKFLOW_DESCRIPTION: "Produces a deterministic dry-run manifest for the docs-vnext baseline"
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1539,55 +1502,6 @@ jobs:
               }
             }
 
-  pre_activation:
-    runs-on: ubuntu-slim
-    env:
-      GH_AW_RUNTIME_FEATURES: ${{ vars.GH_AW_RUNTIME_FEATURES }}
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_skip_if_match.outputs.skip_check_ok == 'true' }}
-      matched_command: ''
-      setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
-      setup-span-id: ${{ steps.setup.outputs.span-id }}
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@ba6380cc6e5be5d21677bebe04d52fb48e3abec7 # v0.81.6
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Docs-vnext Baseline Sync"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/docs-vnext-sync.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "1.0.65"
-          GH_AW_INFO_AWF_VERSION: "v0.27.11"
-          GH_AW_INFO_ENGINE_ID: "copilot"
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
-      - name: Check skip-if-match query
-        id: check_skip_if_match
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_SKIP_QUERY: "is:pr is:open in:title \"[docs-vnext-sync]\""
-          GH_AW_WORKFLOW_NAME: "Docs-vnext Baseline Sync"
-          GH_AW_SKIP_MAX_MATCHES: "1"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_skip_if_match.cjs');
-            await main();
-
   safe_outputs:
     needs:
       - activation
@@ -1596,9 +1510,8 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
-      contents: write
+      contents: read
       issues: write
-      pull-requests: write
     timeout-minutes: 45
     env:
       GH_AW_AGENT_AIC: ${{ needs.agent.outputs.aic }}
@@ -1621,8 +1534,8 @@ jobs:
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
-      created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
-      created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
+      created_issue_number: ${{ steps.process_safe_outputs.outputs.created_issue_number }}
+      created_issue_url: ${{ steps.process_safe_outputs.outputs.created_issue_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
@@ -1654,25 +1567,6 @@ jobs:
           mkdir -p /tmp/gh-aw/
           find "/tmp/gh-aw/" -type f -print
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
-      - name: Download patch artifact
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: agent
-          path: /tmp/gh-aw/
-      - name: Checkout repository
-        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: true
-          token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-      - name: Configure Git credentials
-        if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_SERVER_URL: ${{ github.server_url }}
-          GIT_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_git_credentials.sh"
       - name: Configure GH_HOST for enterprise compatibility
         id: ghes-host-config
         shell: bash
@@ -1688,11 +1582,10 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
-          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,mintlify.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
+          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_pull_request\":{\"auto_merge\":true,\"draft\":false,\"expires\":168,\"labels\":[\"documentation\",\"docs-vnext\",\"sync\"],\"max\":1,\"max_patch_files\":500,\"max_patch_size\":10240,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"request_review\",\"title_prefix\":\"[docs-vnext-sync] \"},\"create_report_incomplete_issue\":{\"title-prefix\":\"[incomplete]\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
-          GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"docs-vnext-sync\"],\"max\":1,\"title_prefix\":\"[docs-vnext-sync]\"},\"create_report_incomplete_issue\":{\"title-prefix\":\"[incomplete]\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docs-vnext-sync.md
+++ b/.github/workflows/docs-vnext-sync.md
@@ -1,56 +1,60 @@
 ---
 name: Docs-vnext Baseline Sync
-description: Refreshes docs-vnext from canonical docs as a weekly baseline
+description: Produces a deterministic dry-run manifest for the docs-vnext baseline
 on:
   schedule: weekly on sunday
   workflow_dispatch:
-  skip-if-match: 'is:pr is:open in:title "[docs-vnext-sync]"'
 
 permissions:
   contents: read
 
+steps:
+  - name: Generate deterministic docs-vnext sync manifest
+    run: |
+      set -euo pipefail
+      mkdir -p /tmp/gh-aw/agent
+      python3 scripts/generate_docs_vnext_sync_manifest.py \
+        --source-dir docs \
+        --target-dir docs-vnext \
+        --allowlist .github/docs-vnext-sync-preserve.json \
+        --output /tmp/gh-aw/agent/docs-vnext-sync-manifest.json
+  - name: Retain docs-vnext sync manifest
+    uses: actions/upload-artifact@v7.0.1
+    with:
+      name: docs-vnext-sync-manifest-${{ github.run_id }}
+      path: /tmp/gh-aw/agent/docs-vnext-sync-manifest.json
+      if-no-files-found: error
+      retention-days: 30
+
 tools:
   bash:
-    - "cp *"
-    - "find *"
-    - "diff *"
-    - "git"
+    - "cat /tmp/gh-aw/agent/docs-vnext-sync-manifest.json"
 
 safe-outputs:
-  max-patch-files: 500
-  max-patch-size: 10240
-  create-pull-request:
-    title-prefix: "[docs-vnext-sync] "
-    labels: [documentation, docs-vnext, sync]
-    auto-merge: true
-    draft: false
-    expires: 7d
   report-incomplete:
   noop:
     report-as-issue: false
 
 engine: copilot
-imports:
-  - shared/mcp/mintlify-docs.md
 concurrency:
   group: "gh-aw-${{ github.workflow }}"
   cancel-in-progress: true
-timeout-minutes: 30
+timeout-minutes: 10
 ---
 
 # Docs-vnext Baseline Sync
 
-Synchronize `docs-vnext/` from the canonical `docs/` directory as a weekly baseline refresh.
+Review the deterministic dry-run synchronization manifest generated before agent execution.
 
 ## Process
 
-1. Copy all MDX files from `docs/` to `docs-vnext/`, preserving directory structure
-2. Preserve any files unique to `docs-vnext/` (glossary, slides, README)
-3. Commit changes if any upstream updates were detected
+1. Read `/tmp/gh-aw/agent/docs-vnext-sync-manifest.json` once.
+2. Verify that it is valid JSON with `schemaVersion: 1`.
+3. Call `noop` with the aggregate add, modify, remove, preserve, and payload-byte totals.
 
 ## Important
 
-- This workflow refreshes the baseline content only
-- Agent-created improvements (glossary, unbloated prose) in files unique to docs-vnext/ are preserved
-- Files that exist in both directories are overwritten from the canonical source
-- The `docs-vnext/README.md`, `docs-vnext/reference/glossary.mdx`, and `docs-vnext/slides/` are NOT overwritten
+- This workflow is a dry run. Do not modify files or create a pull request.
+- Do not walk, hash, compare, or recalculate the documentation trees.
+- The retained manifest is the complete source of truth for downstream synchronization work.
+- If the manifest is missing, unreadable, or invalid, call `report_incomplete` and stop.

--- a/scripts/generate_docs_vnext_sync_manifest.py
+++ b/scripts/generate_docs_vnext_sync_manifest.py
@@ -1,0 +1,326 @@
+"""Generate a deterministic, non-mutating canonical-to-docs-vnext sync manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Sequence
+
+MANIFEST_SCHEMA_VERSION = 1
+ALLOWLIST_SCHEMA_VERSION = 1
+DECISION_ORDER = {"add": 0, "modify": 1, "remove": 2, "preserve": 3}
+
+
+class SyncManifestError(RuntimeError):
+    """Raised when the synchronization inputs do not satisfy the planning contract."""
+
+
+@dataclass(frozen=True, slots=True)
+class PreserveRule:
+    path: str
+    kind: str
+
+    def matches(self, relative_path: str) -> bool:
+        return relative_path == self.path or (
+            self.kind == "directory" and relative_path.startswith(f"{self.path}/")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FileMetadata:
+    bytes: int
+    sha256: str
+
+    def as_dict(self) -> dict[str, int | str]:
+        return {"bytes": self.bytes, "sha256": self.sha256}
+
+
+def _validate_relative_path(value: Any, source: Path) -> str:
+    if not isinstance(value, str) or not value:
+        raise SyncManifestError(f"Preserve rule path must be a non-empty string: {source}")
+    if "\\" in value or value.startswith("/") or value.endswith("/"):
+        raise SyncManifestError(f"Preserve rule path must be a normalized POSIX relative path: {value!r}")
+
+    parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise SyncManifestError(f"Preserve rule path must not contain empty, '.' or '..' segments: {value!r}")
+
+    normalized = PurePosixPath(value).as_posix()
+    if normalized != value:
+        raise SyncManifestError(f"Preserve rule path is not normalized: {value!r}")
+    return normalized
+
+
+def load_preserve_allowlist(path: Path) -> tuple[PreserveRule, ...]:
+    """Load and schema-validate the explicit docs-vnext preserve allowlist."""
+    if not path.is_file():
+        raise SyncManifestError(f"Preserve allowlist does not exist: {path}")
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SyncManifestError(f"Preserve allowlist is not valid JSON: {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SyncManifestError(f"Preserve allowlist must be a JSON object: {path}")
+
+    allowed_keys = {"$schema", "schemaVersion", "preserve"}
+    unexpected_keys = sorted(set(data) - allowed_keys)
+    if unexpected_keys:
+        raise SyncManifestError(f"Preserve allowlist has unsupported fields {unexpected_keys}: {path}")
+    if set(data) < {"schemaVersion", "preserve"}:
+        raise SyncManifestError(f"Preserve allowlist requires schemaVersion and preserve: {path}")
+    if type(data["schemaVersion"]) is not int or data["schemaVersion"] != ALLOWLIST_SCHEMA_VERSION:
+        raise SyncManifestError(
+            f"Preserve allowlist schemaVersion must be {ALLOWLIST_SCHEMA_VERSION}: {path}"
+        )
+    if "$schema" in data and not isinstance(data["$schema"], str):
+        raise SyncManifestError(f"Preserve allowlist $schema must be a string: {path}")
+    if not isinstance(data["preserve"], list):
+        raise SyncManifestError(f"Preserve allowlist preserve field must be an array: {path}")
+
+    rules: list[PreserveRule] = []
+    seen_paths: set[str] = set()
+    for index, item in enumerate(data["preserve"]):
+        if not isinstance(item, dict) or set(item) != {"kind", "path"}:
+            raise SyncManifestError(
+                f"Preserve rule {index} must contain only kind and path fields: {path}"
+            )
+        if item["kind"] not in {"directory", "file"}:
+            raise SyncManifestError(f"Preserve rule {index} has invalid kind {item['kind']!r}: {path}")
+        relative_path = _validate_relative_path(item["path"], path)
+        if relative_path in seen_paths:
+            raise SyncManifestError(f"Preserve allowlist contains duplicate path {relative_path!r}: {path}")
+        seen_paths.add(relative_path)
+        rules.append(PreserveRule(path=relative_path, kind=item["kind"]))
+
+    rules.sort(key=lambda rule: (rule.path, rule.kind))
+    for index, rule in enumerate(rules):
+        for other in rules[index + 1 :]:
+            if rule.kind == "directory" and other.path.startswith(f"{rule.path}/"):
+                raise SyncManifestError(
+                    f"Preserve rule {other.path!r} overlaps directory rule {rule.path!r}: {path}"
+                )
+    return tuple(rules)
+
+
+def _hash_file(path: Path) -> FileMetadata:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return FileMetadata(bytes=size, sha256=digest.hexdigest())
+
+
+def inventory_tree(root: Path) -> dict[str, FileMetadata]:
+    """Return a sorted, content-addressed inventory of all regular files under root."""
+    if not root.is_dir():
+        raise SyncManifestError(f"Synchronization root is not a directory: {root}")
+    if root.is_symlink():
+        raise SyncManifestError(f"Synchronization root must not be a symbolic link: {root}")
+
+    inventory: dict[str, FileMetadata] = {}
+    for candidate in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
+        relative_path = candidate.relative_to(root).as_posix()
+        if candidate.is_symlink():
+            raise SyncManifestError(f"Synchronization trees must not contain symbolic links: {relative_path}")
+        if candidate.is_file():
+            inventory[relative_path] = _hash_file(candidate)
+    return inventory
+
+
+def _operation_id(decision: str, relative_path: str) -> str:
+    value = f"docs-vnext-sync-manifest-v{MANIFEST_SCHEMA_VERSION}\0{decision}\0{relative_path}"
+    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
+
+
+def _matching_rule(rules: tuple[PreserveRule, ...], relative_path: str) -> PreserveRule | None:
+    return next((rule for rule in rules if rule.matches(relative_path)), None)
+
+
+def _operation(
+    decision: str,
+    relative_path: str,
+    source: FileMetadata | None,
+    target: FileMetadata | None,
+    preserve_rule: PreserveRule | None = None,
+) -> dict[str, Any]:
+    payload_bytes = source.bytes if decision in {"add", "modify"} and source is not None else 0
+    operation: dict[str, Any] = {
+        "id": _operation_id(decision, relative_path),
+        "decision": decision,
+        "path": relative_path,
+        "fileCount": 1,
+        "payloadBytes": payload_bytes,
+        "source": source.as_dict() if source is not None else None,
+        "target": target.as_dict() if target is not None else None,
+    }
+    if preserve_rule is not None:
+        operation["preserveRule"] = {"kind": preserve_rule.kind, "path": preserve_rule.path}
+    return operation
+
+
+def _tree_summary(inventory: dict[str, FileMetadata]) -> dict[str, int]:
+    return {
+        "fileCount": len(inventory),
+        "payloadBytes": sum(metadata.bytes for metadata in inventory.values()),
+    }
+
+
+def _logical_path(path: Path, repository_root: Path | None = None) -> str:
+    resolved_path = path.resolve()
+    if repository_root is not None:
+        try:
+            return resolved_path.relative_to(repository_root.resolve()).as_posix()
+        except ValueError as exc:
+            raise SyncManifestError(
+                f"Manifest inputs must be inside the repository root: {resolved_path}"
+            ) from exc
+    if path.is_absolute():
+        raise SyncManifestError("Absolute manifest inputs require an explicit repository root")
+    return path.as_posix()
+
+
+def build_manifest(
+    source_root: Path,
+    target_root: Path,
+    allowlist_path: Path,
+    repository_root: Path | None = None,
+) -> dict[str, Any]:
+    """Build the complete synchronization plan without changing either input tree."""
+    rules = load_preserve_allowlist(allowlist_path)
+    source_inventory = inventory_tree(source_root)
+    target_inventory = inventory_tree(target_root)
+
+    operations: list[dict[str, Any]] = []
+    matched_paths: dict[PreserveRule, list[str]] = {rule: [] for rule in rules}
+    for relative_path in sorted(source_inventory.keys() | target_inventory.keys()):
+        source = source_inventory.get(relative_path)
+        target = target_inventory.get(relative_path)
+        preserve_rule = _matching_rule(rules, relative_path)
+        if preserve_rule is not None:
+            matched_paths[preserve_rule].append(relative_path)
+            operations.append(
+                _operation("preserve", relative_path, source, target, preserve_rule=preserve_rule)
+            )
+        elif source is None:
+            operations.append(_operation("remove", relative_path, source, target))
+        elif target is None:
+            operations.append(_operation("add", relative_path, source, target))
+        elif source != target:
+            operations.append(_operation("modify", relative_path, source, target))
+
+    operations.sort(key=lambda item: (DECISION_ORDER[item["decision"]], item["path"]))
+    decision_summaries = {
+        decision: {
+            "fileCount": sum(item["fileCount"] for item in operations if item["decision"] == decision),
+            "payloadBytes": sum(
+                item["payloadBytes"] for item in operations if item["decision"] == decision
+            ),
+        }
+        for decision in DECISION_ORDER
+    }
+
+    preserve_rules = []
+    for rule in rules:
+        paths = matched_paths[rule]
+        preserve_rules.append(
+            {
+                "kind": rule.kind,
+                "path": rule.path,
+                "matchedFileCount": len(paths),
+                "matchedTargetBytes": sum(
+                    target_inventory[relative_path].bytes
+                    for relative_path in paths
+                    if relative_path in target_inventory
+                ),
+            }
+        )
+
+    return {
+        "schemaVersion": MANIFEST_SCHEMA_VERSION,
+        "source": {"root": _logical_path(source_root, repository_root), **_tree_summary(source_inventory)},
+        "target": {"root": _logical_path(target_root, repository_root), **_tree_summary(target_inventory)},
+        "preserveAllowlist": {
+            "path": _logical_path(allowlist_path, repository_root),
+            "schemaVersion": ALLOWLIST_SCHEMA_VERSION,
+            "rules": preserve_rules,
+        },
+        "summary": {
+            "operationCount": len(operations),
+            "payloadBytes": sum(item["payloadBytes"] for item in operations),
+            "decisions": decision_summaries,
+        },
+        "operations": operations,
+    }
+
+
+def serialize_manifest(manifest: dict[str, Any]) -> str:
+    """Serialize a manifest canonically for byte-for-byte repeatability."""
+    return json.dumps(manifest, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-dir", type=Path, default=Path("docs"))
+    parser.add_argument("--target-dir", type=Path, default=Path("docs-vnext"))
+    parser.add_argument(
+        "--allowlist",
+        type=Path,
+        default=Path(".github/docs-vnext-sync-preserve.json"),
+    )
+    parser.add_argument(
+        "--repository-root",
+        type=Path,
+        default=Path("."),
+        help="Root used to serialize stable repository-relative input paths.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write the manifest outside the input trees. Omit to emit JSON on stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        if args.output is not None and (
+            _is_within(args.output, args.source_dir) or _is_within(args.output, args.target_dir)
+        ):
+            raise SyncManifestError("Manifest output must be outside the synchronization input trees")
+        manifest = build_manifest(
+            args.source_dir,
+            args.target_dir,
+            args.allowlist,
+            repository_root=args.repository_root,
+        )
+        serialized = serialize_manifest(manifest)
+        if args.output is None:
+            sys.stdout.buffer.write(serialized.encode("utf-8"))
+        else:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_bytes(serialized.encode("utf-8"))
+    except (OSError, SyncManifestError) as exc:
+        print(f"docs-vnext sync manifest error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docs_vnext_sync_manifest.py
+++ b/tests/test_docs_vnext_sync_manifest.py
@@ -1,0 +1,303 @@
+"""Tests for the deterministic docs-vnext baseline synchronization manifest."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+from generate_docs_vnext_sync_manifest import (  # noqa: E402
+    SyncManifestError,
+    build_manifest,
+    load_preserve_allowlist,
+    main,
+    serialize_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write(root: Path, relative_path: str, content: bytes | str) -> None:
+    path = root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, bytes):
+        path.write_bytes(content)
+    else:
+        path.write_text(content, encoding="utf-8")
+
+
+def _write_allowlist(path: Path, preserve: list[dict[str, str]], **extra: object) -> None:
+    path.write_text(
+        json.dumps({"schemaVersion": 1, "preserve": preserve, **extra}),
+        encoding="utf-8",
+    )
+
+
+def _snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_plans_all_decisions_with_canonical_payloads_and_stable_order(tmp_path):
+    source = tmp_path / "docs"
+    target = tmp_path / "docs-vnext"
+    allowlist = tmp_path / "preserve.json"
+    _write(source, "z-add.mdx", "new")
+    _write(source, "a-modify.mdx", "canonical")
+    _write(source, "same.mdx", "same")
+    _write(source, "preserved/shared.mdx", "canonical-preserved")
+    _write(source, "docs.json", "canonical-navigation")
+    _write(target, "a-modify.mdx", "vnext")
+    _write(target, "m-remove.png", b"old-image")
+    _write(target, "same.mdx", "same")
+    _write(target, "preserved/shared.mdx", "vnext-preserved")
+    _write(target, "preserved/only-vnext.mdx", "vnext-only")
+    _write(target, "docs.json", "vnext-navigation")
+    _write_allowlist(
+        allowlist,
+        [
+            {"kind": "file", "path": "docs.json"},
+            {"kind": "directory", "path": "preserved"},
+        ],
+    )
+
+    manifest = build_manifest(source, target, allowlist, tmp_path)
+
+    assert [(item["decision"], item["path"]) for item in manifest["operations"]] == [
+        ("add", "z-add.mdx"),
+        ("modify", "a-modify.mdx"),
+        ("remove", "m-remove.png"),
+        ("preserve", "docs.json"),
+        ("preserve", "preserved/only-vnext.mdx"),
+        ("preserve", "preserved/shared.mdx"),
+    ]
+    operations = {item["path"]: item for item in manifest["operations"]}
+    assert operations["a-modify.mdx"]["payloadBytes"] == len("canonical")
+    assert operations["a-modify.mdx"]["source"]["bytes"] == len("canonical")
+    assert operations["a-modify.mdx"]["target"]["bytes"] == len("vnext")
+    assert operations["m-remove.png"]["payloadBytes"] == 0
+    assert operations["docs.json"]["preserveRule"] == {"kind": "file", "path": "docs.json"}
+    assert all(item["fileCount"] == 1 for item in manifest["operations"])
+    assert all(item["id"].startswith("sha256:") for item in manifest["operations"])
+
+
+def test_summary_has_file_counts_and_payload_estimates(tmp_path):
+    source = tmp_path / "docs"
+    target = tmp_path / "docs-vnext"
+    allowlist = tmp_path / "preserve.json"
+    _write(source, "add.mdx", b"1234")
+    _write(source, "modify.mdx", b"123456")
+    _write(target, "modify.mdx", b"x")
+    _write(target, "remove.mdx", b"removed")
+    _write(target, "keep/file.mdx", b"keep")
+    _write_allowlist(allowlist, [{"kind": "directory", "path": "keep"}])
+
+    summary = build_manifest(source, target, allowlist, tmp_path)["summary"]
+
+    assert summary == {
+        "operationCount": 4,
+        "payloadBytes": 10,
+        "decisions": {
+            "add": {"fileCount": 1, "payloadBytes": 4},
+            "modify": {"fileCount": 1, "payloadBytes": 6},
+            "remove": {"fileCount": 1, "payloadBytes": 0},
+            "preserve": {"fileCount": 1, "payloadBytes": 0},
+        },
+    }
+
+
+def test_repeated_planning_is_byte_identical_and_non_mutating(tmp_path):
+    source = tmp_path / "docs"
+    target = tmp_path / "docs-vnext"
+    allowlist = tmp_path / "preserve.json"
+    _write(source, "b/file.mdx", "source-b")
+    _write(source, "a/file.mdx", "source-a")
+    _write(target, "b/file.mdx", "target-b")
+    _write(target, "remove/file.mdx", "remove")
+    _write_allowlist(allowlist, [])
+    before_source = _snapshot(source)
+    before_target = _snapshot(target)
+
+    first = serialize_manifest(build_manifest(source, target, allowlist, tmp_path))
+    second = serialize_manifest(build_manifest(source, target, allowlist, tmp_path))
+
+    assert first == second
+    assert _snapshot(source) == before_source
+    assert _snapshot(target) == before_target
+
+
+def test_repository_root_makes_absolute_and_relative_input_paths_byte_identical(tmp_path):
+    repository_root = tmp_path / "repo"
+    source = repository_root / "docs"
+    target = repository_root / "docs-vnext"
+    allowlist = repository_root / ".github" / "preserve.json"
+    _write(source, "page.mdx", "canonical")
+    _write(target, "page.mdx", "vnext")
+    allowlist.parent.mkdir(parents=True)
+    _write_allowlist(allowlist, [])
+
+    absolute = serialize_manifest(
+        build_manifest(source.resolve(), target.resolve(), allowlist.resolve(), repository_root)
+    )
+    relative = serialize_manifest(
+        build_manifest(
+            repository_root / "docs",
+            repository_root / "docs-vnext",
+            repository_root / ".github" / "preserve.json",
+            repository_root,
+        )
+    )
+
+    assert absolute == relative
+    manifest = json.loads(absolute)
+    assert manifest["source"]["root"] == "docs"
+    assert manifest["target"]["root"] == "docs-vnext"
+    assert manifest["preserveAllowlist"]["path"] == ".github/preserve.json"
+
+
+def test_cli_writes_only_the_requested_external_manifest(tmp_path):
+    source = tmp_path / "docs"
+    target = tmp_path / "docs-vnext"
+    allowlist = tmp_path / "preserve.json"
+    output = tmp_path / "artifacts" / "manifest.json"
+    _write(source, "add.mdx", "content")
+    target.mkdir()
+    _write_allowlist(allowlist, [])
+
+    exit_code = main(
+        [
+            "--source-dir",
+            str(source),
+            "--target-dir",
+            str(target),
+            "--allowlist",
+            str(allowlist),
+            "--repository-root",
+            str(tmp_path),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    output_bytes = output.read_bytes()
+    assert b"\r\n" not in output_bytes
+    assert json.loads(output_bytes)["summary"]["operationCount"] == 1
+    assert _snapshot(source) == {"add.mdx": b"content"}
+    assert _snapshot(target) == {}
+
+
+def test_cli_rejects_manifest_output_inside_an_input_tree(tmp_path, capsys):
+    source = tmp_path / "docs"
+    target = tmp_path / "docs-vnext"
+    allowlist = tmp_path / "preserve.json"
+    source.mkdir()
+    target.mkdir()
+    _write_allowlist(allowlist, [])
+
+    exit_code = main(
+        [
+            "--source-dir",
+            str(source),
+            "--target-dir",
+            str(target),
+            "--allowlist",
+            str(allowlist),
+            "--repository-root",
+            str(tmp_path),
+            "--output",
+            str(target / "manifest.json"),
+        ]
+    )
+
+    assert exit_code == 2
+    assert "outside the synchronization input trees" in capsys.readouterr().err
+    assert not (target / "manifest.json").exists()
+
+
+@pytest.mark.parametrize(
+    "payload,error",
+    [
+        ({"schemaVersion": 2, "preserve": []}, "schemaVersion"),
+        ({"schemaVersion": 1, "preserve": [], "unknown": True}, "unsupported fields"),
+        (
+            {"schemaVersion": 1, "preserve": [{"kind": "file", "path": "../escape"}]},
+            "must not contain",
+        ),
+        (
+            {"schemaVersion": 1, "preserve": [{"kind": "file", "path": "bad\\path"}]},
+            "normalized POSIX",
+        ),
+        (
+            {"schemaVersion": 1, "preserve": [{"kind": "file", "path": "trailing/"}]},
+            "normalized POSIX",
+        ),
+        (
+            {"schemaVersion": 1, "preserve": [{"kind": "file", "path": "empty//segment"}]},
+            "must not contain",
+        ),
+        (
+            {"schemaVersion": 1, "preserve": [{"kind": "file", "path": "dot/./segment"}]},
+            "must not contain",
+        ),
+        (
+            {
+                "schemaVersion": 1,
+                "preserve": [
+                    {"kind": "file", "path": "README.md"},
+                    {"kind": "file", "path": "README.md"},
+                ],
+            },
+            "duplicate",
+        ),
+        (
+            {
+                "schemaVersion": 1,
+                "preserve": [
+                    {"kind": "directory", "path": "slides"},
+                    {"kind": "file", "path": "slides/deck.md"},
+                ],
+            },
+            "overlaps",
+        ),
+    ],
+)
+def test_allowlist_schema_validation_rejects_invalid_contracts(tmp_path, payload, error):
+    allowlist = tmp_path / "preserve.json"
+    allowlist.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(SyncManifestError, match=error):
+        load_preserve_allowlist(allowlist)
+
+
+def test_repository_preserve_allowlist_is_valid_and_explicit():
+    rules = load_preserve_allowlist(REPO_ROOT / ".github" / "docs-vnext-sync-preserve.json")
+
+    assert [(rule.kind, rule.path) for rule in rules] == [
+        ("directory", ".mintlify"),
+        ("file", "README.md"),
+        ("file", "RFC-navigation-reflow.md"),
+        ("file", "docs.json"),
+        ("file", "reference/glossary.mdx"),
+        ("directory", "slides"),
+    ]
+
+
+def test_json_schema_path_pattern_matches_runtime_normalization_contract():
+    schema = json.loads(
+        (REPO_ROOT / ".github" / "docs-vnext-sync-preserve.schema.json").read_text(encoding="utf-8")
+    )
+    pattern = schema["properties"]["preserve"]["items"]["properties"]["path"]["pattern"]
+
+    for valid_path in [".mintlify", "README.md", "reference/glossary.mdx"]:
+        assert re.fullmatch(pattern, valid_path)
+    for invalid_path in ["/absolute", "bad\\path", "../escape", "a/../b", "a/./b", "a//b", "a/"]:
+        assert re.fullmatch(pattern, invalid_path) is None


### PR DESCRIPTION
## Summary

- add a versioned, schema-validated docs-vnext preserve allowlist
- add a non-mutating full-tree planner with stable operation IDs, deterministic ordering, SHA-256 metadata, and file/payload estimates
- retain the dry-run manifest as a 30-day workflow artifact and remove corpus mutation/PR creation from this planning slice
- add focused coverage for preservation, canonical overwrite, additions, removals, ordering, estimates, invalid contracts, non-mutation, and byte-identical reruns

## Validation

- `pytest -q tests/test_docs_vnext_sync_manifest.py` — 17 passed
- `ruff check scripts/generate_docs_vnext_sync_manifest.py tests/test_docs_vnext_sync_manifest.py` — passed
- `gh aw compile docs-vnext-sync --strict` — 1 workflow compiled, 0 errors, 0 warnings
- two real-corpus dry runs produced identical SHA-256 `C34E2C191D3E825F2726CC9194536C383A780244AABCFDDEB8DC4E9B425E7F04` for 914 operations and 75,411,218 planned payload bytes

Closes #630

After merge, use a genuinely new `Docs-vnext Baseline Sync` workflow dispatch (or the next fresh weekly schedule); rerunning an older run will not exercise this workflow definition.