### PR TITLE
Prove hardened irrelevant navigation no-op

### DIFF
--- a/.github/issue-629-noop-proof-v2.txt
+++ b/.github/issue-629-noop-proof-v2.txt
@@ -1,0 +1,1 @@
+Temporary irrelevant-path change used to verify the hardened pull-request classifier.


### PR DESCRIPTION
Disposable stacked validation PR for #647 at head 9113d91. Changes one irrelevant path to prove the merge-base classifier emits a successful implementation no-op. Must not merge; close after evidence capture.