### PR TITLE
Finish deterministic post-index regression gate

### DIFF
--- a/.github/workflows/post-index-sync-testbench.lock.yml
+++ b/.github/workflows/post-index-sync-testbench.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"56baa480016c065f1633572a48a015eb1186fe84724a2e24d43a77a61953c270","body_hash":"2aec2e8bf6771e10d1329e4a1e9bd82de253c48b469495ba305cff3331f702b5","compiler_version":"v0.81.6","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.65"}}
-# gh-aw-manifest: {"version":1,"secrets":["AZURE_AI_PROJECT_API_KEY","AZURE_AI_PROJECT_ENDPOINT","AZURE_OPENAI_EMBEDDING_DEPLOYMENT","AZURE_SEARCH_API_KEY","AZURE_SEARCH_ENDPOINT","AZURE_SEARCH_INDEX_NAME","COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3 (source v6)"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0 (source v6)"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba6380cc6e5be5d21677bebe04d52fb48e3abec7","version":"v0.81.6"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11","digest":"sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11@sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11","digest":"sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11@sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11","digest":"sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11@sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.30","digest":"sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.30@sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"c2e73c6101cc22daf943a80fe9c423f548aa70f2d49a8193f134ab9a7ff2a414","body_hash":"753c037d8ce27a5e3ff6ac7babaaa1f17f9d2404fe1b13e77aebb9421d845ae1","compiler_version":"v0.81.6","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.65"}}
+# gh-aw-manifest: {"version":1,"secrets":["AZURE_AI_PROJECT_API_KEY","AZURE_AI_PROJECT_ENDPOINT","AZURE_OPENAI_EMBEDDING_DEPLOYMENT","AZURE_SEARCH_API_KEY","AZURE_SEARCH_ENDPOINT","AZURE_SEARCH_INDEX_NAME","COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/restore","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/cache/save","sha":"55cc8345863c7cc4c66a329aec7e433d2d1c52a9","version":"v6.1.0"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/checkout","sha":"df4cb1c069e1874edd31b4311f1884172cec0e10","version":"v6.0.3 (source v6)"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0 (source v6)"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ba6380cc6e5be5d21677bebe04d52fb48e3abec7","version":"v0.81.6"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11","digest":"sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.11@sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11","digest":"sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.11@sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11","digest":"sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.11@sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.30","digest":"sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.30@sha256:35625d1a2269b1238606078c879f59a91cffc4ac33eb54bf39c6418822c1a8be"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
 # This file was automatically generated by gh-aw (v0.81.6). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -25,11 +25,6 @@
 #
 # Verifies search quality after the search index is updated
 #
-# Resolved workflow manifest:
-#   Imports:
-#     - shared/mood.md
-#     - shared/reporting.md
-#
 # Secrets used:
 #   - AZURE_AI_PROJECT_API_KEY
 #   - AZURE_AI_PROJECT_ENDPOINT
@@ -43,6 +38,9 @@
 #   - GITHUB_TOKEN
 #
 # Custom actions used:
+#   - actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#   - actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+#   - actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
 #   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 #   - actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 (source v6)
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -64,6 +62,9 @@
 
 name: "Post-Index Search Quality Check"
 on:
+  # needs: # Needs processed as dependency in pre-activation job
+  # - post_index_regression # Needs processed as dependency in pre-activation job
+  # - post_index_conclusion # Needs processed as dependency in pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -91,21 +92,26 @@ run-name: "Post-Index Search Quality Check"
 jobs:
   activation:
     needs:
+      - post_index_conclusion
       - post_index_regression
       - pre_activation
     # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
     if: >
-      (needs.pre_activation.outputs.activated == 'true') && (github.event_name != 'workflow_run' || github.event.workflow_run.repository.id == github.repository_id &&
-      (!(github.event.workflow_run.repository.fork)))
+      (needs.pre_activation.outputs.activated == 'true' && (false)) && (github.event_name != 'workflow_run' ||
+      github.event.workflow_run.repository.id == github.repository_id && (!(github.event.workflow_run.repository.fork)))
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
     env:
+      GH_AW_MAX_DAILY_AI_CREDITS: ${{ vars.GH_AW_DEFAULT_MAX_DAILY_AI_CREDITS || '5000' }}
       GH_AW_RUNTIME_FEATURES: ${{ vars.GH_AW_RUNTIME_FEATURES }}
     outputs:
       comment_id: ""
       comment_repo: ""
+      daily_ai_credits_exceeded: ${{ steps.daily-effective-workflow-guardrail.outputs.daily_ai_credits_exceeded == 'true' }}
+      daily_ai_credits_threshold: ${{ steps.daily-effective-workflow-guardrail.outputs.daily_ai_credits_threshold || '' }}
+      daily_ai_credits_total_effective_tokens: ${{ steps.daily-effective-workflow-guardrail.outputs.daily_ai_credits_total_effective_tokens || '' }}
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
@@ -123,6 +129,7 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
           parent-span-id: ${{ needs.pre_activation.outputs.setup-parent-span-id || needs.pre_activation.outputs.setup-span-id }}
+          safe-output-artifact-client: ${{ env.GH_AW_MAX_DAILY_AI_CREDITS != '' }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Post-Index Search Quality Check"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/post-index-sync-testbench.lock.yml@${{ github.ref }}
@@ -142,7 +149,7 @@ jobs:
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
-          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","github"]'
+          GH_AW_INFO_ALLOWED_DOMAINS: '["defaults"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
           GH_AW_INFO_AWF_VERSION: "v0.27.11"
           GH_AW_INFO_AWMG_VERSION: ""
@@ -155,6 +162,50 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
+      - name: Restore daily AIC usage cache
+        id: restore-daily-aic-cache
+        if: ${{ env.GH_AW_MAX_DAILY_AI_CREDITS != '' }}
+        continue-on-error: true
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: agentic-workflow-usage-postindexsynctestbench-${{ github.run_id }}
+          restore-keys: agentic-workflow-usage-postindexsynctestbench-
+          path: /tmp/gh-aw/agentic-workflow-usage-cache.jsonl
+      - name: Restore daily AIC usage cache (artifact fallback)
+        id: restore-daily-aic-cache-fallback
+        if: ${{ env.GH_AW_MAX_DAILY_AI_CREDITS != '' }}
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GH_AW_RESTORE_DAILY_AIC_CACHE_HIT: ${{ steps.restore-daily-aic-cache.outputs.cache-hit }}
+          GH_AW_RESTORE_DAILY_AIC_CACHE_MATCHED_KEY: ${{ steps.restore-daily-aic-cache.outputs.cache-matched-key }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/restore_aic_usage_cache_fallback.cjs');
+            await main();
+      - name: Check daily workflow token guardrail
+        id: daily-effective-workflow-guardrail
+        if: ${{ env.GH_AW_MAX_DAILY_AI_CREDITS != '' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GH_AW_WORKFLOW_NAME: "Post-Index Search Quality Check"
+          GH_AW_WORKFLOW_ID: "post-index-sync-testbench"
+          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_AW_WORKFLOW_DISPATCH_AW_CONTEXT: ${{ github.event.inputs.aw_context || '' }}
+          GH_AW_HAS_SLASH_COMMAND: "false"
+          GH_AW_HAS_LABEL_COMMAND: "false"
+          GH_AW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_AW_MAX_DAILY_AI_CREDITS: ${{ vars.GH_AW_DEFAULT_MAX_DAILY_AI_CREDITS || '5000' }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_daily_aic_workflow_guardrail.cjs');
+            await main();
       - name: Validate COPILOT_GITHUB_TOKEN secret
         id: validate-secret
         run: bash "${RUNNER_TEMP}/gh-aw/actions/validate_multi_secret.sh" COPILOT_GITHUB_TOKEN 'GitHub Copilot CLI' https://github.github.com/gh-aw/reference/engines/#github-copilot-default
@@ -223,20 +274,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c7923b8376e3e74e_EOF'
+          cat << 'GH_AW_PROMPT_41714b9144192003_EOF'
           <system>
-          GH_AW_PROMPT_c7923b8376e3e74e_EOF
+          GH_AW_PROMPT_41714b9144192003_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c7923b8376e3e74e_EOF'
+          cat << 'GH_AW_PROMPT_41714b9144192003_EOF'
           <safe-output-tools>
-          Tools: create_issue, missing_tool, missing_data, noop
+          Tools: create_issue
+          GH_AW_PROMPT_41714b9144192003_EOF
+          cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_auto_create_issue.md"
+          cat << 'GH_AW_PROMPT_41714b9144192003_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_c7923b8376e3e74e_EOF
+          GH_AW_PROMPT_41714b9144192003_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_c7923b8376e3e74e_EOF'
+          cat << 'GH_AW_PROMPT_41714b9144192003_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -265,14 +319,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c7923b8376e3e74e_EOF
+          GH_AW_PROMPT_41714b9144192003_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c7923b8376e3e74e_EOF'
+          cat << 'GH_AW_PROMPT_41714b9144192003_EOF'
           </system>
-          {{#runtime-import .github/workflows/shared/mood.md}}
-          {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/post-index-sync-testbench.md}}
-          GH_AW_PROMPT_c7923b8376e3e74e_EOF
+          GH_AW_PROMPT_41714b9144192003_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -353,12 +405,14 @@ jobs:
           retention-days: 1
 
   agent:
-    needs: activation
+    needs:
+      - activation
+      - post_index_conclusion
+      - post_index_regression
+    if: needs.activation.outputs.daily_ai_credits_exceeded != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: read
-      pull-requests: read
     concurrency:
       group: "gh-aw-copilot-${{ github.workflow }}"
       queue: max
@@ -421,16 +475,6 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Download deterministic regression evidence
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1 (source v8)
-        with:
-          name: post-index-regression-${{ github.run_id }}
-          path: /tmp/gh-aw/agent
-      - env:
-          GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-        name: Materialize deterministic safe outputs and skip model invocation
-        run: "set -euo pipefail\npython scripts/post_index_regression.py render-safe-outputs-jsonl \\\n  --input /tmp/gh-aw/agent/post-index-result.json \\\n  --output \"$GH_AW_SAFE_OUTPUTS\"\n"
-
       - name: Configure Git credentials
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -494,15 +538,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0080c9bd8e50f4ea_EOF'
-          {"create_issue":{"close_older_issues":true,"expires":168,"labels":["search","automation"],"max":1,"title_prefix":"[search-quality] "},"create_report_incomplete_issue":{"title-prefix":"[incomplete]"},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0080c9bd8e50f4ea_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5528bace8542ff5f_EOF'
+          {"create_issue":{"labels":["post-index-sync-testbench"],"max":1,"title_prefix":"[post-index-sync-testbench]"}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_5528bace8542ff5f_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[search-quality] \". Labels [\"search\" \"automation\"] will be automatically added."
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[post-index-sync-testbench]\". Labels [\"post-index-sync-testbench\"] will be automatically added."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -543,79 +587,6 @@ jobs:
                     "type": "string",
                     "sanitize": true,
                     "maxLength": 128
-                  }
-                }
-              },
-              "missing_data": {
-                "defaultMax": 20,
-                "fields": {
-                  "alternatives": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 256
-                  },
-                  "context": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 256
-                  },
-                  "data_type": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 128
-                  },
-                  "reason": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 256
-                  }
-                }
-              },
-              "missing_tool": {
-                "defaultMax": 20,
-                "fields": {
-                  "alternatives": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 512
-                  },
-                  "reason": {
-                    "required": true,
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 256
-                  },
-                  "tool": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 128
-                  }
-                }
-              },
-              "noop": {
-                "defaultMax": 1,
-                "fields": {
-                  "message": {
-                    "required": true,
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 65000
-                  }
-                }
-              },
-              "report_incomplete": {
-                "defaultMax": 5,
-                "fields": {
-                  "details": {
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 65000
-                  },
-                  "reason": {
-                    "required": true,
-                    "type": "string",
-                    "sanitize": true,
-                    "maxLength": 1024
                   }
                 }
               }
@@ -750,24 +721,6 @@ jobs:
       - name: Execute GitHub Copilot CLI
         id: agentic_execution
         # Copilot CLI tool arguments (sorted):
-        # --allow-tool github
-        # --allow-tool safeoutputs
-        # --allow-tool shell(cat /tmp/gh-aw/agent/post-index-result.json)
-        # --allow-tool shell(cat)
-        # --allow-tool shell(date)
-        # --allow-tool shell(echo)
-        # --allow-tool shell(grep)
-        # --allow-tool shell(head)
-        # --allow-tool shell(ls)
-        # --allow-tool shell(printf)
-        # --allow-tool shell(pwd)
-        # --allow-tool shell(safeoutputs:*)
-        # --allow-tool shell(sort)
-        # --allow-tool shell(tail)
-        # --allow-tool shell(uniq)
-        # --allow-tool shell(wc)
-        # --allow-tool shell(yq)
-        # --allow-tool write
         timeout-minutes: 10
         run: |
           set -o pipefail
@@ -783,7 +736,7 @@ jobs:
           export COPILOT_API_KEY="$COPILOT_DUMMY_BYOK"
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
           GH_AW_MAX_AI_CREDITS="${GH_AW_MAX_AI_CREDITS:-1000}"
-          printf '%s\n' "{\"\$schema\":\"https://github.com/github/gh-aw-firewall/releases/download/v0.27.11/awf-config.schema.json\",\"network\":{\"allowDomains\":[\"*.githubusercontent.com\",\"api.business.githubcopilot.com\",\"api.enterprise.githubcopilot.com\",\"api.github.com\",\"api.githubcopilot.com\",\"api.individual.githubcopilot.com\",\"api.snapcraft.io\",\"archive.ubuntu.com\",\"azure.archive.ubuntu.com\",\"codeload.github.com\",\"crl.geotrust.com\",\"crl.globalsign.com\",\"crl.identrust.com\",\"crl.sectigo.com\",\"crl.thawte.com\",\"crl.usertrust.com\",\"crl.verisign.com\",\"crl3.digicert.com\",\"crl4.digicert.com\",\"crls.ssl.com\",\"docs.github.com\",\"github-cloud.githubusercontent.com\",\"github-cloud.s3.amazonaws.com\",\"github.blog\",\"github.com\",\"github.githubassets.com\",\"host.docker.internal\",\"json-schema.org\",\"json.schemastore.org\",\"keyserver.ubuntu.com\",\"lfs.github.com\",\"objects.githubusercontent.com\",\"ocsp.digicert.com\",\"ocsp.geotrust.com\",\"ocsp.globalsign.com\",\"ocsp.identrust.com\",\"ocsp.sectigo.com\",\"ocsp.ssl.com\",\"ocsp.thawte.com\",\"ocsp.usertrust.com\",\"ocsp.verisign.com\",\"packagecloud.io\",\"packages.cloud.google.com\",\"packages.microsoft.com\",\"patch-diff.githubusercontent.com\",\"ppa.launchpad.net\",\"raw.githubusercontent.com\",\"registry.npmjs.org\",\"s.symcb.com\",\"s.symcd.com\",\"security.ubuntu.com\",\"telemetry.enterprise.githubcopilot.com\",\"ts-crl.ws.symantec.com\",\"ts-ocsp.ws.symantec.com\",\"www.googleapis.com\"]},\"apiProxy\":{\"enabled\":true,\"enableTokenSteering\":true,\"maxRuns\":500,\"maxAiCredits\":${GH_AW_MAX_AI_CREDITS},\"maxCacheMisses\":5,\"models\":{\"agent\":[\"sonnet-6x\",\"gpt-5.5\",\"gpt-5.4\",\"gpt-5.3\",\"gemini-pro\",\"any\"],\"antigravity\":[\"copilot/antigravity*\",\"google/antigravity*\",\"gemini/antigravity*\"],\"any\":[\"copilot/*\",\"anthropic/*\",\"openai/*\",\"google/*\",\"gemini/*\"],\"claude\":[\"agent\"],\"codex\":[\"agent\"],\"coding\":[\"copilot/gpt-5*codex*\",\"openai/gpt-5*codex*\",\"gpt-5-codex\"],\"computer-use\":[\"copilot/*computer-use*\",\"google/*computer-use*\",\"gemini/*computer-use*\",\"openai/*computer-use*\"],\"copilot\":[\"agent\"],\"deep-research\":[\"copilot/deep-research*\",\"copilot/o3-deep-research*\",\"copilot/o4-mini-deep-research*\",\"google/deep-research*\",\"gemini/deep-research*\",\"openai/o3-deep-research*\",\"openai/o4-mini-deep-research*\"],\"gemini\":[\"agent\"],\"gemini-3-flash\":[\"copilot/gemini-3*flash*\",\"google/gemini-3*flash*\",\"gemini/gemini-3*flash*\"],\"gemini-3-pro\":[\"copilot/gemini-3*pro*\",\"google/gemini-3*pro*\",\"google/nano-banana*\",\"gemini/gemini-3*pro*\"],\"gemini-3.1-flash\":[\"copilot/gemini-3.1*flash*\",\"google/gemini-3.1*flash*\",\"gemini/gemini-3.1*flash*\"],\"gemini-3.1-pro\":[\"copilot/gemini-3.1*pro*\",\"google/gemini-3.1*pro*\",\"gemini/gemini-3.1*pro*\"],\"gemini-3.5-flash\":[\"copilot/gemini-3.5*flash*\",\"google/gemini-3.5*flash*\",\"gemini/gemini-3.5*flash*\"],\"gemini-flash\":[\"copilot/gemini-*flash*\",\"google/gemini-*flash*\",\"gemini/gemini-*flash*\"],\"gemini-flash-lite\":[\"copilot/gemini-*flash*lite*\",\"google/gemini-*flash*lite*\",\"gemini/gemini-*flash*lite*\"],\"gemini-pro\":[\"copilot/gemini-*pro*\",\"google/gemini-*pro*\",\"gemini/gemini-*pro*\"],\"gemma\":[\"copilot/gemma*\",\"google/gemma*\",\"gemini/gemma*\"],\"gpt-5\":[\"copilot/gpt-5*\",\"openai/gpt-5*\"],\"gpt-5-codex\":[\"copilot/gpt-5*codex*\",\"openai/gpt-5*codex*\"],\"gpt-5-mini\":[\"copilot/gpt-5*mini*\",\"openai/gpt-5*mini*\"],\"gpt-5-nano\":[\"copilot/gpt-5*nano*\",\"openai/gpt-5*nano*\"],\"gpt-5-pro\":[\"copilot/gpt-5*pro*\",\"openai/gpt-5*pro*\"],\"gpt-5.1\":[\"copilot/gpt-5.1*\",\"openai/gpt-5.1*\"],\"gpt-5.2\":[\"copilot/gpt-5.2*\",\"openai/gpt-5.2*\"],\"gpt-5.3\":[\"copilot/gpt-5.3*\",\"openai/gpt-5.3*\"],\"gpt-5.4\":[\"copilot/gpt-5.4*\",\"openai/gpt-5.4*\"],\"gpt-5.5\":[\"copilot/gpt-5.5*\",\"openai/gpt-5.5*\"],\"haiku\":[\"copilot/*haiku*\",\"anthropic/*haiku*\"],\"image-generation\":[\"copilot/gpt-image*\",\"openai/gpt-image*\",\"openai/chatgpt-image*\",\"copilot/gemini-*image*\",\"google/gemini-*image*\",\"gemini/gemini-*image*\",\"google/imagen*\"],\"large\":[\"sonnet\",\"gpt-5-pro\",\"gpt-5\",\"gemini-pro\"],\"mai-code\":[\"copilot/MAI-Code*\",\"copilot/mai-code*\",\"openai/MAI-Code*\"],\"mini\":[\"haiku\",\"gpt-5-mini\",\"gpt-5-nano\",\"gemini-flash-lite\"],\"nano-banana\":[\"copilot/nano-banana*\",\"google/nano-banana*\",\"gemini/nano-banana*\"],\"opus\":[\"copilot/*opus*\",\"anthropic/*opus*\"],\"opusplan\":[\"opus?effort=high\"],\"reasoning\":[\"copilot/o1*\",\"copilot/o3*\",\"copilot/o4*\",\"openai/o1*\",\"openai/o3*\",\"openai/o4*\"],\"robotics\":[\"copilot/*robotics*\",\"google/*robotics*\",\"gemini/*robotics*\"],\"small\":[\"mini\"],\"small-agent\":[\"haiku\",\"gpt-5-mini\",\"gemini-flash\"],\"sonnet\":[\"copilot/*sonnet*\",\"anthropic/*sonnet*\"],\"sonnet-6x\":[\"copilot/*sonnet-4.5*\",\"copilot/*sonnet-4.6*\",\"copilot/*sonnet-4-5-*\",\"anthropic/*sonnet-4-5-*\",\"copilot/*sonnet-4-6*\",\"anthropic/*sonnet-4-6*\"],\"summarization\":[\"haiku\",\"gpt-5-mini\",\"gemini-flash-lite\",\"mini\"],\"vision\":[\"copilot/gemini-*image*\",\"google/gemini-*image*\",\"gemini/gemini-*image*\",\"copilot/gemini-*flash*\",\"google/gemini-*flash*\",\"gemini/gemini-*flash*\"]}},\"container\":{\"imageTag\":\"0.27.11,squid=sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d,agent=sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7,api-proxy=sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d\"}}" > "${RUNNER_TEMP}/gh-aw/awf-config.json"
+          printf '%s\n' "{\"\$schema\":\"https://github.com/github/gh-aw-firewall/releases/download/v0.27.11/awf-config.schema.json\",\"network\":{\"allowDomains\":[\"api.business.githubcopilot.com\",\"api.enterprise.githubcopilot.com\",\"api.github.com\",\"api.githubcopilot.com\",\"api.individual.githubcopilot.com\",\"api.snapcraft.io\",\"archive.ubuntu.com\",\"azure.archive.ubuntu.com\",\"crl.geotrust.com\",\"crl.globalsign.com\",\"crl.identrust.com\",\"crl.sectigo.com\",\"crl.thawte.com\",\"crl.usertrust.com\",\"crl.verisign.com\",\"crl3.digicert.com\",\"crl4.digicert.com\",\"crls.ssl.com\",\"github.com\",\"host.docker.internal\",\"json-schema.org\",\"json.schemastore.org\",\"keyserver.ubuntu.com\",\"ocsp.digicert.com\",\"ocsp.geotrust.com\",\"ocsp.globalsign.com\",\"ocsp.identrust.com\",\"ocsp.sectigo.com\",\"ocsp.ssl.com\",\"ocsp.thawte.com\",\"ocsp.usertrust.com\",\"ocsp.verisign.com\",\"packagecloud.io\",\"packages.cloud.google.com\",\"packages.microsoft.com\",\"ppa.launchpad.net\",\"raw.githubusercontent.com\",\"registry.npmjs.org\",\"s.symcb.com\",\"s.symcd.com\",\"security.ubuntu.com\",\"telemetry.enterprise.githubcopilot.com\",\"ts-crl.ws.symantec.com\",\"ts-ocsp.ws.symantec.com\",\"www.googleapis.com\"]},\"apiProxy\":{\"enabled\":true,\"enableTokenSteering\":true,\"maxRuns\":500,\"maxAiCredits\":${GH_AW_MAX_AI_CREDITS},\"maxCacheMisses\":5,\"models\":{\"agent\":[\"sonnet-6x\",\"gpt-5.5\",\"gpt-5.4\",\"gpt-5.3\",\"gemini-pro\",\"any\"],\"antigravity\":[\"copilot/antigravity*\",\"google/antigravity*\",\"gemini/antigravity*\"],\"any\":[\"copilot/*\",\"anthropic/*\",\"openai/*\",\"google/*\",\"gemini/*\"],\"claude\":[\"agent\"],\"codex\":[\"agent\"],\"coding\":[\"copilot/gpt-5*codex*\",\"openai/gpt-5*codex*\",\"gpt-5-codex\"],\"computer-use\":[\"copilot/*computer-use*\",\"google/*computer-use*\",\"gemini/*computer-use*\",\"openai/*computer-use*\"],\"copilot\":[\"agent\"],\"deep-research\":[\"copilot/deep-research*\",\"copilot/o3-deep-research*\",\"copilot/o4-mini-deep-research*\",\"google/deep-research*\",\"gemini/deep-research*\",\"openai/o3-deep-research*\",\"openai/o4-mini-deep-research*\"],\"gemini\":[\"agent\"],\"gemini-3-flash\":[\"copilot/gemini-3*flash*\",\"google/gemini-3*flash*\",\"gemini/gemini-3*flash*\"],\"gemini-3-pro\":[\"copilot/gemini-3*pro*\",\"google/gemini-3*pro*\",\"google/nano-banana*\",\"gemini/gemini-3*pro*\"],\"gemini-3.1-flash\":[\"copilot/gemini-3.1*flash*\",\"google/gemini-3.1*flash*\",\"gemini/gemini-3.1*flash*\"],\"gemini-3.1-pro\":[\"copilot/gemini-3.1*pro*\",\"google/gemini-3.1*pro*\",\"gemini/gemini-3.1*pro*\"],\"gemini-3.5-flash\":[\"copilot/gemini-3.5*flash*\",\"google/gemini-3.5*flash*\",\"gemini/gemini-3.5*flash*\"],\"gemini-flash\":[\"copilot/gemini-*flash*\",\"google/gemini-*flash*\",\"gemini/gemini-*flash*\"],\"gemini-flash-lite\":[\"copilot/gemini-*flash*lite*\",\"google/gemini-*flash*lite*\",\"gemini/gemini-*flash*lite*\"],\"gemini-pro\":[\"copilot/gemini-*pro*\",\"google/gemini-*pro*\",\"gemini/gemini-*pro*\"],\"gemma\":[\"copilot/gemma*\",\"google/gemma*\",\"gemini/gemma*\"],\"gpt-5\":[\"copilot/gpt-5*\",\"openai/gpt-5*\"],\"gpt-5-codex\":[\"copilot/gpt-5*codex*\",\"openai/gpt-5*codex*\"],\"gpt-5-mini\":[\"copilot/gpt-5*mini*\",\"openai/gpt-5*mini*\"],\"gpt-5-nano\":[\"copilot/gpt-5*nano*\",\"openai/gpt-5*nano*\"],\"gpt-5-pro\":[\"copilot/gpt-5*pro*\",\"openai/gpt-5*pro*\"],\"gpt-5.1\":[\"copilot/gpt-5.1*\",\"openai/gpt-5.1*\"],\"gpt-5.2\":[\"copilot/gpt-5.2*\",\"openai/gpt-5.2*\"],\"gpt-5.3\":[\"copilot/gpt-5.3*\",\"openai/gpt-5.3*\"],\"gpt-5.4\":[\"copilot/gpt-5.4*\",\"openai/gpt-5.4*\"],\"gpt-5.5\":[\"copilot/gpt-5.5*\",\"openai/gpt-5.5*\"],\"haiku\":[\"copilot/*haiku*\",\"anthropic/*haiku*\"],\"image-generation\":[\"copilot/gpt-image*\",\"openai/gpt-image*\",\"openai/chatgpt-image*\",\"copilot/gemini-*image*\",\"google/gemini-*image*\",\"gemini/gemini-*image*\",\"google/imagen*\"],\"large\":[\"sonnet\",\"gpt-5-pro\",\"gpt-5\",\"gemini-pro\"],\"mai-code\":[\"copilot/MAI-Code*\",\"copilot/mai-code*\",\"openai/MAI-Code*\"],\"mini\":[\"haiku\",\"gpt-5-mini\",\"gpt-5-nano\",\"gemini-flash-lite\"],\"nano-banana\":[\"copilot/nano-banana*\",\"google/nano-banana*\",\"gemini/nano-banana*\"],\"opus\":[\"copilot/*opus*\",\"anthropic/*opus*\"],\"opusplan\":[\"opus?effort=high\"],\"reasoning\":[\"copilot/o1*\",\"copilot/o3*\",\"copilot/o4*\",\"openai/o1*\",\"openai/o3*\",\"openai/o4*\"],\"robotics\":[\"copilot/*robotics*\",\"google/*robotics*\",\"gemini/*robotics*\"],\"small\":[\"mini\"],\"small-agent\":[\"haiku\",\"gpt-5-mini\",\"gemini-flash\"],\"sonnet\":[\"copilot/*sonnet*\",\"anthropic/*sonnet*\"],\"sonnet-6x\":[\"copilot/*sonnet-4.5*\",\"copilot/*sonnet-4.6*\",\"copilot/*sonnet-4-5-*\",\"anthropic/*sonnet-4-5-*\",\"copilot/*sonnet-4-6*\",\"anthropic/*sonnet-4-6*\"],\"summarization\":[\"haiku\",\"gpt-5-mini\",\"gemini-flash-lite\",\"mini\"],\"vision\":[\"copilot/gemini-*image*\",\"google/gemini-*image*\",\"gemini/gemini-*image*\",\"copilot/gemini-*flash*\",\"google/gemini-*flash*\",\"gemini/gemini-*flash*\"]}},\"container\":{\"imageTag\":\"0.27.11,squid=sha256:ff27ea0525ad953a6adee28a5fbe9d2e22be47dbec755c15767af4ea3f91df7d,agent=sha256:979723c628182da7729333f2208bb249fd25ddee579645cf9a3892d681a929c7,api-proxy=sha256:807e4831999b44513b0a66e5859d478dc4da7ae74ab1918cec967d513f95bf9d\"}}" > "${RUNNER_TEMP}/gh-aw/awf-config.json"
           cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           export GH_AW_MODELS_JSON_PATH="/tmp/gh-aw/models.json"
           GH_AW_DOCKER_HOST=""
@@ -804,7 +757,7 @@ jobs:
           fi
           # shellcheck disable=SC1003,SC2086
           sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" ${GH_AW_TOOL_CACHE_MOUNT:+--mount "$GH_AW_TOOL_CACHE_MOUNT"} ${GH_AW_DOCKER_HOST:+--docker-host "$GH_AW_DOCKER_HOST"} ${GH_AW_DOCKER_HOST_PATH_PREFIX_ARGS} --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
-            -- /bin/bash -c 'set +o histexpand; export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && : "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}"; GH_AW_TOOL_CACHE="$RUNNER_TOOL_CACHE"; export PATH="$(find "$GH_AW_TOOL_CACHE" -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; GH_AW_NPM_GLOBAL_ROOT="$(npm root -g 2>/dev/null || true)"; if [ -n "$GH_AW_NPM_GLOBAL_ROOT" ]; then export NODE_PATH="${GH_AW_NPM_GLOBAL_ROOT}${NODE_PATH:+:${NODE_PATH}}"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat /tmp/gh-aw/agent/post-index-result.json)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(printf)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(safeoutputs:*)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'set +o histexpand; export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && : "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}"; GH_AW_TOOL_CACHE="$RUNNER_TOOL_CACHE"; export PATH="$(find "$GH_AW_TOOL_CACHE" -maxdepth 5 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || true)"; fi; if [ -z "$GH_AW_NODE_EXEC" ]; then echo "node runtime missing on this runner — check runtimes.node in workflow YAML" >&2; exit 127; fi; GH_AW_NPM_GLOBAL_ROOT="$(npm root -g 2>/dev/null || true)"; if [ -n "$GH_AW_NPM_GLOBAL_ROOT" ]; then export NODE_PATH="${GH_AW_NPM_GLOBAL_ROOT}${NODE_PATH:+:${NODE_PATH}}"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           AWF_REFLECT_ENABLED: 1
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
@@ -889,7 +842,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
+          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
         with:
@@ -993,7 +946,7 @@ jobs:
       - safe_outputs
     if: >
       always() && (needs.agent.result != 'skipped' || needs.activation.outputs.lockdown_check_failed == 'true' ||
-      needs.activation.outputs.stale_lock_file_failed == 'true')
+      needs.activation.outputs.stale_lock_file_failed == 'true' || needs.activation.outputs.daily_ai_credits_exceeded == 'true')
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -1004,11 +957,6 @@ jobs:
       queue: max
     env:
       GH_AW_RUNTIME_FEATURES: ${{ vars.GH_AW_RUNTIME_FEATURES }}
-    outputs:
-      incomplete_count: ${{ steps.report_incomplete.outputs.incomplete_count }}
-      noop_message: ${{ steps.noop.outputs.noop_message }}
-      tools_reported: ${{ steps.missing_tool.outputs.tools_reported }}
-      total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -1081,61 +1029,45 @@ jobs:
             /tmp/gh-aw/usage/detection/token_usage.jsonl
             /tmp/gh-aw/usage/activity/summary.json
           if-no-files-found: ignore
-      - name: Process no-op messages
-        id: noop
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Post-Index Search Quality Check"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/post-index-sync-testbench.md"
-          GH_AW_TRACKER_ID: "post-index-testbench"
-          GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
-          GH_AW_NOOP_REPORT_AS_ISSUE: "false"
-          GH_AW_AIC: ${{ needs.agent.outputs.aic }}
-          GH_AW_AMBIENT_CONTEXT: ${{ needs.agent.outputs.ambient_context }}
-          GH_AW_WORKFLOW_ID: "post-index-sync-testbench"
+      - name: Restore daily AIC usage cache
+        id: restore-daily-aic-cache-conclusion
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          key: agentic-workflow-usage-postindexsynctestbench-${{ github.run_id }}
+          restore-keys: agentic-workflow-usage-postindexsynctestbench-
+          path: /tmp/gh-aw/agentic-workflow-usage-cache.jsonl
+      - name: Write daily AIC usage cache entry
+        id: write-daily-aic-cache
+        if: always()
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ github.token }}
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_noop_message.cjs');
+            setupGlobals(core, github, context);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/write_daily_aic_usage_cache.cjs');
             await main();
-      - name: Record missing tool
-        id: missing_tool
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Post-Index Search Quality Check"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/post-index-sync-testbench.md"
-          GH_AW_TRACKER_ID: "post-index-testbench"
+      - name: Save daily AIC usage cache
+        id: save-daily-aic-cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/missing_tool.cjs');
-            await main();
-      - name: Record incomplete
-        id: report_incomplete
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_REPORT_INCOMPLETE_TITLE_PREFIX: "[incomplete]"
-          GH_AW_WORKFLOW_NAME: "Post-Index Search Quality Check"
-          GH_AW_WORKFLOW_SOURCE_URL: "${{ github.server_url }}/${{ github.repository }}/blob/${{ github.ref_name }}/.github/workflows/post-index-sync-testbench.md"
-          GH_AW_TRACKER_ID: "post-index-testbench"
+          key: agentic-workflow-usage-postindexsynctestbench-${{ github.run_id }}
+          path: /tmp/gh-aw/agentic-workflow-usage-cache.jsonl
+      - name: Upload daily AIC usage cache artifact
+        id: upload-daily-aic-cache
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/report_incomplete_handler.cjs');
-            await main();
+          name: aic-usage-cache
+          path: /tmp/gh-aw/agentic-workflow-usage-cache.jsonl
+          if-no-files-found: ignore
+          retention-days: 7
       - name: Handle agent failure
         id: handle_agent_failure
         if: always()
@@ -1164,6 +1096,9 @@ jobs:
           GH_AW_ENGINE_API_HOSTS: "api.enterprise.githubcopilot.com,api.githubcopilot.com,api.business.githubcopilot.com,api.individual.githubcopilot.com"
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
+          GH_AW_DAILY_AI_CREDITS_EXCEEDED: ${{ needs.activation.outputs.daily_ai_credits_exceeded }}
+          GH_AW_DAILY_AI_CREDITS_TOTAL_EFFECTIVE_TOKENS: ${{ needs.activation.outputs.daily_ai_credits_total_effective_tokens }}
+          GH_AW_DAILY_AI_CREDITS_THRESHOLD: ${{ needs.activation.outputs.daily_ai_credits_threshold }}
           GH_AW_GROUP_REPORTS: "false"
           GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
@@ -1178,15 +1113,17 @@ jobs:
             await main();
 
   post_index_conclusion:
-    name: Enforce deterministic post-index conclusion
-    needs:
-      - agent
-      - post_index_regression
+    name: Report and enforce deterministic post-index conclusion
+    needs: post_index_regression
     if: always()
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
+      issues: write
 
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Configure GH_HOST for enterprise compatibility
         id: ghes-host-config
@@ -1205,12 +1142,51 @@ jobs:
         with:
           name: post-index-regression-${{ github.run_id }}
           path: /tmp/post-index-regression
+      - name: Publish deterministic regression incident
+        if: needs.post_index_regression.outputs.status == 'failed'
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          decision = json.loads(
+              Path("/tmp/post-index-regression/decision-output.json").read_text(encoding="utf-8")
+          )
+          issue = decision["items"][0]
+          if issue["type"] != "create_issue":
+              raise SystemExit("Expected deterministic create_issue output")
+          Path("/tmp/post-index-regression/issue-title.txt").write_text(issue["title"], encoding="utf-8")
+          Path("/tmp/post-index-regression/issue-body.md").write_text(issue["body"], encoding="utf-8")
+          PY
+          issue_number=$(
+            gh issue list \
+              --state open \
+              --search 'in:title "[search-quality] Search Quality Regression Detected" label:search label:automation' \
+              --json number \
+              --jq '.[0].number // empty'
+          )
+          if [[ -n "$issue_number" ]]; then
+            gh issue edit "$issue_number" \
+              --title "[search-quality] $(cat /tmp/post-index-regression/issue-title.txt)" \
+              --body-file /tmp/post-index-regression/issue-body.md \
+              --add-label search \
+              --add-label automation
+          else
+            gh issue create \
+              --title "[search-quality] $(cat /tmp/post-index-regression/issue-title.txt)" \
+              --body-file /tmp/post-index-regression/issue-body.md \
+              --label search \
+              --label automation
+          fi
+      - name: Record deterministic no-op or blocked outcome
+        if: needs.post_index_regression.outputs.status != 'failed'
+        run: cat /tmp/post-index-regression/decision-output.json >> "$GITHUB_STEP_SUMMARY"
       - name: Enforce the machine-owned conclusion
         run: python scripts/post_index_regression.py validate --input /tmp/post-index-regression/post-index-result.json --phase final
 
   post_index_regression:
     name: Execute deterministic post-index regression
-    needs: pre_activation
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1325,6 +1301,9 @@ jobs:
           python scripts/post_index_regression.py classify \
             --input "$RESULT_PATH" \
             --github-output "$GITHUB_OUTPUT"
+          python scripts/post_index_regression.py render-decision-output \
+            --input "$RESULT_PATH" \
+            --output /tmp/post-index-regression/decision-output.json
           cat "$RESULT_PATH" >> "$GITHUB_STEP_SUMMARY"
       - name: Upload bounded regression evidence
         if: always()
@@ -1339,6 +1318,10 @@ jobs:
         run: python scripts/post_index_regression.py validate --input "$RESULT_PATH" --phase prepare
 
   pre_activation:
+    needs:
+      - post_index_conclusion
+      - post_index_regression
+    if: false
     runs-on: ubuntu-slim
     env:
       GH_AW_RUNTIME_FEATURES: ${{ vars.GH_AW_RUNTIME_FEATURES }}
@@ -1451,10 +1434,10 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_COMMENT_ID: ${{ needs.activation.outputs.comment_id }}
-          GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,patch-diff.githubusercontent.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
+          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"close_older_issues\":true,\"expires\":168,\"labels\":[\"search\",\"automation\"],\"max\":1,\"title_prefix\":\"[search-quality] \"},\"create_report_incomplete_issue\":{\"title-prefix\":\"[incomplete]\"},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"post-index-sync-testbench\"],\"max\":1,\"title_prefix\":\"[post-index-sync-testbench]\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/post-index-sync-testbench.md
+++ b/.github/workflows/post-index-sync-testbench.md
@@ -7,21 +7,19 @@ on:
     types: [completed]
     branches: [main]
   workflow_dispatch:
+  needs: [post_index_regression, post_index_conclusion]
 
 permissions:
   contents: read
-  issues: read
-  pull-requests: read
 
 engine: copilot
 strict: true
 tracker-id: post-index-testbench
-max-daily-ai-credits: -1
+if: ${{ false }}
 
 jobs:
   post_index_regression:
     name: Execute deterministic post-index regression
-    needs: pre_activation
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -123,6 +121,9 @@ jobs:
           python scripts/post_index_regression.py classify \
             --input "$RESULT_PATH" \
             --github-output "$GITHUB_OUTPUT"
+          python scripts/post_index_regression.py render-decision-output \
+            --input "$RESULT_PATH" \
+            --output /tmp/post-index-regression/decision-output.json
           cat "$RESULT_PATH" >> "$GITHUB_STEP_SUMMARY"
       - name: Upload bounded regression evidence
         if: always()
@@ -136,12 +137,16 @@ jobs:
         if: always()
         run: python scripts/post_index_regression.py validate --input "$RESULT_PATH" --phase prepare
   post_index_conclusion:
-    name: Enforce deterministic post-index conclusion
-    needs: [post_index_regression, agent]
+    name: Report and enforce deterministic post-index conclusion
+    needs: post_index_regression
     if: always()
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -151,52 +156,51 @@ jobs:
         with:
           name: post-index-regression-${{ github.run_id }}
           path: /tmp/post-index-regression
+      - name: Publish deterministic regression incident
+        if: needs.post_index_regression.outputs.status == 'failed'
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          decision = json.loads(
+              Path("/tmp/post-index-regression/decision-output.json").read_text(encoding="utf-8")
+          )
+          issue = decision["items"][0]
+          if issue["type"] != "create_issue":
+              raise SystemExit("Expected deterministic create_issue output")
+          Path("/tmp/post-index-regression/issue-title.txt").write_text(issue["title"], encoding="utf-8")
+          Path("/tmp/post-index-regression/issue-body.md").write_text(issue["body"], encoding="utf-8")
+          PY
+          issue_number=$(
+            gh issue list \
+              --state open \
+              --search 'in:title "[search-quality] Search Quality Regression Detected" label:search label:automation' \
+              --json number \
+              --jq '.[0].number // empty'
+          )
+          if [[ -n "$issue_number" ]]; then
+            gh issue edit "$issue_number" \
+              --title "[search-quality] $(cat /tmp/post-index-regression/issue-title.txt)" \
+              --body-file /tmp/post-index-regression/issue-body.md \
+              --add-label search \
+              --add-label automation
+          else
+            gh issue create \
+              --title "[search-quality] $(cat /tmp/post-index-regression/issue-title.txt)" \
+              --body-file /tmp/post-index-regression/issue-body.md \
+              --label search \
+              --label automation
+          fi
+      - name: Record deterministic no-op or blocked outcome
+        if: needs.post_index_regression.outputs.status != 'failed'
+        run: cat /tmp/post-index-regression/decision-output.json >> "$GITHUB_STEP_SUMMARY"
       - name: Enforce the machine-owned conclusion
         run: >-
           python scripts/post_index_regression.py validate
           --input /tmp/post-index-regression/post-index-result.json
           --phase final
-network:
-  allowed:
-    - defaults
-    - github
-
-tools:
-  github:
-    toolsets: [default]
-  bash:
-    - "cat /tmp/gh-aw/agent/post-index-result.json"
-
-steps:
-  - name: Download deterministic regression evidence
-    uses: actions/download-artifact@v8
-    with:
-      name: post-index-regression-${{ github.run_id }}
-      path: /tmp/gh-aw/agent
-  - name: Materialize deterministic safe outputs and skip model invocation
-    env:
-      GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-    run: |
-      set -euo pipefail
-      python scripts/post_index_regression.py render-safe-outputs-jsonl \
-        --input /tmp/gh-aw/agent/post-index-result.json \
-        --output "$GH_AW_SAFE_OUTPUTS"
-
-safe-outputs:
-  threat-detection:
-    engine: false
-  create-issue:
-    title-prefix: "[search-quality] "
-    labels: [search, automation]
-    expires: 7d
-    close-older-issues: true
-  report-incomplete:
-  noop:
-    report-as-issue: false
-
-imports:
-  - shared/mood.md
-  - shared/reporting.md
 
 timeout-minutes: 10
 concurrency:
@@ -206,9 +210,9 @@ concurrency:
 
 # Post-Index Search Quality Check
 
-Deterministic host steps execute and validate the search regression suite, materialize the corresponding safe outputs, and
-write a `noop` before engine startup. The `noop` is a mandatory short-circuit: no model invocation is required or permitted for
-this workflow's regression decision.
+This workflow is fully deterministic. Custom jobs execute and validate the regression suite, render the issue/no-op contract,
+publish any regression incident, and enforce the final conclusion. The static activation condition is false, so Copilot
+activation, model credentials, model setup, and safe-output infrastructure are never part of the execution path.
 
 ## Context
 

--- a/scripts/post_index_regression.py
+++ b/scripts/post_index_regression.py
@@ -169,10 +169,10 @@ def validation_errors(result: object) -> list[str]:
         if status in EXECUTED_STATUSES:
             if total == 0:
                 errors.append("executed results must contain at least one test")
-            if isinstance(scores, list) and len(scores) != total:
-                errors.append("scores must contain one entry per executed test")
-            if isinstance(failed_queries, list) and len(failed_queries) != total - passed:
-                errors.append("failed_queries must contain one entry per failed test")
+            if isinstance(scores, list):
+                if len(scores) != total:
+                    errors.append("scores must contain one entry per executed test")
+                errors.extend(_score_consistency_errors(scores, failed_queries, total, passed, pass_rate))
             expected_status = "passed" if pass_rate >= threshold else "failed"
             expected_decision = "pass" if expected_status == "passed" else "fail"
             if status != expected_status:
@@ -182,13 +182,13 @@ def validation_errors(result: object) -> list[str]:
         elif status == "blocked":
             if decision != "skip":
                 errors.append("blocked results must use decision 'skip'")
-            if total != 0 or passed != 0:
-                errors.append("blocked results cannot report executed tests")
+            errors.extend(_nonexecuted_evidence_errors(result, "blocked"))
         elif status == "error":
             if decision != "fail":
                 errors.append("error results must use decision 'fail'")
             if not diagnostics:
                 errors.append("error results must include diagnostics")
+            errors.extend(_nonexecuted_evidence_errors(result, "error"))
 
     return errors
 
@@ -224,6 +224,65 @@ def _validate_score(item: object, index: int) -> list[str]:
     return errors
 
 
+def _score_consistency_errors(
+    scores: list[object],
+    failed_queries: object,
+    total: int,
+    passed: int,
+    pass_rate: float,
+) -> list[str]:
+    """Cross-check aggregate and failed-query evidence against score records."""
+    if not all(isinstance(item, dict) for item in scores):
+        return []
+
+    score_queries = [item.get("query") for item in scores]
+    if not all(isinstance(query, str) and query for query in score_queries):
+        return []
+
+    errors: list[str] = []
+    if len(set(score_queries)) != len(score_queries):
+        errors.append("scores must contain unique query identities")
+
+    derived_passed = sum(item.get("passed") is True for item in scores)
+    if derived_passed != passed:
+        errors.append("passed_tests must equal the number of scores with passed=true")
+    derived_rate = derived_passed / total if total else 0.0
+    if not math.isclose(pass_rate, derived_rate, rel_tol=0.0, abs_tol=1e-12):
+        errors.append("pass_rate must equal the pass rate derived from scores")
+
+    failed_scores = {item["query"]: item.get("score") for item in scores if item.get("passed") is False}
+    if len(failed_scores) != total - derived_passed:
+        errors.append("failed score count must equal total_tests minus passed_tests")
+
+    if not isinstance(failed_queries, list) or not all(isinstance(item, dict) for item in failed_queries):
+        return errors
+    failed_query_names = [item.get("query") for item in failed_queries]
+    if not all(isinstance(query, str) and query for query in failed_query_names):
+        return errors
+    if len(set(failed_query_names)) != len(failed_query_names):
+        errors.append("failed_queries must contain unique query identities")
+    if set(failed_query_names) != set(failed_scores):
+        errors.append("failed_queries must exactly match queries whose scores have passed=false")
+        return errors
+
+    for item in failed_queries:
+        query = item["query"]
+        if item.get("score") != failed_scores[query]:
+            errors.append(f"failed_queries score must match scores entry for query {query!r}")
+    return errors
+
+
+def _nonexecuted_evidence_errors(result: dict[str, Any], status: str) -> list[str]:
+    errors = []
+    if result["total_tests"] != 0 or result["passed_tests"] != 0 or result["pass_rate"] != 0.0:
+        errors.append(f"{status} results cannot report executed test aggregates")
+    if result["scores"]:
+        errors.append(f"{status} results cannot contain scores")
+    if result["failed_queries"]:
+        errors.append(f"{status} results cannot contain failed_queries")
+    return errors
+
+
 def write_result(path: Path, result: dict[str, Any]) -> None:
     """Validate and atomically write a result."""
     errors = validation_errors(result)
@@ -251,7 +310,7 @@ def phase_exit_code(result: dict[str, Any], phase: str) -> int:
     if phase == "schema":
         return 0
     if phase == "prepare":
-        return 1 if result["status"] in {"blocked", "error"} else 0
+        return 1 if result["status"] == "error" else 0
     if phase == "final":
         return 0 if result["decision"] in {"pass", "skip"} else 1
     raise ValueError(f"Unknown validation phase: {phase}")
@@ -304,24 +363,20 @@ def build_safe_output(result: dict[str, Any]) -> dict[str, Any]:
             ]
         }
 
-    raise ValueError(f"Cannot render a safe output for status {result['status']!r}")
+    if result["status"] in {"blocked", "error"}:
+        message = " ".join(result["diagnostics"]) or f"Post-index regression status: {result['status']}."
+        return {"items": [{"type": "noop", "message": message}]}
+
+    raise ValueError(f"Cannot render a decision output for status {result['status']!r}")
 
 
-def write_safe_outputs_jsonl(path: Path, result: dict[str, Any]) -> None:
-    """Append deterministic safe outputs and a noop engine short-circuit."""
+def write_decision_output(path: Path, result: dict[str, Any]) -> None:
+    """Write the deterministic issue/noop rendering for host-side processing."""
     safe_output = build_safe_output(result)
-    items = list(safe_output["items"])
-    if not any(item["type"] == "noop" for item in items):
-        items.append(
-            {
-                "type": "noop",
-                "message": "Machine-owned regression decision prepared; no model invocation is required.",
-            }
-        )
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as output:
-        for item in items:
-            output.write(json.dumps(item, sort_keys=True) + "\n")
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    temporary.write_text(json.dumps(safe_output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -347,9 +402,9 @@ def _parse_args() -> argparse.Namespace:
     classify.add_argument("--input", type=Path, required=True)
     classify.add_argument("--github-output", type=Path, required=True)
 
-    render_jsonl = subparsers.add_parser("render-safe-outputs-jsonl")
-    render_jsonl.add_argument("--input", type=Path, required=True)
-    render_jsonl.add_argument("--output", type=Path, required=True)
+    render = subparsers.add_parser("render-decision-output")
+    render.add_argument("--input", type=Path, required=True)
+    render.add_argument("--output", type=Path, required=True)
     return parser.parse_args()
 
 
@@ -380,11 +435,11 @@ def main() -> int:
             output.write(f"decision={result['decision']}\n")
             output.write(f"invoke_agent={'true' if result['status'] in EXECUTED_STATUSES else 'false'}\n")
         return 0
-    if args.command == "render-safe-outputs-jsonl":
+    if args.command == "render-decision-output":
         try:
-            write_safe_outputs_jsonl(args.output, result)
+            write_decision_output(args.output, result)
         except ValueError as exc:
-            print(f"Cannot render post-index safe outputs: {exc}", file=sys.stderr)
+            print(f"Cannot render post-index decision output: {exc}", file=sys.stderr)
             return 2
         return 0
 

--- a/tests/test_post_index_regression.py
+++ b/tests/test_post_index_regression.py
@@ -16,7 +16,7 @@ from post_index_regression import (  # noqa: E402
     build_safe_output,
     phase_exit_code,
     validation_errors,
-    write_safe_outputs_jsonl,
+    write_decision_output,
 )
 
 
@@ -33,7 +33,7 @@ def _failed_queries(total: int, passed: int) -> list[dict]:
             "query": f"query-{index}",
             "expected_paths": [f"expected/{index}"],
             "returned_paths": [f"actual/{index}"],
-            "score": 0.1,
+            "score": 1.0 - index / 100,
         }
         for index in range(passed, total)
     ]
@@ -56,7 +56,7 @@ def test_failed_or_cancelled_parent_is_blocked_before_agent() -> None:
         assert result["status"] == "blocked"
         assert result["decision"] == "skip"
         assert conclusion in result["diagnostics"][0]
-        assert phase_exit_code(result, "prepare") == 1
+        assert phase_exit_code(result, "prepare") == 0
         assert validation_errors(result) == []
 
 
@@ -68,6 +68,7 @@ def test_setup_failure_is_machine_failure() -> None:
     assert phase_exit_code(result, "prepare") == 1
     assert phase_exit_code(result, "final") == 1
     assert validation_errors(result) == []
+    assert build_safe_output(result)["items"][0]["type"] == "noop"
 
 
 def test_schema_invalid_output_fails_validation() -> None:
@@ -96,7 +97,7 @@ def test_failed_queries_and_scores_are_preserved() -> None:
             "query": "query-2",
             "expected_paths": ["expected/2"],
             "returned_paths": ["actual/2"],
-            "score": 0.1,
+            "score": 0.98,
         }
     ]
     assert result["scores"] == _scores(3, 2)
@@ -131,10 +132,60 @@ def test_safe_output_is_derived_only_from_machine_decision() -> None:
     assert "80.0% (machine threshold: 85.0%)" in failed["items"][0]["body"]
 
 
-def test_jsonl_safe_outputs_always_short_circuit_model_invocation(tmp_path) -> None:
-    output = tmp_path / "safe-outputs.jsonl"
-    write_safe_outputs_jsonl(output, _result(20, 16))
-    items = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+def test_decision_output_preserves_deterministic_issue_rendering(tmp_path) -> None:
+    output = tmp_path / "decision-output.json"
+    write_decision_output(output, _result(20, 16))
+    items = json.loads(output.read_text(encoding="utf-8"))["items"]
 
-    assert [item["type"] for item in items] == ["create_issue", "noop"]
+    assert [item["type"] for item in items] == ["create_issue"]
     assert items[0]["title"] == "Search Quality Regression Detected"
+
+
+def test_passed_count_must_match_score_evidence() -> None:
+    result = _result(20, 17)
+    for item in result["scores"]:
+        item["passed"] = False
+
+    errors = validation_errors(result)
+
+    assert "passed_tests must equal the number of scores with passed=true" in errors
+    assert "pass_rate must equal the pass rate derived from scores" in errors
+    assert phase_exit_code(result, "final") == 2
+
+
+def test_failed_queries_must_match_failed_score_identities() -> None:
+    result = _result(3, 2)
+    result["failed_queries"][0]["query"] = "different-query"
+
+    errors = validation_errors(result)
+    assert "failed_queries must exactly match queries whose scores have passed=false" in errors
+    assert phase_exit_code(result, "final") == 2
+
+
+def test_failed_query_score_must_match_score_evidence() -> None:
+    result = _result(3, 2)
+    result["failed_queries"][0]["score"] = 0.9
+
+    errors = validation_errors(result)
+    assert "failed_queries score must match scores entry for query 'query-2'" in errors
+    assert phase_exit_code(result, "final") == 2
+
+
+def test_blocked_and_error_results_reject_execution_evidence() -> None:
+    for result in (build_blocked_result("cancelled"), build_error_result("setup", "failed")):
+        status = result["status"]
+        result["scores"] = [{"query": "contradiction", "score": 0.1, "passed": False}]
+        result["failed_queries"] = [
+            {
+                "query": "contradiction",
+                "expected_paths": ["expected"],
+                "returned_paths": ["actual"],
+                "score": 0.1,
+            }
+        ]
+
+        errors = validation_errors(result)
+
+        assert f"{status} results cannot contain scores" in errors
+        assert f"{status} results cannot contain failed_queries" in errors
+        assert phase_exit_code(result, "final") == 2


### PR DESCRIPTION
## Summary

Follow-up required by independent review after #641 was merged before its requested revision could land.

- run `post_index_regression` and `post_index_conclusion` as independent deterministic custom jobs
- statically skip generated `pre_activation`, `activation`, `agent`, and `safe_outputs` jobs, so `COPILOT_GITHUB_TOKEN`, model setup, AI-credit guards, and agent timeouts are not on the execution path
- render pass/blocked/error summaries and update-or-create an automation-owned regression incident directly with the job-scoped `GITHUB_TOKEN`
- enforce the final conclusion from a fresh download of the original bounded result artifact
- fail schema validation when aggregate counts/rate contradict score records, failed-query identities differ from failed scores, failed-query scores differ, or blocked/error results contain execution evidence

Relates to #632 and completes the independent-review fixes for #641.

## Validation

- `python -m pytest tests/test_post_index_regression.py tests/test_run_testbench.py -q` — 13 passed
- `python -m ruff check scripts/post_index_regression.py scripts/run_testbench.py tests/test_post_index_regression.py tests/test_run_testbench.py` — passed
- `gh aw compile post-index-sync-testbench --strict --validate` — 1 workflow compiled, 0 errors, 0 warnings
- generated lock review confirms `post_index_regression` has no `needs`, `post_index_conclusion` needs only that job, and `pre_activation` is `if: false` after both deterministic jobs; all Copilot-dependent jobs remain unreachable
- `git diff --check` — passed
- independent final code review — no significant issues

## Security review

- Azure secrets remain confined to the read-only deterministic regression job.
- Incident publication uses the standard job-scoped `GITHUB_TOKEN` with only `issues: write`, `actions: read`, and `contents: read`.
- Existing automation-owned incidents are selected by title plus both `search` and `automation` labels and updated in place; no issue is closed before a replacement exists.
- Compiler-resolved actions remain pinned to immutable SHAs; no redirect changes.

## Post-merge verification

After this follow-up merges, dispatch a genuinely new `Incremental Index Sync` run on `main`, for example `gh workflow run index-sync.yml --ref main`. Do not rerun an older run because reruns retain the workflow definition from their original event. Verify the resulting new post-index run completes through only the two deterministic jobs, without Copilot credential/setup or model infrastructure.