### PR TITLE
Create a stable docs-vnext navigation check

### DIFF
--- a/.github/workflows/docs-vnext-source-navigation-required.yml
+++ b/.github/workflows/docs-vnext-source-navigation-required.yml
@@ -1,0 +1,55 @@
+name: docs-vnext source navigation required check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  require-source-navigation:
+    name: Validate source navigation
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Require successful pull request validation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          WORKFLOW_FILE: docs-vnext-source-navigation.yml
+        run: |
+          for attempt in {1..132}; do
+            if ! run="$(
+              gh api \
+                "/repos/$REPOSITORY/actions/workflows/$WORKFLOW_FILE/runs?event=pull_request&head_sha=$HEAD_SHA&per_page=100" \
+                --jq ".workflow_runs | map(select(any(.pull_requests[]?; .number == $PR_NUMBER))) | .[0] // empty | [.id, .status, (.conclusion // \"\")] | @tsv"
+            )"; then
+              echo "::error::Unable to query source navigation workflow runs."
+              exit 1
+            fi
+
+            if [[ -n "$run" ]]; then
+              IFS=$'\t' read -r run_id status conclusion <<< "$run"
+              if [[ "$status" == "completed" ]]; then
+                if [[ "$conclusion" == "success" ]]; then
+                  echo "Source navigation validation run $run_id succeeded."
+                  exit 0
+                fi
+                echo "::error::Source navigation validation run $run_id concluded with: $conclusion"
+                exit 1
+              fi
+            fi
+            sleep 5
+          done
+
+          echo "::error::No completed source navigation validation run was found for $HEAD_SHA."
+          echo "::error::Remove any [skip ci] directive or resolve merge conflicts, then push a new commit."
+          exit 1

--- a/.github/workflows/docs-vnext-source-navigation.yml
+++ b/.github/workflows/docs-vnext-source-navigation.yml
@@ -1,12 +1,7 @@
 name: docs-vnext source navigation gate
 
 on:
-  pull_request:
-    paths:
-      - "docs-vnext/**"
-      - "scripts/validate_docs_vnext_navigation.py"
-      - "tests/test_validate_docs_vnext_navigation.py"
-      - ".github/workflows/docs-vnext-source-navigation.yml"
+  pull_request: {}
 
 permissions:
   contents: read
@@ -25,7 +20,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect relevant changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          relevant=false
+          while IFS= read -r -d '' path; do
+            case "$path" in
+              docs-vnext/*|scripts/validate_docs_vnext_navigation.py|tests/test_validate_docs_vnext_navigation.py|.github/workflows/docs-vnext-source-navigation.yml)
+                relevant=true
+                break
+                ;;
+            esac
+          done < <(git diff --no-renames --name-only -z "$BASE_SHA" "$HEAD_SHA" --)
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
+      - name: No relevant source navigation changes
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No docs-vnext source navigation changes require validation."
+
       - name: Initialize failure inventory
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           mkdir -p tests/eval_results
           cat > tests/eval_results/docs-vnext-route-inventory.json <<'JSON'
@@ -61,17 +78,21 @@ jobs:
           JSON
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        if: steps.changes.outputs.relevant == 'true'
         with:
           python-version: "3.12"
           cache: "pip"
 
       - name: Install test dependencies
+        if: steps.changes.outputs.relevant == 'true'
         run: pip install -e ".[dev]"
 
       - name: Run navigation validator tests
+        if: steps.changes.outputs.relevant == 'true'
         run: python -m pytest tests/test_validate_docs_vnext_navigation.py -q
 
       - name: Prepare baseline validation inputs
+        if: steps.changes.outputs.relevant == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
@@ -79,13 +100,14 @@ jobs:
           git archive "$BASE_SHA" docs-vnext | tar -x -C "$RUNNER_TEMP/base"
 
       - name: Validate docs-vnext source navigation
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           python scripts/validate_docs_vnext_navigation.py \
             --base-docs-dir "$RUNNER_TEMP/base/docs-vnext" \
             --output tests/eval_results/docs-vnext-route-inventory.json
 
       - name: Upload route inventory
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: docs-vnext-route-inventory

--- a/.github/workflows/docs-vnext-source-navigation.yml
+++ b/.github/workflows/docs-vnext-source-navigation.yml
@@ -12,7 +12,8 @@ concurrency:
 
 jobs:
   validate-source-navigation:
-    name: Validate source navigation
+    name: Run source navigation validation
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -27,14 +28,23 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           relevant=false
+          changed_paths="$RUNNER_TEMP/source-navigation-changed-paths"
+          if ! merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "::error::Unable to determine the pull request merge base."
+            exit 1
+          fi
+          if ! git diff --no-renames --name-only -z "$merge_base" "$HEAD_SHA" -- > "$changed_paths"; then
+            echo "::error::Unable to enumerate pull request paths."
+            exit 1
+          fi
           while IFS= read -r -d '' path; do
             case "$path" in
-              docs-vnext/*|scripts/validate_docs_vnext_navigation.py|tests/test_validate_docs_vnext_navigation.py|.github/workflows/docs-vnext-source-navigation.yml)
+              docs-vnext/*|scripts/validate_docs_vnext_navigation.py|tests/test_validate_docs_vnext_navigation.py|.github/workflows/docs-vnext-source-navigation.yml|.github/workflows/docs-vnext-source-navigation-required.yml)
                 relevant=true
                 break
                 ;;
             esac
-          done < <(git diff --no-renames --name-only -z "$BASE_SHA" "$HEAD_SHA" --)
+          done < "$changed_paths"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
 
       - name: No relevant source navigation changes

--- a/tests/test_validate_docs_vnext_navigation.py
+++ b/tests/test_validate_docs_vnext_navigation.py
@@ -6,10 +6,14 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from validate_docs_vnext_navigation import main, validate_navigation  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "docs-vnext-source-navigation.yml"
 
 
 def _write_page(docs_dir: Path, route: str, body: str = "Useful documentation.\n") -> None:
@@ -321,3 +325,39 @@ def test_missing_navigation_pages_do_not_cascade_into_link_failures(tmp_path: Pa
     result = validate_navigation(docs_dir, navigation_path)
 
     assert result["diagnosticSummary"]["counts"] == {"missing_source_page": 1}
+
+
+def test_workflow_creates_stable_check_for_every_pull_request() -> None:
+    workflow = yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+    assert workflow["on"]["pull_request"] == {}
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["jobs"]["validate-source-navigation"]["name"] == "Validate source navigation"
+
+
+def test_workflow_noops_irrelevant_changes_and_gates_relevant_work() -> None:
+    workflow = yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["validate-source-navigation"]["steps"]
+    by_name = {step["name"]: step for step in steps if "name" in step}
+
+    detector = by_name["Detect relevant changes"]
+    assert detector["id"] == "changes"
+    assert "git diff --no-renames --name-only -z" in detector["run"]
+    for relevant_path in (
+        "docs-vnext/*",
+        "scripts/validate_docs_vnext_navigation.py",
+        "tests/test_validate_docs_vnext_navigation.py",
+        ".github/workflows/docs-vnext-source-navigation.yml",
+    ):
+        assert relevant_path in detector["run"]
+
+    assert by_name["No relevant source navigation changes"]["if"] == "steps.changes.outputs.relevant != 'true'"
+    for step_name in (
+        "Initialize failure inventory",
+        "Install test dependencies",
+        "Run navigation validator tests",
+        "Prepare baseline validation inputs",
+        "Validate docs-vnext source navigation",
+    ):
+        assert by_name[step_name]["if"] == "steps.changes.outputs.relevant == 'true'"
+    assert by_name["Upload route inventory"]["if"] == "always() && steps.changes.outputs.relevant == 'true'"

--- a/tests/test_validate_docs_vnext_navigation.py
+++ b/tests/test_validate_docs_vnext_navigation.py
@@ -14,6 +14,7 @@ from validate_docs_vnext_navigation import main, validate_navigation  # noqa: E4
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "docs-vnext-source-navigation.yml"
+REQUIRED_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "docs-vnext-source-navigation-required.yml"
 
 
 def _write_page(docs_dir: Path, route: str, body: str = "Useful documentation.\n") -> None:
@@ -332,7 +333,7 @@ def test_workflow_creates_stable_check_for_every_pull_request() -> None:
 
     assert workflow["on"]["pull_request"] == {}
     assert workflow["permissions"] == {"contents": "read"}
-    assert workflow["jobs"]["validate-source-navigation"]["name"] == "Validate source navigation"
+    assert workflow["jobs"]["validate-source-navigation"]["name"] == "Run source navigation validation"
 
 
 def test_workflow_noops_irrelevant_changes_and_gates_relevant_work() -> None:
@@ -342,12 +343,17 @@ def test_workflow_noops_irrelevant_changes_and_gates_relevant_work() -> None:
 
     detector = by_name["Detect relevant changes"]
     assert detector["id"] == "changes"
-    assert "git diff --no-renames --name-only -z" in detector["run"]
+    assert 'if ! merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"' in detector["run"]
+    assert 'if ! git diff --no-renames --name-only -z "$merge_base" "$HEAD_SHA"' in detector["run"]
+    assert '> "$changed_paths"' in detector["run"]
+    assert 'done < "$changed_paths"' in detector["run"]
+    assert "< <(" not in detector["run"]
     for relevant_path in (
         "docs-vnext/*",
         "scripts/validate_docs_vnext_navigation.py",
         "tests/test_validate_docs_vnext_navigation.py",
         ".github/workflows/docs-vnext-source-navigation.yml",
+        ".github/workflows/docs-vnext-source-navigation-required.yml",
     ):
         assert relevant_path in detector["run"]
 
@@ -361,3 +367,36 @@ def test_workflow_noops_irrelevant_changes_and_gates_relevant_work() -> None:
     ):
         assert by_name[step_name]["if"] == "steps.changes.outputs.relevant == 'true'"
     assert by_name["Upload route inventory"]["if"] == "always() && steps.changes.outputs.relevant == 'true'"
+
+
+def test_workflow_fails_closed_when_path_diff_generation_fails() -> None:
+    workflow = yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["validate-source-navigation"]["steps"]
+    detector = next(step for step in steps if step.get("name") == "Detect relevant changes")
+
+    assert "Unable to determine the pull request merge base." in detector["run"]
+    assert "Unable to enumerate pull request paths." in detector["run"]
+    assert detector["run"].count("exit 1") >= 2
+
+
+def test_required_context_is_trusted_read_only_and_skip_ci_resistant() -> None:
+    workflow = yaml.load(REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    sentinel = workflow["jobs"]["require-source-navigation"]
+
+    assert workflow["on"]["pull_request_target"]["types"] == [
+        "opened",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+    ]
+    assert workflow["permissions"] == {"actions": "read", "contents": "read"}
+    assert sentinel["name"] == "Validate source navigation"
+    assert all("uses" not in step for step in sentinel["steps"])
+    script = sentinel["steps"][0]["run"]
+    assert "event=pull_request" in script
+    assert "head_sha=$HEAD_SHA" in script
+    assert ".pull_requests[]?" in script
+    assert ".number == $PR_NUMBER" in script
+    assert "No completed source navigation validation run was found" in script
+    assert "Remove any [skip ci] directive or resolve merge conflicts" in script
+    assert script.count("exit 1") >= 3


### PR DESCRIPTION
## Summary

Final #629 enforcement correction:

- run the implementation workflow on every `pull_request`, using explicit merge-base semantics and a checked NUL-delimited diff file
- fail closed if merge-base or changed-path generation fails
- return a successful deterministic no-op for irrelevant changes; preserve full tests, baseline/delta validation, bounded failure inventory, and artifact upload for relevant changes
- add a separate trusted `pull_request_target` sentinel that is not suppressed by `[skip ci]`, never checks out or executes PR code, uses only `actions: read` and `contents: read`, and fails closed unless the implementation run for the same head SHA **and PR number** succeeds
- reserve stable required context `Validate source navigation` for the trusted sentinel; implementation context is `Run source navigation validation`

## Validation

- `python -m pytest tests/test_validate_docs_vnext_navigation.py -q` (24 passed)
- `python -m ruff check tests/test_validate_docs_vnext_navigation.py`
- `git diff --check`
- fresh implementation run `30390209096` passed with full validation and artifact upload
- exact sentinel API query against this PR/head resolves the successful implementation run
- final independent staged-diff review found no significant issues

## Platform evidence boundary

GitHub only loads `pull_request_target` workflow definitions from the default branch. Therefore the trusted sentinel cannot produce live check evidence on the PR that first introduces it. After merge, a genuinely new irrelevant PR and a `[skip ci]` proof PR must verify respectively that the sentinel accepts the successful no-op implementation run and explicitly fails when the implementation run is suppressed. Do not configure the required context until those post-merge checks complete.

Related to #629, #638, and #645. Do not merge until independent review is complete.