### PR TITLE
Prove irrelevant navigation check no-op

### DIFF
--- a/.github/issue-629-noop-proof.txt
+++ b/.github/issue-629-noop-proof.txt
@@ -1,0 +1,1 @@
+Temporary irrelevant-path change used to verify the stable pull-request check.


### PR DESCRIPTION
Disposable stacked validation PR for #647. Changes one irrelevant path to prove the stable \Validate source navigation\ context succeeds while full validation and artifact steps remain skipped. This PR must not be merged and will be closed after evidence is captured.