### PR TITLE
Fail closed on invalid evaluation evidence

### DIFF
--- a/.github/workflows/docs-eval-harness.yml
+++ b/.github/workflows/docs-eval-harness.yml
@@ -38,6 +38,7 @@ env:
   AZURE_SEARCH_ENDPOINT: ${{ secrets.AZURE_SEARCH_ENDPOINT }}
   AZURE_SEARCH_API_KEY: ${{ secrets.AZURE_SEARCH_API_KEY }}
   AZURE_SEARCH_INDEX_NAME: ${{ secrets.AZURE_SEARCH_INDEX_NAME }}
+  AZURE_SEARCH_VNEXT_INDEX_NAME: ${{ secrets.AZURE_SEARCH_VNEXT_INDEX_NAME }}
   AZURE_AI_PROJECT_ENDPOINT: ${{ secrets.AZURE_AI_PROJECT_ENDPOINT }}
   AZURE_AI_PROJECT_API_KEY: ${{ secrets.AZURE_AI_PROJECT_API_KEY }}
   AZURE_OPENAI_EMBEDDING_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_EMBEDDING_DEPLOYMENT }}
@@ -90,9 +91,14 @@ jobs:
 
       - name: Run evaluation for ${{ matrix.server }}
         run: |
+          AZURE_ARGS=()
+          if [[ "${{ matrix.server }}" == foundry-docs* ]]; then
+            AZURE_ARGS+=(--require-azure)
+          fi
           python scripts/run_docs_eval.py \
             --server ${{ matrix.server }} \
             ${{ steps.inputs.outputs.model_args }} \
+            "${AZURE_ARGS[@]}" \
             --output-dir tests/eval_results
 
       - name: Upload partial results
@@ -139,11 +145,23 @@ jobs:
           echo "Found $(echo $FILES | wc -w) result files"
 
       - name: Score merged results
+        id: score
+        continue-on-error: true
         run: |
           mkdir -p tests/eval_results
+          MODELS="${{ inputs.models || 'all' }}"
+          if [ "$MODELS" = "all" ]; then
+            REQUIRED_MODELS=(claude-sonnet-4.6 gpt-5.4)
+          else
+            IFS=',' read -ra REQUIRED_MODELS <<< "$MODELS"
+          fi
           python scripts/eval_scorer.py \
             ${{ steps.collect.outputs.files }} \
-            --output tests/eval_results/scored-merged.json
+            --output tests/eval_results/scored-merged.json \
+            --required-scenarios tests/docs_eval_scenarios.json \
+            --required-servers microsoft-learn mintlify-hosted foundry-docs foundry-docs-vnext \
+            --required-models "${REQUIRED_MODELS[@]}" \
+            --azure-required-servers foundry-docs foundry-docs-vnext
 
       - name: Check MCP/tool discovery state
         run: |
@@ -152,6 +170,7 @@ jobs:
             --skip-hosted || true
 
       - name: Generate report
+        if: always()
         run: |
           python scripts/eval_report.py tests/eval_results/scored-merged.json \
             --mcp-discovery tests/eval_results/mcp_discovery.json \
@@ -159,6 +178,7 @@ jobs:
           cat tests/eval_results/report.md
 
       - name: Upload combined results
+        if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: eval-results-${{ github.run_id }}
@@ -166,6 +186,7 @@ jobs:
           retention-days: 90
 
       - name: Close previous eval report issues
+        if: steps.score.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -177,6 +198,7 @@ jobs:
             done
 
       - name: Create issue with results
+        if: steps.score.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -192,6 +214,7 @@ jobs:
             --body-file tests/eval_results/report.md
 
       - name: Check for regression
+        if: steps.score.outcome == 'success'
         run: |
           python3 -c "
           import json, sys
@@ -204,3 +227,9 @@ jobs:
               sys.exit(1)
           print('✅ No regressions detected')
           " || echo "regression_detected=true" >> "$GITHUB_OUTPUT"
+
+      - name: Fail invalid evaluation evidence
+        if: steps.score.outcome != 'success'
+        run: |
+          echo "Comparative publication blocked because required evaluation evidence is invalid or incomplete."
+          exit 1

--- a/foundry_docs_mcp/_server_factory.py
+++ b/foundry_docs_mcp/_server_factory.py
@@ -119,6 +119,7 @@ def build_server(cfg: ServerConfig) -> FastMCP:
         embed_query = None
         rewrite_query = None
         foundry_client = None
+        require_azure = os.environ.get("FOUNDRY_EVAL_REQUIRE_AZURE", "").casefold() in {"1", "true", "yes"}
 
         if os.environ.get("AZURE_SEARCH_ENDPOINT"):
             try:
@@ -140,7 +141,11 @@ def build_server(cfg: ServerConfig) -> FastMCP:
                 rewrite_query = foundry_client.rewrite_query_for_search
                 logger.info("Azure AI Search hybrid mode enabled for %s", cfg.name)
             except Exception as exc:
+                if require_azure:
+                    raise RuntimeError(f"Azure-required mode failed to initialize for {cfg.name}: {exc}") from exc
                 logger.warning("Failed to initialize Azure hybrid mode; using local search fallback: %s", exc)
+        elif require_azure:
+            raise RuntimeError(f"Azure-required mode needs AZURE_SEARCH_ENDPOINT for {cfg.name}")
 
         telemetry = setup_telemetry(cfg.telemetry_service)
 
@@ -261,6 +266,8 @@ def build_server(cfg: ServerConfig) -> FastMCP:
                 results = azure_index.search(query=effective_query, limit=limit, embedding_fn=embed_query_fn)
                 backend = "azure-hybrid"
             except Exception as exc:
+                if os.environ.get("FOUNDRY_EVAL_REQUIRE_AZURE", "").casefold() in {"1", "true", "yes"}:
+                    raise RuntimeError(f"Azure-required search failed for {cfg.name}: {exc}") from exc
                 await _log(ctx, "warning", f"Azure search failed, falling back to local index: {exc}")
                 index: SearchIndex = _get_index(ctx)
                 results = index.search(query, limit=limit)

--- a/scripts/eval_report.py
+++ b/scripts/eval_report.py
@@ -261,16 +261,73 @@ def generate_operational_metrics(aggregates: dict) -> str:
         )
 
     lines.append(
-        "\n_Pass = process exited 0, produced a non-empty response, and no tool "
-        "execution reported a failure. \"n/a\" means this run's raw results predate "
-        "operational-metrics capture._"
+        "\n_Pass = process exited 0, produced a non-empty response, proved the selected "
+        "documentation source through successful tool evidence, reported no tool errors, "
+        "and proved a live Azure query when required. \"n/a\" means this run's raw results "
+        "predate operational-metrics capture._"
     )
 
     return "\n".join(lines) + "\n"
 
 
+def generate_blocked_report(scored_data: dict) -> str:
+    """Generate diagnostics without comparative claims when evidence is invalid."""
+    metadata = scored_data.get("metadata", {})
+    publication = scored_data.get("publication", {})
+    denominators = scored_data.get("aggregates", {}).get("denominators", {})
+    status_counts = denominators.get("status_counts", {})
+    response_counts = denominators.get("response_counts", {})
+
+    reasons = publication.get("failure_reasons") or ["publication evidence was not validated"]
+    lines = [
+        "# Documentation Evaluation Diagnostics",
+        "",
+        "**Comparative publication blocked.** No scoreboard, ranking, hypothesis result, or comparative score is published.",
+        "",
+        f"**Run ID**: {metadata.get('run_id', 'unknown')}",
+        f"**Timestamp**: {metadata.get('timestamp', 'unknown')}",
+        "",
+        "## Validation summary",
+        "",
+        "| Required | Observed | Unique observed | Valid | Invalid | Errors | Timeouts | Missing rows | Missing responses |",
+        "|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        (
+            f"| {denominators.get('required_rows', 0)} | {denominators.get('observed_rows', 0)} | "
+            f"{denominators.get('unique_observed_rows', 0)} | {status_counts.get('success', 0)} | "
+            f"{status_counts.get('invalid', 0)} | {status_counts.get('error', 0)} | "
+            f"{status_counts.get('timeout', 0)} | {status_counts.get('missing', 0)} | "
+            f"{response_counts.get('missing', 0)} |"
+        ),
+        "",
+        "## Blocking reasons",
+        "",
+        *[f"- {reason}" for reason in reasons],
+        "",
+        "## Invalid or missing required rows",
+        "",
+        "| Row | Status | Failure reason |",
+        "|---|---|---|",
+    ]
+    invalid_rows = publication.get("invalid_rows", [])
+    for row in invalid_rows:
+        reason = str(row.get("failure_reason", "unknown")).replace("|", "\\|")
+        lines.append(f"| {row.get('row', 'unknown')} | {row.get('status', 'invalid')} | {reason} |")
+    if not invalid_rows:
+        lines.append("| n/a | invalid | Matrix-level validation failed; inspect scored JSON diagnostics. |")
+
+    lines.extend([
+        "",
+        "Raw and scored JSON artifacts retain the row-level evidence for diagnosis.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
 def generate_report(scored_data: dict, discovery: dict[str, Any] | None = None) -> str:
     """Generate the full markdown report."""
+    if scored_data.get("publication", {}).get("allowed") is not True:
+        return generate_blocked_report(scored_data)
+
     metadata = scored_data.get("metadata", {})
     aggregates = scored_data.get("aggregates", {})
 

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -13,10 +13,102 @@ import json
 import re
 import sys
 from collections import defaultdict
+from itertools import product
 from pathlib import Path
+
+from run_docs_eval import MCP_SERVERS, _is_search_tool, _source_for_tool
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 RESULTS_DIR = PROJECT_ROOT / "tests" / "eval_results"
+REQUIRED_ROW_FIELDS = (
+    "scenario_id",
+    "server",
+    "model",
+    "category",
+    "response",
+    "response_present",
+    "status",
+    "passed",
+    "selected_source",
+    "selected_source_config",
+    "source_config_count",
+    "observed_tools",
+    "successful_tools",
+    "source_validated",
+    "azure_required",
+    "azure_live_query_proven",
+    "failure_reason",
+    "event_parse_error",
+    "exit_code",
+    "tool_errors",
+    "response_time_seconds",
+)
+
+
+def validate_row_schema(result: object) -> list[str]:
+    """Return schema errors without throwing so malformed rows remain diagnostic."""
+    if not isinstance(result, dict):
+        return ["row must be a JSON object"]
+
+    errors = [f"missing field: {field}" for field in REQUIRED_ROW_FIELDS if field not in result]
+    for field in ("scenario_id", "server", "model", "category", "response", "selected_source"):
+        if field in result and not isinstance(result[field], str):
+            errors.append(f"{field} must be a string")
+    if "status" in result and (
+        not isinstance(result["status"], str)
+        or result["status"] not in {"success", "invalid", "error", "timeout"}
+    ):
+        errors.append("status must be success, invalid, error, or timeout")
+    for field in (
+        "response_present",
+        "passed",
+        "source_validated",
+        "azure_required",
+        "azure_live_query_proven",
+    ):
+        if field in result and type(result[field]) is not bool:
+            errors.append(f"{field} must be a Boolean")
+    if "selected_source_config" in result and not isinstance(result["selected_source_config"], dict):
+        errors.append("selected_source_config must be a JSON object")
+    if "source_config_count" in result and type(result["source_config_count"]) is not int:
+        errors.append("source_config_count must be an integer")
+    for field in ("observed_tools", "successful_tools"):
+        value = result.get(field)
+        if field in result and (
+            not isinstance(value, list) or not all(isinstance(tool_name, str) for tool_name in value)
+        ):
+            errors.append(f"{field} must be a list of strings")
+    if "failure_reason" in result and result["failure_reason"] is not None and not isinstance(
+        result["failure_reason"], str
+    ):
+        errors.append("failure_reason must be a string or null")
+    if "event_parse_error" in result and result["event_parse_error"] is not None and not isinstance(
+        result["event_parse_error"], str
+    ):
+        errors.append("event_parse_error must be a string or null")
+    for field in ("exit_code", "tool_errors"):
+        if field in result and type(result[field]) is not int:
+            errors.append(f"{field} must be an integer")
+    for field in ("turns", "tool_calls", "output_tokens"):
+        if field in result and (type(result[field]) is not int or result[field] < 0):
+            errors.append(f"{field} must be a non-negative integer")
+    response_time = result.get("response_time_seconds")
+    if "response_time_seconds" in result and (
+        not isinstance(response_time, (int, float))
+        or isinstance(response_time, bool)
+        or response_time < 0
+    ):
+        errors.append("response_time_seconds must be a non-negative number")
+    rubric = result.get("rubric")
+    if rubric is not None:
+        if not isinstance(rubric, dict):
+            errors.append("rubric must be a JSON object")
+        else:
+            for field in ("must_mention", "quality_criteria", "expected_docs"):
+                value = rubric.get(field, [])
+                if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+                    errors.append(f"rubric.{field} must be a list of strings")
+    return errors
 
 
 def score_completeness(response: str, must_mention: list[str]) -> float:
@@ -76,33 +168,135 @@ def score_doc_retrieval(response: str, expected_docs: list[str]) -> float:
     return hits / len(expected_docs)
 
 
-def score_result(result: dict) -> dict:
+def score_result(result: object) -> dict:
     """Score a single evaluation result."""
+    schema_errors = validate_row_schema(result)
+    if not isinstance(result, dict):
+        result = {"raw_row": result}
+
     response = result.get("response", "")
+    if not isinstance(response, str):
+        response = ""
     rubric = result.get("rubric", {})
+    if not isinstance(rubric, dict):
+        rubric = {}
     status = result.get("status", "error")
 
     # Operational metrics captured by run_docs_eval.py's structured event-stream
     # parsing. Older raw result files won't have these -- default to None/0 so
     # aggregation can distinguish "known zero" from "not captured".
     operational = {
-        "passed": result.get("passed"),
-        "turns": result.get("turns"),
-        "tool_calls": result.get("tool_calls"),
-        "tool_errors": result.get("tool_errors"),
-        "output_tokens": result.get("output_tokens"),
-        "response_time_seconds": result.get("response_time_seconds"),
+        "passed": result.get("passed") if type(result.get("passed")) is bool else None,
+        "turns": result.get("turns") if type(result.get("turns")) is int and result.get("turns") >= 0 else None,
+        "tool_calls": (
+            result.get("tool_calls")
+            if type(result.get("tool_calls")) is int and result.get("tool_calls") >= 0
+            else None
+        ),
+        "tool_errors": (
+            result.get("tool_errors")
+            if type(result.get("tool_errors")) is int and result.get("tool_errors") >= 0
+            else None
+        ),
+        "output_tokens": (
+            result.get("output_tokens")
+            if type(result.get("output_tokens")) is int and result.get("output_tokens") >= 0
+            else None
+        ),
+        "response_time_seconds": (
+            result.get("response_time_seconds")
+            if isinstance(result.get("response_time_seconds"), (int, float))
+            and not isinstance(result.get("response_time_seconds"), bool)
+            and result.get("response_time_seconds") >= 0
+            else None
+        ),
     }
-
-    if status != "success" or not response:
+    if schema_errors:
+        existing_failure = result.get("failure_reason")
+        schema_failure = "row_schema_invalid: " + "; ".join(schema_errors)
+        failure_reason = f"{existing_failure}; {schema_failure}" if existing_failure else schema_failure
         return {
             **result,
+            "response": response,
+            "response_present": bool(response),
+            "status": "invalid",
+            "passed": False,
+            "source_validated": False,
+            "failure_reason": failure_reason,
+            "row_valid": False,
             "scores": {
                 "completeness": 0.0,
                 "quality": 0.0,
                 "doc_retrieval": 0.0,
-                "response_length": 0,
-                "has_response": False,
+                "response_length": len(response),
+                "has_response": bool(response),
+            },
+            "operational": operational,
+        }
+
+    server = result.get("server")
+    expected_server = MCP_SERVERS.get(server, {})
+    expected_config = expected_server.get("config", {})
+    selected_config = result.get("selected_source_config")
+    observed_tools = result.get("observed_tools")
+    successful_tools = result.get("successful_tools")
+    response_time = result.get("response_time_seconds")
+    expected_type = "local" if expected_server.get("type") == "stdio" else "http"
+    source_schema_valid = (
+        result.get("selected_source") == server
+        and result.get("source_config_count") == 1
+        and isinstance(selected_config, dict)
+        and selected_config.get("name") == expected_config.get("name")
+        and selected_config.get("type") == expected_type
+        and selected_config.get("endpoint") == expected_config.get("url")
+        and selected_config.get("command") == expected_config.get("command")
+        and selected_config.get("tool_prefix") == expected_config.get("tool_prefix")
+        and selected_config.get("azure_required") is result.get("azure_required")
+        and isinstance(observed_tools, list)
+        and bool(observed_tools)
+        and isinstance(successful_tools, list)
+        and bool(successful_tools)
+        and set(successful_tools).issubset(observed_tools)
+        and all(
+            isinstance(tool_name, str) and _source_for_tool(tool_name) == expected_config.get("tool_prefix")
+            for tool_name in observed_tools
+        )
+        and result.get("response_present") is True
+        and bool(response)
+        and isinstance(response_time, (int, float))
+        and not isinstance(response_time, bool)
+        and response_time >= 0
+        and result.get("failure_reason") is None
+        and result.get("event_parse_error") is None
+        and result.get("exit_code") == 0
+        and result.get("tool_errors") == 0
+    )
+    azure_evidence_valid = not result.get("azure_required") or (
+        result.get("azure_live_query_proven") is True
+        and isinstance(successful_tools, list)
+        and any(
+            _source_for_tool(tool_name) == expected_config.get("tool_prefix") and _is_search_tool(tool_name)
+            for tool_name in successful_tools
+        )
+    )
+    row_valid = (
+        status == "success"
+        and result.get("passed") is True
+        and result.get("source_validated") is True
+        and source_schema_valid
+        and azure_evidence_valid
+    )
+
+    if not row_valid:
+        return {
+            **result,
+            "row_valid": False,
+            "scores": {
+                "completeness": 0.0,
+                "quality": 0.0,
+                "doc_retrieval": 0.0,
+                "response_length": len(response),
+                "has_response": bool(response),
             },
             "operational": operational,
         }
@@ -128,7 +322,7 @@ def score_result(result: dict) -> dict:
         + scores["doc_retrieval"] * 0.3
     )
 
-    return {**result, "scores": scores, "operational": operational}
+    return {**result, "row_valid": True, "scores": scores, "operational": operational}
 
 
 def aggregate_scores(scored_results: list[dict]) -> dict:
@@ -151,16 +345,24 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
         "tool_errors_known": False,
         "output_tokens": [],
         "response_time_seconds": [],
+        "status_counts": defaultdict(int),
+        "response_present": 0,
+        "response_missing": 0,
     })
 
     for r in scored_results:
-        server = r["server"]
-        model = r["model"]
-        category = r["category"]
+        server = r.get("server") if isinstance(r.get("server"), str) else "<invalid-server>"
+        model = r.get("model") if isinstance(r.get("model"), str) else "<invalid-model>"
+        category = r.get("category") if isinstance(r.get("category"), str) else "<invalid-category>"
 
         ops = r.get("operational", {})
         agg = server_ops[server]
         agg["total"] += 1
+        agg["status_counts"][r.get("status", "invalid")] += 1
+        if r.get("response_present", bool(r.get("response"))):
+            agg["response_present"] += 1
+        else:
+            agg["response_missing"] += 1
         if ops.get("passed") is not None:
             agg["passed_known"] += 1
             if ops["passed"]:
@@ -177,7 +379,7 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
         if ops.get("response_time_seconds") is not None:
             agg["response_time_seconds"].append(ops["response_time_seconds"])
 
-        if not r.get("scores", {}).get("has_response", False):
+        if not r.get("row_valid"):
             continue
 
         composite = r["scores"]["composite"]
@@ -218,6 +420,11 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
             "avg_response_time_seconds": (
                 avg(agg["response_time_seconds"]) if agg["response_time_seconds"] else None
             ),
+            "status_counts": dict(agg["status_counts"]),
+            "response_counts": {
+                "present": agg["response_present"],
+                "missing": agg["response_missing"],
+            },
         }
 
     return {
@@ -225,6 +432,97 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
         "category_breakdown": category_avg,
         "server_averages": server_avg,
         "operational_metrics": operational_avg,
+    }
+
+
+def validate_required_matrix(
+    scored_results: list[dict],
+    scenario_ids: list[str] | None = None,
+    servers: list[str] | None = None,
+    models: list[str] | None = None,
+    azure_required_servers: set[str] | None = None,
+) -> dict:
+    """Validate required scenario/server/model rows and produce complete denominators."""
+    azure_required_servers = azure_required_servers or set()
+    rows_by_key: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
+    malformed_rows: list[dict] = []
+    for index, row in enumerate(scored_results):
+        identity = (row.get("scenario_id"), row.get("server"), row.get("model"))
+        if not all(isinstance(value, str) for value in identity):
+            malformed_rows.append({
+                "row": f"input-index-{index}",
+                "status": "invalid",
+                "failure_reason": row.get("failure_reason") or "row identity is missing or invalid",
+            })
+            continue
+        key = identity
+        rows_by_key[key].append(row)
+
+    if scenario_ids is not None and servers is not None and models is not None:
+        expected_keys = set(product(scenario_ids, servers, models))
+    else:
+        expected_keys = set(rows_by_key)
+
+    status_counts = {"success": 0, "invalid": 0, "error": 0, "timeout": 0, "missing": 0}
+    response_counts = {"present": 0, "missing": 0}
+    invalid_rows: list[dict] = []
+    duplicate_rows: list[str] = []
+
+    for key in sorted(expected_keys):
+        row_id = " / ".join(key)
+        rows = rows_by_key.get(key, [])
+        if not rows:
+            status_counts["missing"] += 1
+            invalid_rows.append({"row": row_id, "status": "missing", "failure_reason": "required row missing"})
+            continue
+
+        if len(rows) > 1:
+            duplicate_rows.append(row_id)
+
+        row = rows[0]
+        if row["server"] in azure_required_servers and not (
+            row.get("azure_required") is True
+            and row.get("azure_live_query_proven") is True
+            and any(_is_search_tool(tool_name) for tool_name in row.get("successful_tools", []))
+        ):
+            row["row_valid"] = False
+            if not row.get("failure_reason"):
+                row["failure_reason"] = "azure_required_evidence_missing"
+        response_counts["present" if row.get("response_present", bool(row.get("response"))) else "missing"] += 1
+        status = row.get("status", "invalid")
+        outcome = status if status in {"error", "timeout"} else ("success" if row.get("row_valid") else "invalid")
+        status_counts[outcome] += 1
+
+        if not row.get("row_valid"):
+            invalid_rows.append({
+                "row": row_id,
+                "status": outcome,
+                "failure_reason": row.get("failure_reason") or "row evidence invalid",
+            })
+
+    unexpected_rows = sorted(" / ".join(key) for key in set(rows_by_key) - expected_keys)
+    invalid_rows.extend(malformed_rows)
+    status_counts["invalid"] += len(malformed_rows)
+    allowed = not invalid_rows and not duplicate_rows and not unexpected_rows
+    failure_reasons = []
+    if invalid_rows:
+        failure_reasons.append(f"{len(invalid_rows)} required row(s) are invalid or missing")
+    if duplicate_rows:
+        failure_reasons.append(f"{len(duplicate_rows)} required row(s) are duplicated")
+    if unexpected_rows:
+        failure_reasons.append(f"{len(unexpected_rows)} unexpected row(s) were supplied")
+
+    return {
+        "allowed": allowed,
+        "failure_reasons": failure_reasons,
+        "required_rows": len(expected_keys),
+        "observed_rows": len(scored_results),
+        "unique_observed_rows": len(rows_by_key),
+        "status_counts": status_counts,
+        "response_counts": response_counts,
+        "invalid_rows": invalid_rows,
+        "duplicate_rows": duplicate_rows,
+        "unexpected_rows": unexpected_rows,
     }
 
 
@@ -238,6 +536,22 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output", default=None,
         help="Path to save scored results (default: scored-{run_id}.json)"
+    )
+    parser.add_argument(
+        "--required-scenarios", default=None,
+        help="Scenario JSON whose IDs define the required matrix rows"
+    )
+    parser.add_argument(
+        "--required-servers", nargs="+", default=None,
+        help="Servers required for comparative publication"
+    )
+    parser.add_argument(
+        "--required-models", nargs="+", default=None,
+        help="Models required for comparative publication"
+    )
+    parser.add_argument(
+        "--azure-required-servers", nargs="*", default=None,
+        help="Required servers whose rows must prove a live Azure search"
     )
     return parser.parse_args()
 
@@ -284,6 +598,24 @@ def main():
 
     scored_results = [score_result(r) for r in all_results]
     aggregates = aggregate_scores(scored_results)
+    scenario_ids = None
+    if args.required_scenarios:
+        with open(args.required_scenarios) as f:
+            scenario_ids = [scenario["id"] for scenario in json.load(f)]
+    publication = validate_required_matrix(
+        scored_results,
+        scenario_ids=scenario_ids,
+        servers=args.required_servers,
+        models=args.required_models,
+        azure_required_servers=set(args.azure_required_servers or []),
+    )
+    aggregates["denominators"] = {
+        "required_rows": publication["required_rows"],
+        "observed_rows": publication["observed_rows"],
+        "unique_observed_rows": publication["unique_observed_rows"],
+        "status_counts": publication["status_counts"],
+        "response_counts": publication["response_counts"],
+    }
 
     output_data = {
         "metadata": {
@@ -291,6 +623,7 @@ def main():
             "scoring_version": "1.0",
         },
         "aggregates": aggregates,
+        "publication": publication,
         "results": scored_results,
     }
 
@@ -304,8 +637,15 @@ def main():
         json.dump(output_data, f, indent=2)
 
     print(f"Scored results saved to {output_path}")
+    if not publication["allowed"]:
+        print(
+            "Comparative publication blocked: " + "; ".join(publication["failure_reasons"]),
+            file=sys.stderr,
+        )
 
-    # Print summary
+    if not publication["allowed"]:
+        raise SystemExit(1)
+
     print("\n=== Server Averages ===")
     for server, avg_val in sorted(
         aggregates["server_averages"].items(), key=lambda x: -x[1]

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -20,6 +20,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -36,7 +37,8 @@ MCP_SERVERS = {
         "type": "remote",
         "description": "Microsoft Learn official docs (control A)",
         "config": {
-            # MS Learn MCP is available as a built-in tool in Copilot CLI
+            "name": "MicrosoftDocs",
+            "url": "https://learn.microsoft.com/api/mcp",
             "tool_prefix": "MicrosoftDocs",
         },
     },
@@ -44,6 +46,7 @@ MCP_SERVERS = {
         "type": "remote",
         "description": "Mintlify hosted MCP (control B)",
         "config": {
+            "name": "mintlify",
             "url": "https://hobbyist-e43fa225.mintlify.app/mcp",
             "tool_prefix": "mintlify",
         },
@@ -52,19 +55,43 @@ MCP_SERVERS = {
         "type": "stdio",
         "description": "Custom FastMCP over docs/ (control C)",
         "config": {
+            "name": "foundry_docs",
             "command": "foundry-docs",
             "tool_prefix": "foundry_docs",
+            "supports_azure": True,
         },
     },
     "foundry-docs-vnext": {
         "type": "stdio",
         "description": "Custom FastMCP over docs-vnext/ (treatment)",
         "config": {
+            "name": "foundry_docs_vnext",
             "command": "foundry-docs-vnext",
             "tool_prefix": "foundry_docs_vnext",
+            "supports_azure": True,
         },
     },
 }
+
+AZURE_REQUIRED_ENV = ("AZURE_SEARCH_ENDPOINT", "AZURE_AI_PROJECT_ENDPOINT")
+AZURE_PASSTHROUGH_ENV = (
+    "AZURE_SEARCH_ENDPOINT",
+    "AZURE_SEARCH_API_KEY",
+    "AZURE_SEARCH_INDEX_NAME",
+    "AZURE_SEARCH_VNEXT_INDEX_NAME",
+    "AZURE_AI_PROJECT_ENDPOINT",
+    "AZURE_AI_PROJECT_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_OPENAI_EMBEDDING_DEPLOYMENT",
+    "AZURE_AI_MODEL_DEPLOYMENT_NAME",
+)
+KNOWN_TOOL_PREFIXES = tuple(
+    sorted(
+        (server["config"]["tool_prefix"] for server in MCP_SERVERS.values()),
+        key=len,
+        reverse=True,
+    )
+)
 
 
 def load_scenarios(path: Path) -> list[dict]:
@@ -76,8 +103,9 @@ def load_scenarios(path: Path) -> list[dict]:
 def build_prompt(question: str, server_name: str) -> str:
     """Build the evaluation prompt for a given question and server."""
     return (
-        f"Answer the following question about Microsoft Foundry using ONLY "
-        f"the documentation tools available to you. Be thorough and include "
+        f"Answer the following question about Microsoft Foundry using ONLY the "
+        f"`{server_name}` documentation source configured for this evaluation row. "
+        f"You must call its documentation search tool before answering. Be thorough and include "
         f"code examples where relevant.\n\n"
         f"Question: {question}\n\n"
         f"Instructions:\n"
@@ -89,14 +117,80 @@ def build_prompt(question: str, server_name: str) -> str:
     )
 
 
+def build_mcp_config(server_config: dict, require_azure: bool = False) -> tuple[dict, dict]:
+    """Build one isolated MCP configuration and its non-secret row descriptor."""
+    config = server_config["config"]
+    source_name = config["name"]
+
+    if server_config["type"] == "remote":
+        mcp_server = {
+            "type": "http",
+            "url": config["url"],
+            "tools": ["*"],
+        }
+    elif server_config["type"] == "stdio":
+        mcp_server = {
+            "type": "local",
+            "command": config["command"],
+            "args": list(config.get("args", [])),
+            "tools": ["*"],
+        }
+    else:
+        raise ValueError(f"Unsupported MCP server type: {server_config['type']}")
+
+    azure_required = require_azure and bool(config.get("supports_azure"))
+    if azure_required:
+        missing = [name for name in AZURE_REQUIRED_ENV if not os.environ.get(name)]
+        if missing:
+            raise ValueError(f"Azure-required mode is missing environment variables: {', '.join(missing)}")
+        mcp_server["env"] = {
+            name: os.environ[name]
+            for name in AZURE_PASSTHROUGH_ENV
+            if os.environ.get(name)
+        }
+        mcp_server["env"]["FOUNDRY_EVAL_REQUIRE_AZURE"] = "true"
+
+    descriptor = {
+        "name": source_name,
+        "type": mcp_server["type"],
+        "endpoint": config.get("url"),
+        "command": config.get("command"),
+        "tool_prefix": config["tool_prefix"],
+        "azure_required": azure_required,
+    }
+    return {"mcpServers": {source_name: mcp_server}}, descriptor
+
+
+def _tool_matches_source(tool_name: str, tool_prefix: str) -> bool:
+    normalized_tool = tool_name.casefold()
+    normalized_prefix = tool_prefix.casefold()
+    if normalized_tool == normalized_prefix:
+        return True
+    return any(
+        normalized_tool.startswith(f"{normalized_prefix}{separator}")
+        for separator in (".", "/", ":", "-", "_")
+    )
+
+
+def _source_for_tool(tool_name: str) -> str | None:
+    return next(
+        (prefix for prefix in KNOWN_TOOL_PREFIXES if _tool_matches_source(tool_name, prefix)),
+        None,
+    )
+
+
+def _is_search_tool(tool_name: str) -> bool:
+    normalized = tool_name.casefold().replace("-", "_").replace(".", "_").replace("/", "_").replace(":", "_")
+    return "search_docs" in normalized or normalized.endswith("_search")
+
+
 def parse_event_stream(stdout: str) -> dict:
     """Parse `copilot --output-format json` JSONL output into operational metrics.
 
     Extracts the final assistant response text plus turn count, tool-call count,
     tool-execution failures, output token usage, and session/API duration from the
-    structured event stream. Falls back gracefully (zeroed metrics, raw stdout as
-    response) if a line fails to parse or the expected events are absent -- e.g. for
-    older copilot CLI builds or unexpected output shapes.
+    structured event stream. Malformed or incomplete event evidence is retained as
+    a parse error so evaluation rows fail closed.
     """
     metrics = {
         "turns": 0,
@@ -108,51 +202,166 @@ def parse_event_stream(stdout: str) -> dict:
         "session_duration_ms": None,
         "result_exit_code": None,
         "parse_error": None,
+        "observed_tools": [],
+        "successful_tools": [],
     }
 
     last_message_content = ""
     turn_ids: set[str] = set()
     parsed_any = False
+    result_seen = False
+    parse_errors: list[str] = []
+    started_tools: dict[str, str] = {}
+    completed_tool_calls: set[str] = set()
+    final_response_line: int | None = None
+    last_successful_tool_line: int | None = None
 
-    for line in stdout.splitlines():
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
         line = line.strip()
         if not line:
             continue
         try:
             event = json.loads(line)
         except (json.JSONDecodeError, ValueError):
+            parse_errors.append(f"line {line_number}: invalid JSON event")
             continue
+        if not isinstance(event, dict):
+            parse_errors.append(f"line {line_number}: event must be a JSON object")
+            continue
+        if result_seen:
+            parse_errors.append(f"line {line_number}: event occurred after terminal result")
 
         parsed_any = True
         etype = event.get("type")
         data = event.get("data", {})
+        if not isinstance(data, dict):
+            parse_errors.append(f"line {line_number}: event data must be a JSON object")
+            continue
 
         if etype == "assistant.turn_start":
             turn_id = data.get("turnId")
-            if turn_id is not None:
-                turn_ids.add(turn_id)
+            if isinstance(turn_id, (str, int)):
+                turn_ids.add(str(turn_id))
+            elif turn_id is not None:
+                parse_errors.append(f"line {line_number}: turn ID must be a string or integer")
         elif etype == "assistant.message":
             content = data.get("content")
-            if content:
+            if isinstance(content, str) and content:
                 last_message_content = content
-            metrics["output_tokens"] += data.get("outputTokens", 0) or 0
+                final_response_line = line_number
+            elif content is not None and not isinstance(content, str):
+                parse_errors.append(f"line {line_number}: assistant content must be a string")
+            output_tokens = data.get("outputTokens", 0) or 0
+            if type(output_tokens) is int and output_tokens >= 0:
+                metrics["output_tokens"] += output_tokens
+            else:
+                parse_errors.append(f"line {line_number}: output token count must be a non-negative integer")
+        elif etype == "tool.execution_start":
+            tool_call_id = data.get("toolCallId")
+            tool_name = data.get("toolName")
+            if not isinstance(tool_call_id, str) or not isinstance(tool_name, str):
+                parse_errors.append(f"line {line_number}: tool start missing identity")
+                continue
+            if tool_call_id in started_tools:
+                parse_errors.append(f"line {line_number}: duplicate tool start for {tool_call_id}")
+                continue
+            started_tools[tool_call_id] = tool_name
+            if tool_name not in metrics["observed_tools"]:
+                metrics["observed_tools"].append(tool_name)
         elif etype == "tool.execution_complete":
             metrics["tool_calls"] += 1
+            tool_call_id = data.get("toolCallId")
+            tool_name = data.get("toolName") or started_tools.get(tool_call_id)
+            if (
+                not isinstance(tool_call_id, str)
+                or not isinstance(tool_name, str)
+                or tool_call_id not in started_tools
+            ):
+                parse_errors.append(f"line {line_number}: tool completion missing matching start")
+            elif tool_call_id in completed_tool_calls:
+                parse_errors.append(f"line {line_number}: duplicate tool completion for {tool_call_id}")
+            elif tool_name != started_tools[tool_call_id]:
+                parse_errors.append(
+                    f"line {line_number}: tool completion name {tool_name} does not match "
+                    f"start name {started_tools[tool_call_id]}"
+                )
+            else:
+                completed_tool_calls.add(tool_call_id)
+                if tool_name not in metrics["observed_tools"]:
+                    metrics["observed_tools"].append(tool_name)
+                if type(data.get("success")) is not bool:
+                    parse_errors.append(f"line {line_number}: tool completion missing Boolean success")
+                elif data["success"] is True and tool_name not in metrics["successful_tools"]:
+                    metrics["successful_tools"].append(tool_name)
+                    last_successful_tool_line = line_number
             if data.get("success") is False:
                 metrics["tool_errors"] += 1
         elif etype == "result":
+            if result_seen:
+                parse_errors.append(f"line {line_number}: duplicate terminal result")
+            result_seen = True
             metrics["result_exit_code"] = event.get("exitCode")
             usage = event.get("usage", {}) or {}
-            metrics["premium_requests"] = usage.get("premiumRequests")
-            metrics["api_duration_ms"] = usage.get("totalApiDurationMs")
-            metrics["session_duration_ms"] = usage.get("sessionDurationMs")
+            if isinstance(usage, dict):
+                metrics["premium_requests"] = usage.get("premiumRequests")
+                metrics["api_duration_ms"] = usage.get("totalApiDurationMs")
+                metrics["session_duration_ms"] = usage.get("sessionDurationMs")
+            else:
+                parse_errors.append(f"line {line_number}: result usage must be a JSON object")
 
     metrics["turns"] = len(turn_ids)
 
     if not parsed_any:
-        metrics["parse_error"] = "no parseable JSON events found in stdout"
+        parse_errors.append("no parseable JSON events found in stdout")
+    if not result_seen:
+        parse_errors.append("result event missing from stdout")
+    elif type(metrics["result_exit_code"]) is not int:
+        parse_errors.append("result event missing integer exit code")
+
+    incomplete_calls = sorted(set(started_tools) - completed_tool_calls)
+    if incomplete_calls:
+        parse_errors.append(f"{len(incomplete_calls)} tool call(s) missing completion evidence")
+    if (
+        final_response_line is not None
+        and last_successful_tool_line is not None
+        and final_response_line < last_successful_tool_line
+    ):
+        parse_errors.append("assistant response preceded the final successful documentation tool")
+
+    metrics["parse_error"] = "; ".join(dict.fromkeys(parse_errors)) or None
 
     return {"response": last_message_content, **metrics}
+
+
+def validate_row_evidence(parsed: dict, tool_prefix: str, azure_required: bool) -> tuple[bool, str | None, bool]:
+    """Validate selected-source and optional Azure evidence for one row."""
+    if parsed["parse_error"]:
+        return False, f"event_parse_failure: {parsed['parse_error']}", False
+    if parsed["tool_errors"]:
+        return False, f"tool_error: {parsed['tool_errors']} tool execution(s) failed", False
+
+    observed_tools = parsed["observed_tools"]
+    cross_source_tools = [name for name in observed_tools if _source_for_tool(name) != tool_prefix]
+    if cross_source_tools:
+        return False, f"cross_source_tool_call: {', '.join(cross_source_tools)}", False
+    if not observed_tools:
+        return False, "source_selection_unproven: no documentation tool calls observed", False
+    if not any(_source_for_tool(name) == tool_prefix for name in parsed["successful_tools"]):
+        return False, "source_selection_unproven: no selected-source tool completed successfully", False
+    if not parsed["response"]:
+        return False, "missing_response: no assistant response event contained content", False
+
+    azure_live_query_proven = (
+        azure_required
+        and any(
+            _tool_matches_source(name, tool_prefix) and _is_search_tool(name)
+            for name in parsed["successful_tools"]
+        )
+    )
+    if azure_required and not azure_live_query_proven:
+        return False, "azure_live_query_unproven: selected search tool did not complete successfully", False
+
+    return True, None, azure_live_query_proven
 
 
 def run_single_eval(
@@ -161,10 +370,12 @@ def run_single_eval(
     server_config: dict,
     model: str,
     timeout: int = 120,
+    require_azure: bool = False,
 ) -> dict:
     """Run a single evaluation: one scenario × one server × one model."""
     question = scenario["question"]
-    prompt = build_prompt(question, server_name)
+    source_name = server_config["config"]["name"]
+    prompt = build_prompt(question, source_name)
 
     result = {
         "scenario_id": scenario["id"],
@@ -174,48 +385,110 @@ def run_single_eval(
         "model": model,
         "rubric": scenario["rubric"],
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "selected_source": server_name,
+        "selected_source_config": None,
+        "source_config_count": 0,
+        "observed_tools": [],
+        "successful_tools": [],
+        "response_present": False,
+        "failure_reason": None,
+        "source_validated": False,
+        "azure_required": False,
+        "azure_live_query_proven": False,
     }
 
     start_time = time.monotonic()
 
     try:
-        cmd = [
-            "copilot",
-            "--model", model,
-            "--prompt", prompt,
-            "--output-format", "json",
-        ]
+        mcp_config, source_descriptor = build_mcp_config(server_config, require_azure=require_azure)
+        result["selected_source_config"] = source_descriptor
+        result["source_config_count"] = len(mcp_config["mcpServers"])
+        result["azure_required"] = source_descriptor["azure_required"]
+    except ValueError as exc:
+        elapsed = time.monotonic() - start_time
+        result.update({
+            "response": "",
+            "stderr": str(exc),
+            "exit_code": -1,
+            "response_time_seconds": round(elapsed, 2),
+            "status": "error",
+            "passed": False,
+            "failure_reason": f"setup_error: {exc}",
+            "turns": 0,
+            "tool_calls": 0,
+            "tool_errors": 0,
+            "output_tokens": 0,
+            "premium_requests": None,
+            "api_duration_ms": None,
+            "session_duration_ms": None,
+            "event_parse_error": None,
+        })
+        return result
 
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=timeout,
-            cwd=str(PROJECT_ROOT),
-        )
+    try:
+        with tempfile.TemporaryDirectory(prefix="foundry-docs-eval-") as isolated_home:
+            config_path = Path(isolated_home) / "selected-source.json"
+            config_path.write_text(json.dumps(mcp_config), encoding="utf-8")
+            config_path.chmod(0o600)
+
+            cmd = [
+                "copilot",
+                "--model", model,
+                "--prompt", prompt,
+                "--output-format", "json",
+                "--disable-builtin-mcps",
+                "--additional-mcp-config", f"@{config_path}",
+                f"--available-tools={source_name}",
+                f"--allow-tool={source_name}",
+                "--no-ask-user",
+            ]
+            process_env = os.environ.copy()
+            process_env["COPILOT_HOME"] = isolated_home
+
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout,
+                cwd=isolated_home,
+                env=process_env,
+            )
 
         elapsed = time.monotonic() - start_time
         parsed = parse_event_stream(proc.stdout)
-
-        # If the JSON event stream didn't parse (unexpected CLI version/output),
-        # fall back to raw stdout so the response isn't silently lost.
-        response = parsed["response"] or (proc.stdout.strip() if parsed["parse_error"] else "")
-
-        tool_errors = parsed["tool_errors"]
-        clean_run = proc.returncode == 0 and tool_errors == 0 and bool(response)
+        response = parsed["response"]
+        evidence_valid, failure_reason, azure_live_query_proven = validate_row_evidence(
+            parsed,
+            source_descriptor["tool_prefix"],
+            source_descriptor["azure_required"],
+        )
+        if proc.returncode != 0:
+            status = "error"
+            failure_reason = f"process_exit_code: {proc.returncode}"
+        elif parsed["result_exit_code"] not in (0, None):
+            status = "invalid"
+            failure_reason = f"event_result_exit_code: {parsed['result_exit_code']}"
+        else:
+            status = "success" if evidence_valid else "invalid"
 
         result.update({
             "response": response,
             "stderr": proc.stderr.strip() if proc.stderr else "",
             "exit_code": proc.returncode,
             "response_time_seconds": round(elapsed, 2),
-            "status": "success" if proc.returncode == 0 else "error",
-            "passed": clean_run,
+            "status": status,
+            "passed": status == "success",
+            "response_present": bool(response),
+            "failure_reason": failure_reason,
+            "source_validated": evidence_valid,
+            "azure_live_query_proven": azure_live_query_proven,
+            "observed_tools": parsed["observed_tools"],
+            "successful_tools": parsed["successful_tools"],
             "turns": parsed["turns"],
             "tool_calls": parsed["tool_calls"],
-            "tool_errors": tool_errors,
+            "tool_errors": parsed["tool_errors"],
             "output_tokens": parsed["output_tokens"],
             "premium_requests": parsed["premium_requests"],
             "api_duration_ms": parsed["api_duration_ms"],
@@ -232,6 +505,7 @@ def run_single_eval(
             "response_time_seconds": round(elapsed, 2),
             "status": "timeout",
             "passed": False,
+            "failure_reason": f"timeout: exceeded {timeout}s",
             "turns": 0,
             "tool_calls": 0,
             "tool_errors": 0,
@@ -241,15 +515,16 @@ def run_single_eval(
             "session_duration_ms": None,
             "event_parse_error": None,
         })
-    except Exception as e:
+    except OSError as exc:
         elapsed = time.monotonic() - start_time
         result.update({
             "response": "",
-            "stderr": str(e),
+            "stderr": str(exc),
             "exit_code": -1,
             "response_time_seconds": round(elapsed, 2),
             "status": "error",
             "passed": False,
+            "failure_reason": f"process_launch_error: {exc}",
             "turns": 0,
             "tool_calls": 0,
             "tool_errors": 0,
@@ -268,6 +543,7 @@ def run_evaluation(
     servers: dict | None = None,
     models: list[str] | None = None,
     timeout: int = 120,
+    require_azure: bool = False,
 ) -> dict:
     """Run the full evaluation matrix."""
     servers = servers or MCP_SERVERS
@@ -288,7 +564,12 @@ def run_evaluation(
                       f"{server_name} × {model}...", end=" ", flush=True)
 
                 result = run_single_eval(
-                    scenario, server_name, server_config, model, timeout
+                    scenario,
+                    server_name,
+                    server_config,
+                    model,
+                    timeout,
+                    require_azure=require_azure,
                 )
                 results.append(result)
 
@@ -425,6 +706,10 @@ def _parse_args() -> argparse.Namespace:
         help="Timeout per evaluation in seconds"
     )
     parser.add_argument(
+        "--require-azure", action="store_true",
+        help="Require Azure hybrid search for Azure-capable selected sources"
+    )
+    parser.add_argument(
         "--dry-run", action="store_true",
         help="Print what would run without executing"
     )
@@ -460,7 +745,13 @@ def main():
         print(f"  Scenarios: {[s['id'] for s in scenarios]}")
         return
 
-    output = run_evaluation(scenarios, servers, models, args.timeout)
+    output = run_evaluation(
+        scenarios,
+        servers,
+        models,
+        args.timeout,
+        require_azure=args.require_azure,
+    )
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -1,0 +1,577 @@
+"""Process-boundary and publication-gate tests for documentation evaluation evidence."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from eval_report import generate_report  # noqa: E402
+from eval_scorer import aggregate_scores, score_result, validate_required_matrix  # noqa: E402
+from foundry_docs_mcp._server_factory import DOCS_CONFIG, build_server  # noqa: E402
+from run_docs_eval import MCP_SERVERS, build_mcp_config, parse_event_stream, run_single_eval  # noqa: E402
+
+
+SCENARIO = {
+    "id": "scenario-1",
+    "category": "getting-started",
+    "question": "How do I create an agent?",
+    "rubric": {
+        "must_mention": ["agent"],
+        "quality_criteria": [],
+        "expected_docs": [],
+    },
+}
+
+
+def _event_stream(
+    tool_name: str = "foundry_docs-search_docs",
+    *,
+    tool_success: bool = True,
+    response: str | None = "Use an agent.",
+) -> str:
+    events = [
+        {
+            "type": "assistant.turn_start",
+            "data": {"turnId": "turn-1"},
+        },
+        {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-1", "toolName": tool_name, "arguments": {"query": "agent"}},
+        },
+        {
+            "type": "tool.execution_complete",
+            "data": {"toolCallId": "call-1", "success": tool_success, "result": {"content": "result"}},
+        },
+    ]
+    if response is not None:
+        events.append({"type": "assistant.message", "data": {"content": response, "outputTokens": 12}})
+    events.append({"type": "result", "exitCode": 0, "usage": {"sessionDurationMs": 25}})
+    return "\n".join(json.dumps(event) for event in events)
+
+
+def _raw_row(
+    *,
+    scenario_id: str = "scenario-1",
+    server: str = "foundry-docs",
+    model: str = "model-1",
+    status: str = "success",
+    response: str = "Use an agent.",
+    failure_reason: str | None = None,
+) -> dict:
+    valid = status == "success"
+    config = MCP_SERVERS[server]["config"]
+    return {
+        "scenario_id": scenario_id,
+        "server": server,
+        "model": model,
+        "category": "getting-started",
+        "response": response,
+        "response_present": bool(response),
+        "status": status,
+        "passed": valid,
+        "selected_source": server,
+        "selected_source_config": {
+            "name": config["name"],
+            "type": "local" if MCP_SERVERS[server]["type"] == "stdio" else "http",
+            "endpoint": config.get("url"),
+            "command": config.get("command"),
+            "tool_prefix": config["tool_prefix"],
+            "azure_required": False,
+        },
+        "source_config_count": 1,
+        "observed_tools": [f"{config['tool_prefix']}-search_docs"],
+        "successful_tools": [f"{config['tool_prefix']}-search_docs"],
+        "source_validated": valid,
+        "azure_required": False,
+        "azure_live_query_proven": False,
+        "failure_reason": failure_reason,
+        "event_parse_error": None,
+        "exit_code": 0 if valid else -1,
+        "rubric": SCENARIO["rubric"],
+        "turns": 1,
+        "tool_calls": 1,
+        "tool_errors": 0,
+        "output_tokens": 12,
+        "response_time_seconds": 0.1,
+    }
+
+
+def test_build_mcp_config_contains_exactly_one_selected_source(monkeypatch):
+    monkeypatch.setenv("AZURE_SEARCH_ENDPOINT", "https://search.example")
+    monkeypatch.setenv("AZURE_AI_PROJECT_ENDPOINT", "https://project.example")
+    monkeypatch.setenv("AZURE_SEARCH_API_KEY", "secret")
+
+    payload, descriptor = build_mcp_config(MCP_SERVERS["foundry-docs"], require_azure=True)
+
+    assert list(payload["mcpServers"]) == ["foundry_docs"]
+    assert payload["mcpServers"]["foundry_docs"]["command"] == "foundry-docs"
+    assert payload["mcpServers"]["foundry_docs"]["env"]["FOUNDRY_EVAL_REQUIRE_AZURE"] == "true"
+    assert descriptor == {
+        "name": "foundry_docs",
+        "type": "local",
+        "endpoint": None,
+        "command": "foundry-docs",
+        "tool_prefix": "foundry_docs",
+        "azure_required": True,
+    }
+
+
+def test_azure_required_config_fails_fast_with_setup_diagnostics(monkeypatch):
+    monkeypatch.delenv("AZURE_SEARCH_ENDPOINT", raising=False)
+    monkeypatch.delenv("AZURE_AI_PROJECT_ENDPOINT", raising=False)
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+        require_azure=True,
+    )
+
+    assert result["status"] == "error"
+    assert result["passed"] is False
+    assert result["failure_reason"].startswith("setup_error:")
+    assert "AZURE_SEARCH_ENDPOINT" in result["failure_reason"]
+    assert result["response_present"] is False
+
+
+def test_mcp_server_refuses_local_fallback_in_azure_required_mode(monkeypatch):
+    monkeypatch.setenv("FOUNDRY_EVAL_REQUIRE_AZURE", "true")
+    monkeypatch.delenv("AZURE_SEARCH_ENDPOINT", raising=False)
+    server = build_server(DOCS_CONFIG)
+
+    async def connect() -> None:
+        async with Client(server):
+            pass
+
+    with pytest.raises(RuntimeError, match="AZURE_SEARCH_ENDPOINT"):
+        asyncio.run(connect())
+
+
+def test_run_single_eval_passes_only_selected_config_across_process_boundary(monkeypatch):
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        config_arg = cmd[cmd.index("--additional-mcp-config") + 1]
+        config_path = Path(config_arg.removeprefix("@"))
+        captured["config"] = json.loads(config_path.read_text(encoding="utf-8"))
+        captured["cmd"] = cmd
+        captured["cwd"] = kwargs["cwd"]
+        captured["copilot_home"] = kwargs["env"]["COPILOT_HOME"]
+        return subprocess.CompletedProcess(cmd, 0, stdout=_event_stream(), stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert list(captured["config"]["mcpServers"]) == ["foundry_docs"]
+    assert "--disable-builtin-mcps" in captured["cmd"]
+    assert "--available-tools=foundry_docs" in captured["cmd"]
+    assert "--allow-tool=foundry_docs" in captured["cmd"]
+    assert captured["cwd"] == captured["copilot_home"]
+    assert result["selected_source"] == "foundry-docs"
+    assert result["source_config_count"] == 1
+    assert result["observed_tools"] == ["foundry_docs-search_docs"]
+    assert result["successful_tools"] == ["foundry_docs-search_docs"]
+    assert result["source_validated"] is True
+    assert result["response_present"] is True
+    assert result["status"] == "success"
+    assert result["failure_reason"] is None
+
+
+@pytest.mark.parametrize(
+    ("stdout", "failure_prefix"),
+    [
+        (_event_stream(tool_name="mintlify-search"), "cross_source_tool_call:"),
+        (_event_stream(tool_name="foundry_docs_vnext-search_docs"), "cross_source_tool_call:"),
+        (_event_stream(tool_success=False), "tool_error:"),
+        (_event_stream(response=None), "missing_response:"),
+        ("not-json", "event_parse_failure:"),
+    ],
+)
+def test_invalid_event_evidence_fails_closed(monkeypatch, stdout, failure_prefix):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["passed"] is False
+    assert result["failure_reason"].startswith(failure_prefix)
+
+
+def test_azure_required_row_needs_successful_selected_search(monkeypatch):
+    monkeypatch.setenv("AZURE_SEARCH_ENDPOINT", "https://search.example")
+    monkeypatch.setenv("AZURE_AI_PROJECT_ENDPOINT", "https://project.example")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=_event_stream(tool_name="foundry_docs-get_doc"),
+            stderr="",
+        ),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+        require_azure=True,
+    )
+
+    assert result["azure_required"] is True
+    assert result["azure_live_query_proven"] is False
+    assert result["status"] == "invalid"
+    assert result["failure_reason"].startswith("azure_live_query_unproven:")
+
+
+def test_timeout_is_preserved_as_invalid_row_diagnostics(monkeypatch):
+    def time_out(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", time_out)
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+        timeout=3,
+    )
+
+    assert result["status"] == "timeout"
+    assert result["response_present"] is False
+    assert result["failure_reason"] == "timeout: exceeded 3s"
+    assert result["response_time_seconds"] >= 0
+
+
+def test_parse_event_stream_rejects_incomplete_tool_call():
+    stdout = "\n".join(
+        [
+            json.dumps({
+                "type": "tool.execution_start",
+                "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+            }),
+            json.dumps({"type": "result", "exitCode": 0}),
+        ]
+    )
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["observed_tools"] == ["foundry_docs-search_docs"]
+    assert "missing completion evidence" in parsed["parse_error"]
+
+
+def test_parse_event_stream_rejects_non_object_events_and_unknown_tool_outcomes():
+    stdout = "\n".join(
+        [
+            "[]",
+            json.dumps({
+                "type": "tool.execution_start",
+                "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+            }),
+            json.dumps({
+                "type": "tool.execution_complete",
+                "data": {"toolCallId": "call-1"},
+            }),
+            json.dumps({"type": "assistant.message", "data": {"content": "answer"}}),
+            json.dumps({"type": "result", "exitCode": 0}),
+        ]
+    )
+
+    parsed = parse_event_stream(stdout)
+
+    assert "event must be a JSON object" in parsed["parse_error"]
+    assert "tool completion missing Boolean success" in parsed["parse_error"]
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        [
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"}},
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"}},
+        ],
+        [
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"}},
+            {"type": "tool.execution_complete", "data": {"toolCallId": "call-1", "success": True}},
+            {"type": "tool.execution_complete", "data": {"toolCallId": "call-1", "success": True}},
+        ],
+        [
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"}},
+            {
+                "type": "tool.execution_complete",
+                "data": {
+                    "toolCallId": "call-1",
+                    "toolName": "foundry_docs-get_doc",
+                    "success": True,
+                },
+            },
+        ],
+    ],
+)
+def test_parse_event_stream_rejects_malformed_tool_lifecycles(events):
+    events.extend([
+        {"type": "assistant.message", "data": {"content": "answer"}},
+        {"type": "result", "exitCode": 0},
+    ])
+
+    parsed = parse_event_stream("\n".join(json.dumps(event) for event in events))
+
+    assert parsed["parse_error"] is not None
+
+
+def test_scorer_rejects_success_row_missing_required_evidence_fields():
+    fabricated = {
+        "scenario_id": "scenario-1",
+        "server": "foundry-docs",
+        "model": "model-1",
+        "category": "getting-started",
+        "response": "Use an agent.",
+        "status": "success",
+        "passed": True,
+        "source_validated": True,
+        "rubric": SCENARIO["rubric"],
+    }
+
+    scored = score_result(fabricated)
+
+    assert scored["row_valid"] is False
+    assert scored["scores"]["has_response"] is True
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        None,
+        {"server": "foundry-docs", "response": "answer"},
+        {**_raw_row(), "response": ["not", "text"]},
+        {**_raw_row(), "category": None},
+        {**_raw_row(), "status": ["success"]},
+        {**_raw_row(), "rubric": {"must_mention": [None]}},
+        {**_raw_row(), "tool_errors": "bad"},
+        {**_raw_row(), "turns": []},
+        {**_raw_row(), "response_time_seconds": "bad"},
+    ],
+)
+def test_malformed_rows_become_invalid_diagnostics_without_crashing(malformed):
+    scored = score_result(malformed)
+    aggregates = aggregate_scores([scored])
+    publication = validate_required_matrix(
+        [scored],
+        scenario_ids=["scenario-1"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+    )
+
+    assert scored["row_valid"] is False
+    assert aggregates["operational_metrics"]
+    assert publication["allowed"] is False
+
+
+def test_required_matrix_enforces_azure_server_policy():
+    row = score_result(_raw_row())
+
+    publication = validate_required_matrix(
+        [row],
+        scenario_ids=["scenario-1"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+        azure_required_servers={"foundry-docs"},
+    )
+
+    assert publication["allowed"] is False
+    assert publication["invalid_rows"][0]["failure_reason"] == "azure_required_evidence_missing"
+
+
+def test_scorer_rejects_contradictory_source_descriptor_and_tool_evidence():
+    row = _raw_row()
+    row["selected_source_config"]["command"] = "different-command"
+    row["observed_tools"] = ["foundry_docs-get_doc"]
+    row["successful_tools"] = ["foundry_docs-search_docs"]
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+
+
+def test_scorer_rejects_contradictory_azure_descriptor():
+    row = _raw_row()
+    row["azure_required"] = True
+    row["azure_live_query_proven"] = True
+    row["selected_source_config"]["azure_required"] = False
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        [
+            {"type": "assistant.message", "data": {"content": "answer"}},
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"}},
+            {"type": "tool.execution_complete", "data": {"toolCallId": "call-1", "success": True}},
+            {"type": "result", "exitCode": 0},
+        ],
+        [
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"}},
+            {"type": "tool.execution_complete", "data": {"toolCallId": "call-1", "success": True}},
+            {"type": "assistant.message", "data": {"content": "answer"}},
+            {"type": "result", "exitCode": 0},
+            {"type": "assistant.message", "data": {"content": "late answer"}},
+        ],
+        [
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"}},
+            {"type": "tool.execution_complete", "data": {"toolCallId": "call-1", "success": True}},
+            {"type": "assistant.message", "data": {"content": "answer"}},
+            {"type": "result", "exitCode": 0},
+            {"type": "result", "exitCode": 0},
+        ],
+        [
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-1", "toolName": "foundry_docs-get_doc"}},
+            {"type": "tool.execution_complete", "data": {"toolCallId": "call-1", "success": True}},
+            {"type": "assistant.message", "data": {"content": "answer"}},
+            {"type": "tool.execution_start", "data": {"toolCallId": "call-2", "toolName": "foundry_docs-search_docs"}},
+            {"type": "tool.execution_complete", "data": {"toolCallId": "call-2", "success": True}},
+            {"type": "result", "exitCode": 0},
+        ],
+    ],
+)
+def test_parse_event_stream_rejects_causally_invalid_sequences(events):
+    parsed = parse_event_stream("\n".join(json.dumps(event) for event in events))
+
+    assert parsed["parse_error"] is not None
+
+
+def test_required_matrix_denominators_include_every_outcome():
+    rows = [
+        score_result(_raw_row(scenario_id="success", status="success")),
+        score_result(_raw_row(scenario_id="invalid", status="invalid", response="", failure_reason="bad evidence")),
+        score_result(_raw_row(scenario_id="error", status="error", response="", failure_reason="process failed")),
+        score_result(_raw_row(scenario_id="timeout", status="timeout", response="", failure_reason="timed out")),
+    ]
+
+    publication = validate_required_matrix(
+        rows,
+        scenario_ids=["success", "invalid", "error", "timeout", "missing"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+    )
+
+    assert publication["allowed"] is False
+    assert publication["required_rows"] == 5
+    assert publication["status_counts"] == {
+        "success": 1,
+        "invalid": 1,
+        "error": 1,
+        "timeout": 1,
+        "missing": 1,
+    }
+    assert publication["response_counts"] == {"present": 1, "missing": 3}
+
+
+def test_invalid_matrix_generates_diagnostics_without_comparative_scores():
+    rows = [
+        score_result(_raw_row()),
+        score_result(_raw_row(scenario_id="scenario-2", status="invalid", failure_reason="unproven source")),
+    ]
+    publication = validate_required_matrix(
+        rows,
+        scenario_ids=["scenario-1", "scenario-2"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+    )
+    aggregates = aggregate_scores(rows)
+    aggregates["denominators"] = {
+        "required_rows": publication["required_rows"],
+        "observed_rows": publication["observed_rows"],
+        "unique_observed_rows": publication["unique_observed_rows"],
+        "status_counts": publication["status_counts"],
+        "response_counts": publication["response_counts"],
+    }
+
+    report = generate_report({
+        "metadata": {"run_id": "run-1", "timestamp": "2026-07-28T00:00:00Z"},
+        "aggregates": aggregates,
+        "publication": publication,
+        "results": rows,
+    })
+
+    assert "Comparative publication blocked" in report
+    assert "unproven source" in report
+    assert "Scoreboard" not in report
+    assert "Hypothesis Testing" not in report
+
+
+def test_scorer_cli_writes_blocked_diagnostics_before_failing(tmp_path):
+    raw_path = tmp_path / "raw.json"
+    scenarios_path = tmp_path / "scenarios.json"
+    output_path = tmp_path / "scored.json"
+    raw_path.write_text(
+        json.dumps({
+            "metadata": {
+                "run_id": "run-1",
+                "servers": ["foundry-docs"],
+                "models": ["model-1"],
+            },
+            "results": [_raw_row()],
+        }),
+        encoding="utf-8",
+    )
+    scenarios_path.write_text(
+        json.dumps([{"id": "scenario-1"}, {"id": "scenario-2"}]),
+        encoding="utf-8",
+    )
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parents[1] / "scripts" / "eval_scorer.py"),
+            str(raw_path),
+            "--output",
+            str(output_path),
+            "--required-scenarios",
+            str(scenarios_path),
+            "--required-servers",
+            "foundry-docs",
+            "--required-models",
+            "model-1",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    assert "=== Server Averages ===" not in proc.stdout
+    assert "=== Server × Model Matrix ===" not in proc.stdout
+    scored = json.loads(output_path.read_text(encoding="utf-8"))
+    assert scored["publication"]["allowed"] is False
+    assert scored["aggregates"]["denominators"]["status_counts"]["missing"] == 1


### PR DESCRIPTION
## Summary
- isolate each Copilot evaluation row in a fresh process home with exactly one selected MCP configuration and validate its structured tool/event evidence
- fail closed on malformed streams, cross-source calls, tool failures, missing responses, timeouts, and Azure-required rows without a proven live hybrid search
- validate the complete required matrix, retain machine-readable diagnostics, suppress comparative output when invalid, and gate report issue publication in the existing Actions harness

## Validation
- `python -m pytest tests\test_docs_eval_evidence.py tests\test_mcp_server_inspection.py -q` (58 passed)
- `python -m ruff check scripts\run_docs_eval.py scripts\eval_scorer.py scripts\eval_report.py foundry_docs_mcp\_server_factory.py tests\test_docs_eval_evidence.py`
- parsed `.github/workflows/docs-eval-harness.yml` with PyYAML
- `python scripts\run_docs_eval.py --dry-run --server foundry-docs --models gpt-5.4`
- scoped `git diff --check`

The workflow change is traditional Actions YAML; no gh-aw markdown source or generated lock file changed.

Closes #631