### PR TITLE
Complete docs-vnext source navigation gate

### DIFF
--- a/.github/workflows/docs-vnext-source-navigation.yml
+++ b/.github/workflows/docs-vnext-source-navigation.yml
@@ -25,6 +25,41 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Initialize failure inventory
+        run: |
+          mkdir -p tests/eval_results
+          cat > tests/eval_results/docs-vnext-route-inventory.json <<'JSON'
+          {
+            "schemaVersion": 1,
+            "status": "failed",
+            "navigationSource": "docs-vnext/docs.json",
+            "routes": [],
+            "openapi": [],
+            "aliases": [],
+            "externalNavigation": [],
+            "linkSummary": {
+              "currentStale": 0,
+              "baselineStale": 0,
+              "grandfathered": 0,
+              "introduced": 0
+            },
+            "diagnosticSummary": {
+              "total": 1,
+              "counts": {"workflow_incomplete": 1},
+              "truncated": false
+            },
+            "diagnostics": [
+              {
+                "sourceNavigationEntry": "navigation",
+                "route": null,
+                "failureClass": "workflow_incomplete",
+                "candidateSourcePath": "docs-vnext/docs.json",
+                "detail": "Workflow did not reach successful navigation validation."
+              }
+            ]
+          }
+          JSON
+
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
@@ -36,22 +71,17 @@ jobs:
       - name: Run navigation validator tests
         run: python -m pytest tests/test_validate_docs_vnext_navigation.py -q
 
-      - name: Prepare incremental validation inputs
+      - name: Prepare baseline validation inputs
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          mkdir -p tests/eval_results
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- docs-vnext \
-            > "$RUNNER_TEMP/docs-vnext-changed-files.txt"
-          git show "$BASE_SHA:docs-vnext/docs.json" \
-            > "$RUNNER_TEMP/base-docs-vnext-docs.json"
+          mkdir -p "$RUNNER_TEMP/base"
+          git archive "$BASE_SHA" docs-vnext | tar -x -C "$RUNNER_TEMP/base"
 
       - name: Validate docs-vnext source navigation
         run: |
           python scripts/validate_docs_vnext_navigation.py \
-            --changed-files-file "$RUNNER_TEMP/docs-vnext-changed-files.txt" \
-            --base-navigation "$RUNNER_TEMP/base-docs-vnext-docs.json" \
+            --base-docs-dir "$RUNNER_TEMP/base/docs-vnext" \
             --output tests/eval_results/docs-vnext-route-inventory.json
 
       - name: Upload route inventory

--- a/scripts/validate_docs_vnext_navigation.py
+++ b/scripts/validate_docs_vnext_navigation.py
@@ -71,6 +71,29 @@ class RouteEntry:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class LinkFailure:
+    source_navigation_entry: str
+    source_route: str
+    target_route: str
+    raw_link: str
+    candidate_source_path: str
+
+    @property
+    def fingerprint(self) -> tuple[str, str, str]:
+        return (self.source_route, self.raw_link, self.target_route)
+
+    def as_diagnostic(self) -> dict[str, str]:
+        return {
+            "sourceNavigationEntry": self.source_navigation_entry,
+            "route": f"/{self.target_route}" if self.target_route else "/",
+            "failureClass": "stale_internal_link",
+            "candidateSourcePath": self.candidate_source_path,
+            "sourcePage": f"docs-vnext/{self.source_route}.mdx",
+            "link": self.raw_link,
+        }
+
+
 class NavigationCollector:
     def __init__(self, docs_dir: Path, max_diagnostics: int) -> None:
         self.docs_dir = docs_dir
@@ -268,6 +291,18 @@ class NavigationCollector:
             if isinstance(item, str):
                 self._collect_route(item, entry_path)
             elif isinstance(item, dict):
+                if "page" in item:
+                    page = item["page"]
+                    if isinstance(page, str):
+                        self._collect_route(page, f"{entry_path}.page")
+                    else:
+                        self.add_diagnostic(
+                            source_navigation_entry=f"{entry_path}.page",
+                            route=repr(page),
+                            failure_class="invalid_route_target",
+                            candidate_source_path=None,
+                            detail="named page entries require a route string in page",
+                        )
                 self._visit_container(item, entry_path)
             else:
                 self.add_diagnostic(
@@ -480,17 +515,16 @@ def _resolve_internal_link(source_route: str, raw_link: str) -> str | None:
     return "/".join(normalized_parts).rstrip("/")
 
 
-def _validate_internal_links(collector: NavigationCollector, routes_to_scan: set[str] | None = None) -> None:
+def _scan_internal_links(collector: NavigationCollector) -> list[LinkFailure]:
     route_entries: dict[str, RouteEntry] = {}
     for entry in collector.routes:
         route_entries.setdefault(entry.route, entry)
     valid_routes = set(route_entries)
     valid_routes.update(alias["route"].lstrip("/") for alias in collector.aliases)
     valid_routes.add("")
+    failures: list[LinkFailure] = []
 
     for route, entry in route_entries.items():
-        if routes_to_scan is not None and route not in routes_to_scan:
-            continue
         source_path = collector.docs_dir / f"{route}.mdx"
         if not source_path.is_file():
             continue
@@ -509,45 +543,50 @@ def _validate_internal_links(collector: NavigationCollector, routes_to_scan: set
             if key in seen:
                 continue
             seen.add(key)
-            collector.add_diagnostic(
-                source_navigation_entry=entry.source_navigation_entry,
-                route=f"/{target}" if target else "/",
-                failure_class="stale_internal_link",
-                candidate_source_path=candidate_source_path(collector.docs_dir, target),
-                sourcePage=entry.candidate_source_path,
-                link=raw_link,
+            failures.append(
+                LinkFailure(
+                    source_navigation_entry=entry.source_navigation_entry,
+                    source_route=route,
+                    target_route=target,
+                    raw_link=raw_link,
+                    candidate_source_path=candidate_source_path(collector.docs_dir, target),
+                )
             )
+    return failures
 
 
 def validate_navigation(
     docs_dir: Path,
     navigation_path: Path,
     *,
-    changed_files: set[str] | None = None,
-    base_navigation_path: Path | None = None,
+    base_docs_dir: Path | None = None,
     max_diagnostics: int = DEFAULT_MAX_DIAGNOSTICS,
 ) -> dict[str, Any]:
     config = json.loads(navigation_path.read_text(encoding="utf-8"))
     collector = NavigationCollector(docs_dir, max_diagnostics)
     collector.collect(config.get("navigation"))
     collector.collect_redirects(config.get("redirects"))
-    routes_to_scan: set[str] | None = None
-    if changed_files is not None:
-        docs_prefix = f"{docs_dir.name}/"
-        routes_to_scan = {
-            path[len(docs_prefix) : -len(".mdx")]
-            for path in changed_files
-            if path.startswith(docs_prefix) and path.endswith(".mdx")
-        }
-        if base_navigation_path is not None and base_navigation_path.is_file():
-            base_config = json.loads(base_navigation_path.read_text(encoding="utf-8"))
-            base_collector = NavigationCollector(docs_dir, 0)
-            base_collector.collect(base_config.get("navigation"))
-            base_routes = {entry.route for entry in base_collector.routes}
-            routes_to_scan.update(entry.route for entry in collector.routes if entry.route not in base_routes)
-    if collector.total_diagnostics:
-        routes_to_scan = set()
-    _validate_internal_links(collector, routes_to_scan)
+    current_stale = _scan_internal_links(collector)
+    baseline_stale: list[LinkFailure] = []
+    if base_docs_dir is not None:
+        base_navigation_path = base_docs_dir / "docs.json"
+        base_config = json.loads(base_navigation_path.read_text(encoding="utf-8"))
+        base_collector = NavigationCollector(base_docs_dir, 0)
+        base_collector.collect(base_config.get("navigation"))
+        base_collector.collect_redirects(base_config.get("redirects"))
+        baseline_stale = _scan_internal_links(base_collector)
+
+    baseline_fingerprints = {failure.fingerprint for failure in baseline_stale}
+    introduced_stale = [failure for failure in current_stale if failure.fingerprint not in baseline_fingerprints]
+    for failure in introduced_stale:
+        diagnostic = failure.as_diagnostic()
+        collector.add_diagnostic(
+            source_navigation_entry=diagnostic.pop("sourceNavigationEntry"),
+            route=diagnostic.pop("route"),
+            failure_class=diagnostic.pop("failureClass"),
+            candidate_source_path=diagnostic.pop("candidateSourcePath"),
+            **diagnostic,
+        )
     return {
         "schemaVersion": SCHEMA_VERSION,
         "status": "failed" if collector.total_diagnostics else "passed",
@@ -556,6 +595,12 @@ def validate_navigation(
         "openapi": collector.openapi,
         "aliases": collector.aliases,
         "externalNavigation": collector.external_navigation,
+        "linkSummary": {
+            "currentStale": len(current_stale),
+            "baselineStale": len(baseline_stale),
+            "grandfathered": len(current_stale) - len(introduced_stale),
+            "introduced": len(introduced_stale),
+        },
         "diagnosticSummary": {
             "total": collector.total_diagnostics,
             "counts": dict(sorted(collector.diagnostic_counts.items())),
@@ -565,41 +610,109 @@ def validate_navigation(
     }
 
 
+def build_failure_inventory(
+    docs_dir: Path,
+    navigation_path: Path,
+    *,
+    failure_class: str,
+    detail: str,
+) -> dict[str, Any]:
+    bounded_detail = bounded_diagnostic_value(detail)
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "status": "failed",
+        "navigationSource": candidate_config_path(docs_dir, navigation_path.name),
+        "routes": [],
+        "openapi": [],
+        "aliases": [],
+        "externalNavigation": [],
+        "linkSummary": {
+            "currentStale": 0,
+            "baselineStale": 0,
+            "grandfathered": 0,
+            "introduced": 0,
+        },
+        "diagnosticSummary": {
+            "total": 1,
+            "counts": {failure_class: 1},
+            "truncated": False,
+        },
+        "diagnostics": [
+            {
+                "sourceNavigationEntry": "navigation",
+                "route": None,
+                "failureClass": failure_class,
+                "candidateSourcePath": candidate_config_path(docs_dir, navigation_path.name),
+                "detail": bounded_detail,
+            }
+        ],
+    }
+
+
+def write_inventory(output_path: Path, result: dict[str, Any]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--docs-dir", type=Path, default=Path("docs-vnext"))
     parser.add_argument("--navigation", type=Path)
     parser.add_argument("--output", type=Path, default=Path("tests/eval_results/docs-vnext-route-inventory.json"))
-    parser.add_argument("--changed-files-file", type=Path)
-    parser.add_argument("--base-navigation", type=Path)
+    parser.add_argument("--base-docs-dir", type=Path)
     parser.add_argument("--max-diagnostics", type=int, default=DEFAULT_MAX_DIAGNOSTICS)
+    parser.add_argument(
+        "--initialize-output",
+        action="store_true",
+        help="Write an uploadable workflow-incomplete inventory without validating",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     navigation_path = args.navigation or args.docs_dir / "docs.json"
+    if args.initialize_output:
+        result = build_failure_inventory(
+            args.docs_dir,
+            navigation_path,
+            failure_class="workflow_incomplete",
+            detail="Workflow did not reach successful navigation validation.",
+        )
+        try:
+            write_inventory(args.output, result)
+        except OSError as exc:
+            print(f"Failure inventory could not be written: {exc}", file=sys.stderr)
+            return 2
+        return 0
+
     try:
-        changed_files = None
-        if args.changed_files_file:
-            changed_files = {
-                line.strip().replace("\\", "/")
-                for line in args.changed_files_file.read_text(encoding="utf-8").splitlines()
-                if line.strip()
-            }
         result = validate_navigation(
             args.docs_dir,
             navigation_path,
-            changed_files=changed_files,
-            base_navigation_path=args.base_navigation,
+            base_docs_dir=args.base_docs_dir,
             max_diagnostics=args.max_diagnostics,
         )
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        result = build_failure_inventory(
+            args.docs_dir,
+            navigation_path,
+            failure_class="validator_error",
+            detail=str(exc),
+        )
+        try:
+            write_inventory(args.output, result)
+        except OSError as write_exc:
+            print(f"Failure inventory could not be written: {write_exc}", file=sys.stderr)
+            return 2
         print(f"Navigation validation could not run: {exc}", file=sys.stderr)
         return 2
 
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    try:
+        write_inventory(args.output, result)
+    except OSError as exc:
+        print(f"Navigation inventory could not be written: {exc}", file=sys.stderr)
+        return 2
     summary = result["diagnosticSummary"]
     print(
         f"docs-vnext navigation: {result['status']} "

--- a/tests/test_validate_docs_vnext_navigation.py
+++ b/tests/test_validate_docs_vnext_navigation.py
@@ -5,6 +5,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from validate_docs_vnext_navigation import main, validate_navigation  # noqa: E402
@@ -42,6 +44,22 @@ def test_valid_routes_produce_ordered_publishable_inventory(tmp_path: Path) -> N
         "docs-vnext/guide/second.mdx",
         "docs-vnext/guide/first.mdx",
     ]
+
+
+def test_named_page_object_is_included_in_ordered_inventory(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs-vnext"
+    navigation_path = _write_navigation(
+        docs_dir,
+        [{"name": "Enterprise Planning", "page": "setup/planning"}, "setup/create-projects"],
+    )
+    _write_page(docs_dir, "setup/planning")
+    _write_page(docs_dir, "setup/create-projects")
+
+    result = validate_navigation(docs_dir, navigation_path)
+
+    assert result["status"] == "passed"
+    assert [entry["route"] for entry in result["routes"]] == ["/setup/planning", "/setup/create-projects"]
+    assert result["routes"][0]["sourceNavigationEntry"] == "navigation.groups[0].pages[0].page"
 
 
 def test_stale_internal_link_fails_with_bounded_route_diagnostic(tmp_path: Path) -> None:
@@ -135,36 +153,56 @@ def test_empty_navigable_page_fails(tmp_path: Path) -> None:
     assert result["diagnosticSummary"]["counts"] == {"empty_navigable_page": 1}
 
 
-def test_incremental_check_scans_only_touched_navigable_pages(tmp_path: Path) -> None:
-    docs_dir = tmp_path / "docs-vnext"
-    navigation_path = _write_navigation(docs_dir, ["guide/touched", "guide/legacy"])
-    _write_page(docs_dir, "guide/touched", "See the [legacy guide](/guide/legacy).\n")
+def test_unchanged_legacy_stale_link_is_explicitly_grandfathered(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "current" / "docs-vnext"
+    base_docs_dir = tmp_path / "base" / "docs-vnext"
+    navigation_path = _write_navigation(docs_dir, ["guide/legacy"])
+    _write_navigation(base_docs_dir, ["guide/legacy"])
     _write_page(docs_dir, "guide/legacy", "Old [broken link](/guide/missing).\n")
+    _write_page(base_docs_dir, "guide/legacy", "Old [broken link](/guide/missing).\n")
 
-    result = validate_navigation(
-        docs_dir,
-        navigation_path,
-        changed_files={"docs-vnext/guide/touched.mdx"},
-    )
+    result = validate_navigation(docs_dir, navigation_path, base_docs_dir=base_docs_dir)
 
     assert result["status"] == "passed"
+    assert result["linkSummary"] == {
+        "currentStale": 1,
+        "baselineStale": 1,
+        "grandfathered": 1,
+        "introduced": 0,
+    }
 
 
-def test_incremental_check_scans_newly_navigable_pages(tmp_path: Path) -> None:
-    docs_dir = tmp_path / "docs-vnext"
-    _write_navigation(docs_dir, ["guide/existing"])
-    base_navigation = tmp_path / "base-docs.json"
-    base_navigation.write_text((docs_dir / "docs.json").read_text(encoding="utf-8"), encoding="utf-8")
-    navigation_path = _write_navigation(docs_dir, ["guide/existing", "guide/new"])
-    _write_page(docs_dir, "guide/existing")
-    _write_page(docs_dir, "guide/new", "New [broken link](/guide/missing).\n")
+def test_removing_route_fails_when_unchanged_page_still_links_to_it(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "current" / "docs-vnext"
+    base_docs_dir = tmp_path / "base" / "docs-vnext"
+    navigation_path = _write_navigation(docs_dir, ["guide/start"])
+    _write_navigation(base_docs_dir, ["guide/start", "guide/target"])
+    _write_page(docs_dir, "guide/start", "Read the [target guide](/guide/target).\n")
+    _write_page(base_docs_dir, "guide/start", "Read the [target guide](/guide/target).\n")
+    _write_page(base_docs_dir, "guide/target")
 
-    result = validate_navigation(
-        docs_dir,
-        navigation_path,
-        changed_files={"docs-vnext/docs.json"},
-        base_navigation_path=base_navigation,
+    result = validate_navigation(docs_dir, navigation_path, base_docs_dir=base_docs_dir)
+
+    assert result["status"] == "failed"
+    assert result["diagnosticSummary"]["counts"] == {"stale_internal_link": 1}
+    assert result["diagnostics"][0]["sourcePage"] == "docs-vnext/guide/start.mdx"
+
+
+def test_removing_alias_fails_when_unchanged_page_still_links_to_it(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "current" / "docs-vnext"
+    base_docs_dir = tmp_path / "base" / "docs-vnext"
+    navigation_path = _write_navigation(docs_dir, ["guide/start", "guide/current"])
+    _write_navigation(
+        base_docs_dir,
+        ["guide/start", "guide/current"],
+        redirects=[{"source": "/guide/old", "destination": "/guide/current"}],
     )
+    _write_page(docs_dir, "guide/start", "Read the [legacy route](/guide/old).\n")
+    _write_page(docs_dir, "guide/current")
+    _write_page(base_docs_dir, "guide/start", "Read the [legacy route](/guide/old).\n")
+    _write_page(base_docs_dir, "guide/current")
+
+    result = validate_navigation(docs_dir, navigation_path, base_docs_dir=base_docs_dir)
 
     assert result["status"] == "failed"
     assert result["diagnosticSummary"]["counts"] == {"stale_internal_link": 1}
@@ -207,6 +245,46 @@ def test_cli_writes_byte_stable_inventory(tmp_path: Path) -> None:
     assert main(args) == 0
 
     assert output.read_bytes() == first
+
+
+@pytest.mark.parametrize(
+    ("navigation_content", "expected_detail"),
+    [
+        ("{", "Expecting property name"),
+        (b"\xff", "utf-8"),
+        (None, "No such file"),
+    ],
+)
+def test_cli_writes_bounded_failure_inventory_for_json_and_io_errors(
+    tmp_path: Path,
+    navigation_content: str | bytes | None,
+    expected_detail: str,
+) -> None:
+    docs_dir = tmp_path / "docs-vnext"
+    docs_dir.mkdir()
+    if isinstance(navigation_content, bytes):
+        (docs_dir / "docs.json").write_bytes(navigation_content)
+    elif navigation_content is not None:
+        (docs_dir / "docs.json").write_text(navigation_content, encoding="utf-8")
+    output = tmp_path / "inventory.json"
+
+    assert main(["--docs-dir", str(docs_dir), "--output", str(output)]) == 2
+
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert result["diagnosticSummary"]["counts"] == {"validator_error": 1}
+    assert expected_detail in result["diagnostics"][0]["detail"]
+    assert len(result["diagnostics"][0]["detail"]) <= 500
+
+
+def test_cli_can_initialize_uploadable_failure_inventory(tmp_path: Path) -> None:
+    output = tmp_path / "inventory.json"
+
+    assert main(["--output", str(output), "--initialize-output"]) == 0
+
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["status"] == "failed"
+    assert result["diagnosticSummary"]["counts"] == {"workflow_incomplete": 1}
 
 
 def test_link_examples_inside_code_are_not_validated_as_navigation(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #629 after #638 merged before its independent review corrections could be applied.

- parse Mintlify named `{name, page}` entries so `/setup/planning` is included in the publishable route inventory
- replace touched-page-only link checks with a full current/base scan that explicitly grandfathers unchanged legacy debt and fails newly introduced stale links, including route or alias removals affecting unchanged pages
- write bounded failure inventories for JSON, UTF-8, and I/O failures, and bootstrap an uploadable failure artifact immediately after checkout

## Validation

- `python -m pytest tests/test_validate_docs_vnext_navigation.py -q` (20 passed)
- `python -m ruff check scripts/validate_docs_vnext_navigation.py tests/test_validate_docs_vnext_navigation.py`
- repository baseline/delta smoke: 527 routes, `/setup/planning` present, 686 current/base stale fingerprints grandfathered, 0 introduced, 0 diagnostics
- workflow artifact bootstrap ordering validated before `actions/setup-python`
- `git diff --check origin/main...HEAD`

Related to #629 and #638. Do not merge until the fresh navigation gate and artifact are verified.

Fixes: #629