### PR TITLE
Retain sanitized evaluation row diagnostics

### DIFF
--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -10,6 +10,7 @@ Reads raw evaluation results and produces scored results with metrics:
 
 import argparse
 import json
+import math
 import re
 import sys
 from collections import defaultdict
@@ -21,6 +22,7 @@ from run_docs_eval import (
     MAX_DIAGNOSTIC_EVENTS_CHARS,
     MAX_STDERR_EXCERPT,
     MAX_STDOUT_EXCERPT,
+    MAX_USAGE_METRIC,
     MCP_SERVERS,
     _is_search_tool,
     _sanitize_diagnostic_value,
@@ -187,14 +189,28 @@ def _sanitize_invalid_result_fields(result: dict) -> dict:
             if isinstance(rubric, dict)
             else _sanitize_diagnostic_value(rubric)
         )
-    for field in ("premium_requests", "api_duration_ms", "session_duration_ms"):
+    for field in ("premium_requests", "api_duration_ms", "session_duration_ms", "response_time_seconds"):
         value = sanitized.get(field)
         if value is not None and (
             not isinstance(value, (int, float))
             or isinstance(value, bool)
+            or (isinstance(value, float) and not math.isfinite(value))
             or value < 0
+            or value > MAX_USAGE_METRIC
         ):
             sanitized[field] = None
+    for field in ("turns", "tool_calls", "tool_errors", "output_tokens"):
+        value = sanitized.get(field)
+        if type(value) is not int or value < 0 or value > MAX_USAGE_METRIC:
+            sanitized[field] = None
+    if (
+        type(sanitized.get("source_config_count")) is not int
+        or sanitized["source_config_count"] < 0
+        or sanitized["source_config_count"] > MAX_USAGE_METRIC
+    ):
+        sanitized["source_config_count"] = 0
+    if type(sanitized.get("exit_code")) is not int:
+        sanitized["exit_code"] = -1
     if "diagnostics" in sanitized:
         sanitized["diagnostics"] = _canonical_diagnostics(sanitized["diagnostics"])
     return sanitized
@@ -248,7 +264,7 @@ def _sanitize_metadata(metadata: object) -> dict:
     }
     for field in METADATA_COUNT_FIELDS:
         value = metadata.get(field)
-        if type(value) is int and value >= 0:
+        if type(value) is int and 0 <= value <= MAX_USAGE_METRIC:
             sanitized[field] = value
     for field in METADATA_LIST_FIELDS:
         value = metadata.get(field)
@@ -314,8 +330,12 @@ def validate_row_schema(result: object) -> list[str]:
         result["selected_source_config"]
     ) != SOURCE_CONFIG_FIELDS:
         errors.append("selected_source_config must contain exactly the required fields")
-    if "source_config_count" in result and type(result["source_config_count"]) is not int:
-        errors.append("source_config_count must be an integer")
+    if "source_config_count" in result and (
+        type(result["source_config_count"]) is not int
+        or result["source_config_count"] < 0
+        or result["source_config_count"] > MAX_USAGE_METRIC
+    ):
+        errors.append("source_config_count must be a bounded non-negative integer")
     for field in ("observed_tools", "successful_tools"):
         value = result.get(field)
         if field in result and (
@@ -398,17 +418,28 @@ def validate_row_schema(result: object) -> list[str]:
             errors.append("stderr must be a string")
         elif stderr != _sanitize_text(stderr, max_chars=MAX_STDERR_EXCERPT)[0]:
             errors.append("stderr must equal its bounded sanitized canonical form")
-    for field in ("exit_code", "tool_errors"):
-        if field in result and type(result[field]) is not int:
-            errors.append(f"{field} must be an integer")
+    if "exit_code" in result and type(result["exit_code"]) is not int:
+        errors.append("exit_code must be an integer")
+    if "tool_errors" in result and (
+        type(result["tool_errors"]) is not int
+        or result["tool_errors"] < 0
+        or result["tool_errors"] > MAX_USAGE_METRIC
+    ):
+        errors.append("tool_errors must be a bounded non-negative integer")
     for field in ("turns", "tool_calls", "output_tokens"):
-        if field in result and (type(result[field]) is not int or result[field] < 0):
+        if field in result and (
+            type(result[field]) is not int
+            or result[field] < 0
+            or result[field] > MAX_USAGE_METRIC
+        ):
             errors.append(f"{field} must be a non-negative integer")
     response_time = result.get("response_time_seconds")
     if "response_time_seconds" in result and (
         not isinstance(response_time, (int, float))
         or isinstance(response_time, bool)
+        or (isinstance(response_time, float) and not math.isfinite(response_time))
         or response_time < 0
+        or response_time > MAX_USAGE_METRIC
     ):
         errors.append("response_time_seconds must be a non-negative number")
     rubric = result.get("rubric")
@@ -438,7 +469,9 @@ def validate_row_schema(result: object) -> list[str]:
         if value is not None and (
             not isinstance(value, (int, float))
             or isinstance(value, bool)
+            or (isinstance(value, float) and not math.isfinite(value))
             or value < 0
+            or value > MAX_USAGE_METRIC
         ):
             errors.append(f"{field} must be a non-negative number or null")
     return errors
@@ -520,27 +553,36 @@ def score_result(result: object) -> dict:
     # aggregation can distinguish "known zero" from "not captured".
     operational = {
         "passed": result.get("passed") if type(result.get("passed")) is bool else None,
-        "turns": result.get("turns") if type(result.get("turns")) is int and result.get("turns") >= 0 else None,
+        "turns": (
+            result.get("turns")
+            if type(result.get("turns")) is int and 0 <= result.get("turns") <= MAX_USAGE_METRIC
+            else None
+        ),
         "tool_calls": (
             result.get("tool_calls")
-            if type(result.get("tool_calls")) is int and result.get("tool_calls") >= 0
+            if type(result.get("tool_calls")) is int and 0 <= result.get("tool_calls") <= MAX_USAGE_METRIC
             else None
         ),
         "tool_errors": (
             result.get("tool_errors")
-            if type(result.get("tool_errors")) is int and result.get("tool_errors") >= 0
+            if type(result.get("tool_errors")) is int and 0 <= result.get("tool_errors") <= MAX_USAGE_METRIC
             else None
         ),
         "output_tokens": (
             result.get("output_tokens")
-            if type(result.get("output_tokens")) is int and result.get("output_tokens") >= 0
+            if type(result.get("output_tokens")) is int and 0 <= result.get("output_tokens") <= MAX_USAGE_METRIC
             else None
         ),
         "response_time_seconds": (
             result.get("response_time_seconds")
             if isinstance(result.get("response_time_seconds"), (int, float))
             and not isinstance(result.get("response_time_seconds"), bool)
+            and (
+                not isinstance(result.get("response_time_seconds"), float)
+                or math.isfinite(result.get("response_time_seconds"))
+            )
             and result.get("response_time_seconds") >= 0
+            and result.get("response_time_seconds") <= MAX_USAGE_METRIC
             else None
         ),
     }
@@ -674,6 +716,7 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
         "tool_calls": [],
         "tool_errors": 0,
         "tool_errors_known": False,
+        "tool_errors_overflow": False,
         "output_tokens": [],
         "response_time_seconds": [],
         "status_counts": defaultdict(int),
@@ -703,8 +746,14 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
         if ops.get("tool_calls") is not None:
             agg["tool_calls"].append(ops["tool_calls"])
         if ops.get("tool_errors") is not None:
-            agg["tool_errors_known"] = True
-            agg["tool_errors"] += ops["tool_errors"]
+            if not agg["tool_errors_overflow"]:
+                agg["tool_errors_known"] = True
+                if agg["tool_errors"] + ops["tool_errors"] <= MAX_USAGE_METRIC:
+                    agg["tool_errors"] += ops["tool_errors"]
+                else:
+                    agg["tool_errors_known"] = False
+                    agg["tool_errors_overflow"] = True
+                    agg["tool_errors"] = 0
         if ops.get("output_tokens") is not None:
             agg["output_tokens"].append(ops["output_tokens"])
         if ops.get("response_time_seconds") is not None:
@@ -747,6 +796,7 @@ def aggregate_scores(scored_results: list[dict]) -> dict:
             "avg_turns": avg(agg["turns"]) if agg["turns"] else None,
             "avg_tool_calls": avg(agg["tool_calls"]) if agg["tool_calls"] else None,
             "total_tool_errors": agg["tool_errors"] if agg["tool_errors_known"] else None,
+            "tool_errors_overflow": agg["tool_errors_overflow"],
             "avg_output_tokens": avg(agg["output_tokens"]) if agg["output_tokens"] else None,
             "avg_response_time_seconds": (
                 avg(agg["response_time_seconds"]) if agg["response_time_seconds"] else None
@@ -1025,7 +1075,7 @@ def main():
         output_path = Path(args.input[0]).parent / f"scored-{run_id}.json"
 
     with open(output_path, "w") as f:
-        json.dump(output_data, f, indent=2)
+        json.dump(output_data, f, indent=2, allow_nan=False)
 
     print(f"Scored results saved to {output_path}")
     if not publication["allowed"]:

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -40,6 +40,8 @@ REQUIRED_ROW_FIELDS = (
     "server",
     "model",
     "category",
+    "question",
+    "rubric",
     "response",
     "response_present",
     "status",
@@ -492,8 +494,12 @@ def validate_row_schema(result: object) -> list[str]:
                 errors.append("rubric must contain exactly the required fields")
             for field in ("must_mention", "quality_criteria", "expected_docs"):
                 value = rubric.get(field, [])
-                if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-                    errors.append(f"rubric.{field} must be a list of strings")
+                if (
+                    not isinstance(value, list)
+                    or not value
+                    or not all(isinstance(item, str) and item.strip() for item in value)
+                ):
+                    errors.append(f"rubric.{field} must be a non-empty list of non-empty strings")
                 elif any(item != _sanitize_text(item)[0] for item in value):
                     errors.append(f"rubric.{field} must contain sanitized bounded strings")
     question = result.get("question")
@@ -516,6 +522,47 @@ def validate_row_schema(result: object) -> list[str]:
         ):
             errors.append(f"{field} must be a non-negative number or null")
     return errors
+
+
+def validate_trusted_scenarios(scenarios: object) -> dict[str, dict]:
+    """Validate and index complete trusted scenario definitions."""
+    if not isinstance(scenarios, list) or not scenarios:
+        raise ValueError("trusted scenarios must be a non-empty JSON array")
+    trusted: dict[str, dict] = {}
+    for index, scenario in enumerate(scenarios):
+        if not isinstance(scenario, dict):
+            raise ValueError(f"trusted scenario {index} must be an object")
+        scenario_id = scenario.get("id")
+        question = scenario.get("question")
+        category = scenario.get("category")
+        rubric = scenario.get("rubric")
+        if not isinstance(scenario_id, str) or not scenario_id.strip():
+            raise ValueError(f"trusted scenario {index} must have a non-empty id")
+        if scenario_id in trusted:
+            raise ValueError(f"duplicate trusted scenario id: {scenario_id}")
+        if not isinstance(question, str) or not question.strip():
+            raise ValueError(f"trusted scenario {scenario_id} must have a non-empty question")
+        if not isinstance(category, str) or not category.strip():
+            raise ValueError(f"trusted scenario {scenario_id} must have a non-empty category")
+        if not isinstance(rubric, dict) or set(rubric) != RUBRIC_FIELDS:
+            raise ValueError(f"trusted scenario {scenario_id} must have a complete rubric")
+        for field in RUBRIC_FIELDS:
+            value = rubric.get(field)
+            if (
+                not isinstance(value, list)
+                or not value
+                or not all(isinstance(item, str) and item.strip() for item in value)
+            ):
+                raise ValueError(
+                    f"trusted scenario {scenario_id} rubric.{field} must be a non-empty list"
+                )
+        trusted[scenario_id] = {
+            "id": scenario_id,
+            "question": question,
+            "category": category,
+            "rubric": rubric,
+        }
+    return trusted
 
 
 def score_completeness(response: str, must_mention: list[str]) -> float:
@@ -575,11 +622,22 @@ def score_doc_retrieval(response: str, expected_docs: list[str]) -> float:
     return hits / len(expected_docs)
 
 
-def score_result(result: object) -> dict:
+def score_result(result: object, trusted_scenarios: dict[str, dict]) -> dict:
     """Score a single evaluation result."""
     schema_errors = validate_row_schema(result)
     if not isinstance(result, dict):
         result = {"raw_row": result}
+    scenario_id = result.get("scenario_id")
+    trusted = trusted_scenarios.get(scenario_id) if isinstance(scenario_id, str) else None
+    if trusted is None:
+        schema_errors.append("scenario_id is not present in trusted scenarios")
+    else:
+        if result.get("question") != trusted["question"]:
+            schema_errors.append("question does not match trusted scenario")
+        if result.get("category") != trusted["category"]:
+            schema_errors.append("category does not match trusted scenario")
+        if result.get("rubric") != trusted["rubric"]:
+            schema_errors.append("rubric does not match trusted scenario")
 
     response = result.get("response", "")
     if not isinstance(response, str):
@@ -1092,11 +1150,13 @@ def main():
 
     print(f"Scoring {len(all_results)} evaluation results from {len(args.input)} file(s)...")
 
-    scored_results = [score_result(r) for r in all_results]
     scenario_ids = None
+    trusted_scenarios = None
     if args.required_scenarios:
         with open(args.required_scenarios) as f:
-            scenario_ids = [scenario["id"] for scenario in json.load(f)]
+            trusted_scenarios = validate_trusted_scenarios(json.load(f))
+            scenario_ids = list(trusted_scenarios)
+    scored_results = [score_result(r, trusted_scenarios) for r in all_results]
     publication = validate_required_matrix(
         scored_results,
         scenario_ids=scenario_ids,

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -835,6 +835,13 @@ def validate_required_matrix(
         models is not None,
     )
     partial_required_selectors = not all(selector_presence)
+    empty_required_selectors = []
+    if scenario_ids is not None and not scenario_ids:
+        empty_required_selectors.append("scenarios")
+    if servers is not None and not servers:
+        empty_required_selectors.append("servers")
+    if models is not None and not models:
+        empty_required_selectors.append("models")
     rows_by_key: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
     malformed_rows: list[dict] = []
     for index, row in enumerate(scored_results):
@@ -923,6 +930,7 @@ def validate_required_matrix(
         and not unsupported_azure_required_servers
         and not azure_required_outside_matrix
         and not partial_required_selectors
+        and not empty_required_selectors
     )
     failure_reasons = []
     if invalid_rows:
@@ -949,6 +957,11 @@ def validate_required_matrix(
         failure_reasons.append(
             "required scenario, server, and model selectors must be supplied together"
         )
+    if empty_required_selectors:
+        failure_reasons.append(
+            "required selector collection(s) must not be empty: "
+            + ", ".join(empty_required_selectors)
+        )
 
     return {
         "allowed": allowed,
@@ -965,6 +978,7 @@ def validate_required_matrix(
         "unsupported_azure_required_servers": unsupported_azure_required_servers,
         "azure_required_outside_matrix": azure_required_outside_matrix,
         "partial_required_selectors": partial_required_selectors,
+        "empty_required_selectors": empty_required_selectors,
     }
 
 

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -14,7 +14,7 @@ import math
 import re
 import sys
 from collections import defaultdict
-from itertools import product
+from itertools import islice, product
 from pathlib import Path
 
 from run_docs_eval import (
@@ -110,10 +110,19 @@ def _identifier_errors(value: object, field: str) -> list[str]:
     return []
 
 
-def _diagnostic_identifier_errors(value: object, path: str = "diagnostics") -> list[str]:
+def _diagnostic_identifier_errors(
+    value: object,
+    path: str = "diagnostics",
+    *,
+    depth: int = 0,
+) -> list[str]:
     errors = []
+    if depth >= 4 and isinstance(value, (dict, list)):
+        return [f"{path} exceeds maximum diagnostic nesting depth"]
     if isinstance(value, dict):
-        for key, child in value.items():
+        if len(value) > 20:
+            errors.append(f"{path} contains more than 20 fields")
+        for key, child in islice(value.items(), 20):
             child_path = f"{path}.{key}"
             if key in {
                 "toolName",
@@ -125,10 +134,14 @@ def _diagnostic_identifier_errors(value: object, path: str = "diagnostics") -> l
                 "name",
             }:
                 errors.extend(_identifier_errors(child, child_path))
-            errors.extend(_diagnostic_identifier_errors(child, child_path))
+            errors.extend(_diagnostic_identifier_errors(child, child_path, depth=depth + 1))
     elif isinstance(value, list):
-        for index, child in enumerate(value):
-            errors.extend(_diagnostic_identifier_errors(child, f"{path}[{index}]"))
+        if len(value) > 20:
+            errors.append(f"{path} contains more than 20 items")
+        for index, child in enumerate(value[:20]):
+            errors.extend(
+                _diagnostic_identifier_errors(child, f"{path}[{index}]", depth=depth + 1)
+            )
     return errors
 
 
@@ -375,18 +388,30 @@ def validate_row_schema(result: object) -> list[str]:
     elif set(diagnostics) != required_diagnostic_fields:
         errors.append("diagnostics must contain exactly the required bounded-output fields")
     else:
-        errors.extend(_diagnostic_identifier_errors(diagnostics))
+        diagnostic_identifier_errors = _diagnostic_identifier_errors(diagnostics)
+        errors.extend(diagnostic_identifier_errors)
+        excessive_depth = any(
+            "exceeds maximum diagnostic nesting depth" in error
+            for error in diagnostic_identifier_errors
+        )
         events = diagnostics["events"]
-        if events != _sanitize_diagnostic_value(events):
-            errors.append("diagnostics.events must equal its sanitized canonical form")
+        if not excessive_depth:
+            try:
+                canonical_events = _sanitize_diagnostic_value(events)
+            except RecursionError:
+                excessive_depth = True
+                errors.append("diagnostics.events exceeds maximum diagnostic nesting depth")
+            else:
+                if events != canonical_events:
+                    errors.append("diagnostics.events must equal its sanitized canonical form")
         if not isinstance(events, list):
             errors.append("diagnostics.events must be a list")
         elif len(events) > MAX_DIAGNOSTIC_EVENTS:
             errors.append(f"diagnostics.events must contain at most {MAX_DIAGNOSTIC_EVENTS} entries")
-        else:
+        elif not excessive_depth:
             try:
                 serialized_event_chars = serialized_diagnostic_events_size(events)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, RecursionError):
                 errors.append("diagnostics.events must contain JSON-serializable values")
             else:
                 if serialized_event_chars > MAX_DIAGNOSTIC_EVENTS_CHARS:

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -25,6 +25,7 @@ from run_docs_eval import (
     _is_search_tool,
     _sanitize_diagnostic_value,
     _sanitize_identifier,
+    _sanitize_response_text,
     _sanitize_text,
     _source_for_tool,
     serialized_diagnostic_events_size,
@@ -232,6 +233,8 @@ def _project_result_fields(result: dict) -> dict:
         }
     if "diagnostics" in projected:
         projected["diagnostics"] = _canonical_diagnostics(projected["diagnostics"])
+    if isinstance(projected.get("response"), str):
+        projected["response"] = _sanitize_response_text(projected["response"])
     return projected
 
 
@@ -268,6 +271,13 @@ def validate_row_schema(result: object) -> list[str]:
             errors.append(f"{field} must be a string")
     if isinstance(result.get("server"), str) and result["server"] not in MCP_SERVERS:
         errors.append(f"unknown server: {_sanitize_identifier(result['server'])}")
+    if isinstance(result.get("server"), str) and result["server"] in MCP_SERVERS:
+        supports_azure = bool(MCP_SERVERS[result["server"]]["config"].get("supports_azure"))
+        if not supports_azure and (
+            result.get("azure_required") is True
+            or result.get("azure_live_query_proven") is True
+        ):
+            errors.append(f"server does not support Azure-required evidence: {result['server']}")
     for field in ("scenario_id", "server", "model", "category", "selected_source"):
         errors.extend(_identifier_errors(result.get(field), field))
     if "status" in result and (
@@ -275,6 +285,9 @@ def validate_row_schema(result: object) -> list[str]:
         or result["status"] not in {"success", "invalid", "error", "timeout"}
     ):
         errors.append("status must be success, invalid, error, or timeout")
+    response = result.get("response")
+    if isinstance(response, str) and response != _sanitize_response_text(response):
+        errors.append("response must equal its bounded sanitized canonical form")
     status = result.get("status")
     if isinstance(status, str) and status in {"invalid", "error", "timeout"} and (
         result.get("response") != "" or result.get("response_present") is not False
@@ -766,6 +779,12 @@ def validate_required_matrix(
     servers = [_sanitize_identifier(value) for value in servers] if servers is not None else None
     models = [_sanitize_identifier(value) for value in models] if models is not None else None
     azure_required_servers = {_sanitize_identifier(value) for value in azure_required_servers}
+    selector_presence = (
+        scenario_ids is not None,
+        servers is not None,
+        models is not None,
+    )
+    partial_required_selectors = not all(selector_presence)
     rows_by_key: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
     malformed_rows: list[dict] = []
     for index, row in enumerate(scored_results):
@@ -787,6 +806,15 @@ def validate_required_matrix(
     unknown_required_servers = sorted(
         _sanitize_identifier(server)
         for server in (set(servers or []) | azure_required_servers) - set(MCP_SERVERS)
+    )
+    unsupported_azure_required_servers = sorted(
+        server
+        for server in azure_required_servers
+        if server in MCP_SERVERS and not MCP_SERVERS[server]["config"].get("supports_azure")
+    )
+    effective_matrix_servers = set(servers) if servers is not None else {key[1] for key in rows_by_key}
+    azure_required_outside_matrix = sorted(
+        azure_required_servers - effective_matrix_servers
     )
 
     for key, rows in rows_by_key.items():
@@ -837,7 +865,15 @@ def validate_required_matrix(
     unexpected_rows = sorted(" / ".join(key) for key in set(rows_by_key) - expected_keys)
     invalid_rows.extend(malformed_rows)
     status_counts["invalid"] += len(malformed_rows)
-    allowed = not invalid_rows and not duplicate_rows and not unexpected_rows and not unknown_required_servers
+    allowed = (
+        not invalid_rows
+        and not duplicate_rows
+        and not unexpected_rows
+        and not unknown_required_servers
+        and not unsupported_azure_required_servers
+        and not azure_required_outside_matrix
+        and not partial_required_selectors
+    )
     failure_reasons = []
     if invalid_rows:
         failure_reasons.append(f"{len(invalid_rows)} required row(s) are invalid or missing")
@@ -848,6 +884,20 @@ def validate_required_matrix(
     if unknown_required_servers:
         failure_reasons.append(
             "unknown required server(s): " + ", ".join(_sanitize_identifier(server) for server in unknown_required_servers)
+        )
+    if unsupported_azure_required_servers:
+        failure_reasons.append(
+            "Azure-required server(s) do not support Azure evidence: "
+            + ", ".join(unsupported_azure_required_servers)
+        )
+    if azure_required_outside_matrix:
+        failure_reasons.append(
+            "Azure-required server(s) are outside the required server matrix: "
+            + ", ".join(azure_required_outside_matrix)
+        )
+    if partial_required_selectors:
+        failure_reasons.append(
+            "required scenario, server, and model selectors must be supplied together"
         )
 
     return {
@@ -862,6 +912,9 @@ def validate_required_matrix(
         "duplicate_rows": duplicate_rows,
         "unexpected_rows": unexpected_rows,
         "unknown_required_servers": unknown_required_servers,
+        "unsupported_azure_required_servers": unsupported_azure_required_servers,
+        "azure_required_outside_matrix": azure_required_outside_matrix,
+        "partial_required_selectors": partial_required_selectors,
     }
 
 

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -538,18 +538,20 @@ def validate_trusted_scenarios(scenarios: object) -> dict[str, dict]:
         rubric = scenario.get("rubric")
         if not isinstance(scenario_id, str) or not scenario_id.strip():
             raise ValueError(f"trusted scenario {index} must have a non-empty id")
-        if scenario_id != _sanitize_identifier(scenario_id):
+        safe_scenario_id = _sanitize_identifier(scenario_id)
+        if scenario_id != safe_scenario_id:
             raise ValueError(
-                f"trusted scenario id must equal its bounded sanitized canonical form: {scenario_id}"
+                "trusted scenario id must equal its bounded sanitized canonical form: "
+                f"{safe_scenario_id}"
             )
         if scenario_id in trusted:
-            raise ValueError(f"duplicate trusted scenario id: {scenario_id}")
+            raise ValueError(f"duplicate trusted scenario id: {safe_scenario_id}")
         if not isinstance(question, str) or not question.strip():
-            raise ValueError(f"trusted scenario {scenario_id} must have a non-empty question")
+            raise ValueError(f"trusted scenario {safe_scenario_id} must have a non-empty question")
         if not isinstance(category, str) or not category.strip():
-            raise ValueError(f"trusted scenario {scenario_id} must have a non-empty category")
+            raise ValueError(f"trusted scenario {safe_scenario_id} must have a non-empty category")
         if not isinstance(rubric, dict) or set(rubric) != RUBRIC_FIELDS:
-            raise ValueError(f"trusted scenario {scenario_id} must have a complete rubric")
+            raise ValueError(f"trusted scenario {safe_scenario_id} must have a complete rubric")
         for field in RUBRIC_FIELDS:
             value = rubric.get(field)
             if (
@@ -558,7 +560,7 @@ def validate_trusted_scenarios(scenarios: object) -> dict[str, dict]:
                 or not all(isinstance(item, str) and item.strip() for item in value)
             ):
                 raise ValueError(
-                    f"trusted scenario {scenario_id} rubric.{field} must be a non-empty list"
+                    f"trusted scenario {safe_scenario_id} rubric.{field} must be a non-empty list"
                 )
         trusted[scenario_id] = {
             "id": scenario_id,

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -55,6 +55,29 @@ REQUIRED_ROW_FIELDS = (
 )
 
 
+def _invalid_scores() -> dict:
+    return {
+        "completeness": 0.0,
+        "quality": 0.0,
+        "doc_retrieval": 0.0,
+        "response_length": 0,
+        "has_response": False,
+    }
+
+
+def _invalidate_scored_row(row: dict, failure_reason: str) -> None:
+    row["response"] = ""
+    row["response_present"] = False
+    row["status"] = "invalid"
+    row["passed"] = False
+    row["row_valid"] = False
+    row["scores"] = _invalid_scores()
+    if isinstance(row.get("operational"), dict):
+        row["operational"]["passed"] = False
+    if not row.get("failure_reason"):
+        row["failure_reason"] = failure_reason
+
+
 def validate_row_schema(result: object) -> list[str]:
     """Return schema errors without throwing so malformed rows remain diagnostic."""
     if not isinstance(result, dict):
@@ -273,6 +296,7 @@ def score_result(result: object) -> dict:
         ),
     }
     if schema_errors:
+        operational["passed"] = False
         existing_failure = result.get("failure_reason")
         schema_failure = "row_schema_invalid: " + "; ".join(schema_errors)
         failure_reason = f"{existing_failure}; {schema_failure}" if existing_failure else schema_failure
@@ -285,13 +309,7 @@ def score_result(result: object) -> dict:
             "source_validated": False,
             "failure_reason": failure_reason,
             "row_valid": False,
-            "scores": {
-                "completeness": 0.0,
-                "quality": 0.0,
-                "doc_retrieval": 0.0,
-                "response_length": len(response),
-                "has_response": bool(response),
-            },
+            "scores": _invalid_scores(),
             "operational": operational,
         }
 
@@ -349,18 +367,17 @@ def score_result(result: object) -> dict:
     )
 
     if not row_valid:
+        operational["passed"] = False
+        normalized_status = status if status in {"error", "timeout"} else "invalid"
         return {
             **result,
             "response": "",
             "response_present": False,
+            "status": normalized_status,
+            "passed": False,
+            "failure_reason": result.get("failure_reason") or "scoring_evidence_invalid",
             "row_valid": False,
-            "scores": {
-                "completeness": 0.0,
-                "quality": 0.0,
-                "doc_retrieval": 0.0,
-                "response_length": len(response),
-                "has_response": bool(response),
-            },
+            "scores": _invalid_scores(),
             "operational": operational,
         }
 
@@ -526,6 +543,22 @@ def validate_required_matrix(
     else:
         expected_keys = set(rows_by_key)
 
+    for key, rows in rows_by_key.items():
+        if len(rows) > 1:
+            for row in rows:
+                _invalidate_scored_row(row, "duplicate_required_row")
+        if key not in expected_keys:
+            for row in rows:
+                _invalidate_scored_row(row, "unexpected_matrix_row")
+        for row in rows:
+            if row["server"] in azure_required_servers and row.get("row_valid") is True and not (
+                row.get("azure_required") is True
+                and row.get("azure_live_query_proven") is True
+                and all(isinstance(tool_name, str) for tool_name in row.get("successful_tools", []))
+                and any(_is_search_tool(tool_name) for tool_name in row.get("successful_tools", []))
+            ):
+                _invalidate_scored_row(row, "azure_required_evidence_missing")
+
     status_counts = {"success": 0, "invalid": 0, "error": 0, "timeout": 0, "missing": 0}
     response_counts = {"present": 0, "missing": 0}
     invalid_rows: list[dict] = []
@@ -543,14 +576,6 @@ def validate_required_matrix(
             duplicate_rows.append(row_id)
 
         row = rows[0]
-        if row["server"] in azure_required_servers and not (
-            row.get("azure_required") is True
-            and row.get("azure_live_query_proven") is True
-            and any(_is_search_tool(tool_name) for tool_name in row.get("successful_tools", []))
-        ):
-            row["row_valid"] = False
-            if not row.get("failure_reason"):
-                row["failure_reason"] = "azure_required_evidence_missing"
         response_counts["present" if row.get("response_present", bool(row.get("response"))) else "missing"] += 1
         status = row.get("status", "invalid")
         outcome = status if status in {"error", "timeout"} else ("success" if row.get("row_valid") else "invalid")
@@ -660,7 +685,6 @@ def main():
     print(f"Scoring {len(all_results)} evaluation results from {len(args.input)} file(s)...")
 
     scored_results = [score_result(r) for r in all_results]
-    aggregates = aggregate_scores(scored_results)
     scenario_ids = None
     if args.required_scenarios:
         with open(args.required_scenarios) as f:
@@ -672,6 +696,7 @@ def main():
         models=args.required_models,
         azure_required_servers=set(args.azure_required_servers or []),
     )
+    aggregates = aggregate_scores(scored_results)
     aggregates["denominators"] = {
         "required_rows": publication["required_rows"],
         "observed_rows": publication["observed_rows"],

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -16,7 +16,15 @@ from collections import defaultdict
 from itertools import product
 from pathlib import Path
 
-from run_docs_eval import MCP_SERVERS, _is_search_tool, _source_for_tool
+from run_docs_eval import (
+    MAX_DIAGNOSTIC_EVENTS,
+    MAX_DIAGNOSTIC_EVENTS_CHARS,
+    MAX_STDERR_EXCERPT,
+    MAX_STDOUT_EXCERPT,
+    MCP_SERVERS,
+    _is_search_tool,
+    _source_for_tool,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 RESULTS_DIR = PROJECT_ROOT / "tests" / "eval_results"
@@ -39,6 +47,7 @@ REQUIRED_ROW_FIELDS = (
     "azure_live_query_proven",
     "failure_reason",
     "event_parse_error",
+    "diagnostics",
     "exit_code",
     "tool_errors",
     "response_time_seconds",
@@ -86,6 +95,46 @@ def validate_row_schema(result: object) -> list[str]:
         result["event_parse_error"], str
     ):
         errors.append("event_parse_error must be a string or null")
+    diagnostics = result.get("diagnostics")
+    required_diagnostic_fields = {
+        "events",
+        "events_truncated",
+        "stdout_excerpt",
+        "stdout_truncated",
+        "stderr_excerpt",
+        "stderr_truncated",
+    }
+    if not isinstance(diagnostics, dict):
+        errors.append("diagnostics must be a JSON object")
+    elif set(diagnostics) != required_diagnostic_fields:
+        errors.append("diagnostics must contain exactly the required bounded-output fields")
+    else:
+        events = diagnostics["events"]
+        if not isinstance(events, list):
+            errors.append("diagnostics.events must be a list")
+        elif len(events) > MAX_DIAGNOSTIC_EVENTS:
+            errors.append(f"diagnostics.events must contain at most {MAX_DIAGNOSTIC_EVENTS} entries")
+        else:
+            try:
+                serialized_event_chars = len(json.dumps(events, ensure_ascii=True))
+            except (TypeError, ValueError):
+                errors.append("diagnostics.events must contain JSON-serializable values")
+            else:
+                if serialized_event_chars > MAX_DIAGNOSTIC_EVENTS_CHARS:
+                    errors.append("diagnostics.events exceeds its total serialized size limit")
+        for field in ("events_truncated", "stdout_truncated", "stderr_truncated"):
+            if type(diagnostics[field]) is not bool:
+                errors.append(f"diagnostics.{field} must be a Boolean")
+        excerpt_limits = {
+            "stdout_excerpt": MAX_STDOUT_EXCERPT + len("...[truncated]"),
+            "stderr_excerpt": MAX_STDERR_EXCERPT + len("...[truncated]"),
+        }
+        for field, max_length in excerpt_limits.items():
+            excerpt = diagnostics[field]
+            if not isinstance(excerpt, str):
+                errors.append(f"diagnostics.{field} must be a string")
+            elif len(excerpt) > max_length:
+                errors.append(f"diagnostics.{field} exceeds its maximum length")
     for field in ("exit_code", "tool_errors"):
         if field in result and type(result[field]) is not int:
             errors.append(f"{field} must be an integer")

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -77,6 +77,7 @@ SOURCE_CONFIG_FIELDS = {"name", "type", "endpoint", "command", "tool_prefix", "a
 METADATA_IDENTIFIER_FIELDS = {"run_id", "timestamp"}
 METADATA_COUNT_FIELDS = {"scenarios_count", "total_evaluations", "completed", "input_files"}
 METADATA_LIST_FIELDS = {"servers", "models"}
+MAX_DIAGNOSTIC_IDENTIFIER_DEPTH = 7
 
 
 def _invalid_scores() -> dict:
@@ -117,7 +118,7 @@ def _diagnostic_identifier_errors(
     depth: int = 0,
 ) -> list[str]:
     errors = []
-    if depth >= 4 and isinstance(value, (dict, list)):
+    if depth >= MAX_DIAGNOSTIC_IDENTIFIER_DEPTH and isinstance(value, (dict, list)):
         return [f"{path} exceeds maximum diagnostic nesting depth"]
     if isinstance(value, dict):
         if len(value) > 20:
@@ -233,13 +234,28 @@ def _canonical_diagnostics(value: object) -> object:
     if not isinstance(value, dict):
         return _sanitize_diagnostic_value(value)
     return {
-        "events": _sanitize_diagnostic_value(value.get("events", [])),
+        "events": _canonical_diagnostic_events(value.get("events", [])),
         "events_truncated": value.get("events_truncated") if type(value.get("events_truncated")) is bool else False,
         "stdout_excerpt": _sanitize_text(str(value.get("stdout_excerpt", "")), max_chars=MAX_STDOUT_EXCERPT)[0],
         "stdout_truncated": value.get("stdout_truncated") if type(value.get("stdout_truncated")) is bool else False,
         "stderr_excerpt": _sanitize_text(str(value.get("stderr_excerpt", "")), max_chars=MAX_STDERR_EXCERPT)[0],
         "stderr_truncated": value.get("stderr_truncated") if type(value.get("stderr_truncated")) is bool else False,
     }
+
+
+def _canonical_diagnostic_events(value: object) -> object:
+    if not isinstance(value, list):
+        return _sanitize_diagnostic_value(value)
+    canonical = []
+    for event in value[:20]:
+        if not isinstance(event, dict):
+            canonical.append(_sanitize_diagnostic_value(event))
+            continue
+        canonical.append({
+            "event_type": _sanitize_text(str(event.get("event_type", "")))[0],
+            "data": _sanitize_diagnostic_value(event.get("data", {})),
+        })
+    return canonical
 
 
 def _project_result_fields(result: dict) -> dict:
@@ -397,7 +413,7 @@ def validate_row_schema(result: object) -> list[str]:
         events = diagnostics["events"]
         if not excessive_depth:
             try:
-                canonical_events = _sanitize_diagnostic_value(events)
+                canonical_events = _canonical_diagnostic_events(events)
             except RecursionError:
                 excessive_depth = True
                 errors.append("diagnostics.events exceeds maximum diagnostic nesting depth")

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -68,6 +68,17 @@ def validate_row_schema(result: object) -> list[str]:
         or result["status"] not in {"success", "invalid", "error", "timeout"}
     ):
         errors.append("status must be success, invalid, error, or timeout")
+    status = result.get("status")
+    if isinstance(status, str) and status in {"invalid", "error", "timeout"} and (
+        result.get("response") != "" or result.get("response_present") is not False
+    ):
+        errors.append("non-success rows must clear response and set response_present=false")
+    if status == "success" and (
+        not isinstance(result.get("response"), str)
+        or not result.get("response")
+        or result.get("response_present") is not True
+    ):
+        errors.append("success rows must contain a response and set response_present=true")
     for field in (
         "response_present",
         "passed",
@@ -266,8 +277,8 @@ def score_result(result: object) -> dict:
         failure_reason = f"{existing_failure}; {schema_failure}" if existing_failure else schema_failure
         return {
             **result,
-            "response": response,
-            "response_present": bool(response),
+            "response": "",
+            "response_present": False,
             "status": "invalid",
             "passed": False,
             "source_validated": False,
@@ -339,6 +350,8 @@ def score_result(result: object) -> dict:
     if not row_valid:
         return {
             **result,
+            "response": "",
+            "response_present": False,
             "row_valid": False,
             "scores": {
                 "completeness": 0.0,

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -24,6 +24,7 @@ from run_docs_eval import (
     MCP_SERVERS,
     _is_search_tool,
     _source_for_tool,
+    serialized_diagnostic_events_size,
 )
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -127,7 +128,7 @@ def validate_row_schema(result: object) -> list[str]:
             errors.append(f"diagnostics.events must contain at most {MAX_DIAGNOSTIC_EVENTS} entries")
         else:
             try:
-                serialized_event_chars = len(json.dumps(events, ensure_ascii=True))
+                serialized_event_chars = serialized_diagnostic_events_size(events)
             except (TypeError, ValueError):
                 errors.append("diagnostics.events must contain JSON-serializable values")
             else:

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -538,6 +538,10 @@ def validate_trusted_scenarios(scenarios: object) -> dict[str, dict]:
         rubric = scenario.get("rubric")
         if not isinstance(scenario_id, str) or not scenario_id.strip():
             raise ValueError(f"trusted scenario {index} must have a non-empty id")
+        if scenario_id != _sanitize_identifier(scenario_id):
+            raise ValueError(
+                f"trusted scenario id must equal its bounded sanitized canonical form: {scenario_id}"
+            )
         if scenario_id in trusted:
             raise ValueError(f"duplicate trusted scenario id: {scenario_id}")
         if not isinstance(question, str) or not question.strip():
@@ -1093,7 +1097,7 @@ def _parse_args() -> argparse.Namespace:
         help="Path to save scored results (default: scored-{run_id}.json)"
     )
     parser.add_argument(
-        "--required-scenarios", default=None,
+        "--required-scenarios", required=True,
         help="Scenario JSON whose IDs define the required matrix rows"
     )
     parser.add_argument(
@@ -1150,12 +1154,9 @@ def main():
 
     print(f"Scoring {len(all_results)} evaluation results from {len(args.input)} file(s)...")
 
-    scenario_ids = None
-    trusted_scenarios = None
-    if args.required_scenarios:
-        with open(args.required_scenarios) as f:
-            trusted_scenarios = validate_trusted_scenarios(json.load(f))
-            scenario_ids = list(trusted_scenarios)
+    with open(args.required_scenarios) as f:
+        trusted_scenarios = validate_trusted_scenarios(json.load(f))
+        scenario_ids = list(trusted_scenarios)
     scored_results = [score_result(r, trusted_scenarios) for r in all_results]
     publication = validate_required_matrix(
         scored_results,

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -23,6 +23,9 @@ from run_docs_eval import (
     MAX_STDOUT_EXCERPT,
     MCP_SERVERS,
     _is_search_tool,
+    _sanitize_diagnostic_value,
+    _sanitize_identifier,
+    _sanitize_text,
     _source_for_tool,
     serialized_diagnostic_events_size,
 )
@@ -53,6 +56,24 @@ REQUIRED_ROW_FIELDS = (
     "tool_errors",
     "response_time_seconds",
 )
+SCORED_ROW_FIELDS = {
+    *REQUIRED_ROW_FIELDS,
+    "question",
+    "rubric",
+    "timestamp",
+    "stderr",
+    "turns",
+    "tool_calls",
+    "output_tokens",
+    "premium_requests",
+    "api_duration_ms",
+    "session_duration_ms",
+}
+RUBRIC_FIELDS = {"must_mention", "quality_criteria", "expected_docs"}
+SOURCE_CONFIG_FIELDS = {"name", "type", "endpoint", "command", "tool_prefix", "azure_required"}
+METADATA_IDENTIFIER_FIELDS = {"run_id", "timestamp"}
+METADATA_COUNT_FIELDS = {"scenarios_count", "total_evaluations", "completed", "input_files"}
+METADATA_LIST_FIELDS = {"servers", "models"}
 
 
 def _invalid_scores() -> dict:
@@ -78,6 +99,164 @@ def _invalidate_scored_row(row: dict, failure_reason: str) -> None:
         row["failure_reason"] = failure_reason
 
 
+def _identifier_errors(value: object, field: str) -> list[str]:
+    if not isinstance(value, str):
+        return [f"{field} must be a string identifier"]
+    if value != _sanitize_identifier(value):
+        return [f"{field} must equal its bounded sanitized canonical form"]
+    return []
+
+
+def _diagnostic_identifier_errors(value: object, path: str = "diagnostics") -> list[str]:
+    errors = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            if key in {
+                "toolName",
+                "toolCallId",
+                "serverName",
+                "providerCallId",
+                "serviceRequestId",
+                "turnId",
+                "name",
+            }:
+                errors.extend(_identifier_errors(child, child_path))
+            errors.extend(_diagnostic_identifier_errors(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            errors.extend(_diagnostic_identifier_errors(child, f"{path}[{index}]"))
+    return errors
+
+
+def _sanitize_invalid_result_fields(result: dict) -> dict:
+    sanitized = {
+        field: result[field]
+        for field in SCORED_ROW_FIELDS
+        if field in result
+    }
+    for field in ("scenario_id", "server", "model", "category", "selected_source"):
+        if field in sanitized:
+            sanitized[field] = _sanitize_identifier(sanitized[field])
+    if "question" in sanitized:
+        sanitized["question"] = (
+            _sanitize_text(sanitized["question"])[0]
+            if isinstance(sanitized["question"], str)
+            else _sanitize_diagnostic_value(sanitized["question"])
+        )
+    if "timestamp" in sanitized:
+        sanitized["timestamp"] = _sanitize_identifier(sanitized["timestamp"])
+    for field in ("observed_tools", "successful_tools"):
+        value = sanitized.get(field)
+        if isinstance(value, list):
+            sanitized[field] = [_sanitize_identifier(item) for item in value]
+        elif field in sanitized:
+            sanitized[field] = []
+    for field in ("failure_reason", "event_parse_error"):
+        value = sanitized.get(field)
+        if isinstance(value, str):
+            sanitized[field] = _sanitize_text(value)[0]
+        elif field in sanitized and value is not None:
+            sanitized[field] = _sanitize_diagnostic_value(value)
+    if "stderr" in sanitized:
+        sanitized["stderr"] = (
+            _sanitize_text(sanitized["stderr"], max_chars=MAX_STDERR_EXCERPT)[0]
+            if isinstance(sanitized["stderr"], str)
+            else _sanitize_diagnostic_value(sanitized["stderr"])
+        )
+    if "selected_source_config" in sanitized:
+        config = sanitized["selected_source_config"]
+        sanitized["selected_source_config"] = (
+            {
+                field: _sanitize_diagnostic_value(config[field])
+                for field in SOURCE_CONFIG_FIELDS
+                if field in config
+            }
+            if isinstance(config, dict)
+            else _sanitize_diagnostic_value(config)
+        )
+    if "rubric" in sanitized:
+        rubric = sanitized["rubric"]
+        sanitized["rubric"] = (
+            {
+                field: _sanitize_diagnostic_value(rubric[field])
+                for field in RUBRIC_FIELDS
+                if field in rubric
+            }
+            if isinstance(rubric, dict)
+            else _sanitize_diagnostic_value(rubric)
+        )
+    for field in ("premium_requests", "api_duration_ms", "session_duration_ms"):
+        value = sanitized.get(field)
+        if value is not None and (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or value < 0
+        ):
+            sanitized[field] = None
+    if "diagnostics" in sanitized:
+        sanitized["diagnostics"] = _canonical_diagnostics(sanitized["diagnostics"])
+    return sanitized
+
+
+def _canonical_diagnostics(value: object) -> object:
+    if not isinstance(value, dict):
+        return _sanitize_diagnostic_value(value)
+    return {
+        "events": _sanitize_diagnostic_value(value.get("events", [])),
+        "events_truncated": value.get("events_truncated") if type(value.get("events_truncated")) is bool else False,
+        "stdout_excerpt": _sanitize_text(str(value.get("stdout_excerpt", "")), max_chars=MAX_STDOUT_EXCERPT)[0],
+        "stdout_truncated": value.get("stdout_truncated") if type(value.get("stdout_truncated")) is bool else False,
+        "stderr_excerpt": _sanitize_text(str(value.get("stderr_excerpt", "")), max_chars=MAX_STDERR_EXCERPT)[0],
+        "stderr_truncated": value.get("stderr_truncated") if type(value.get("stderr_truncated")) is bool else False,
+    }
+
+
+def _project_result_fields(result: dict) -> dict:
+    projected = {
+        field: result[field]
+        for field in SCORED_ROW_FIELDS
+        if field in result
+    }
+    if isinstance(projected.get("rubric"), dict):
+        projected["rubric"] = {
+            field: projected["rubric"][field]
+            for field in RUBRIC_FIELDS
+            if field in projected["rubric"]
+        }
+    if isinstance(projected.get("selected_source_config"), dict):
+        projected["selected_source_config"] = {
+            field: projected["selected_source_config"][field]
+            for field in SOURCE_CONFIG_FIELDS
+            if field in projected["selected_source_config"]
+        }
+    if "diagnostics" in projected:
+        projected["diagnostics"] = _canonical_diagnostics(projected["diagnostics"])
+    return projected
+
+
+def _sanitize_metadata(metadata: object) -> dict:
+    if not isinstance(metadata, dict):
+        return {"servers": [], "models": []}
+    sanitized = {
+        field: _sanitize_identifier(metadata[field])
+        for field in METADATA_IDENTIFIER_FIELDS
+        if field in metadata
+    }
+    for field in METADATA_COUNT_FIELDS:
+        value = metadata.get(field)
+        if type(value) is int and value >= 0:
+            sanitized[field] = value
+    for field in METADATA_LIST_FIELDS:
+        value = metadata.get(field)
+        sanitized[field] = (
+            [_sanitize_identifier(item) for item in value]
+            if isinstance(value, list)
+            else []
+        )
+    return sanitized
+
+
 def validate_row_schema(result: object) -> list[str]:
     """Return schema errors without throwing so malformed rows remain diagnostic."""
     if not isinstance(result, dict):
@@ -87,6 +266,10 @@ def validate_row_schema(result: object) -> list[str]:
     for field in ("scenario_id", "server", "model", "category", "response", "selected_source"):
         if field in result and not isinstance(result[field], str):
             errors.append(f"{field} must be a string")
+    if isinstance(result.get("server"), str) and result["server"] not in MCP_SERVERS:
+        errors.append(f"unknown server: {_sanitize_identifier(result['server'])}")
+    for field in ("scenario_id", "server", "model", "category", "selected_source"):
+        errors.extend(_identifier_errors(result.get(field), field))
     if "status" in result and (
         not isinstance(result["status"], str)
         or result["status"] not in {"success", "invalid", "error", "timeout"}
@@ -114,6 +297,10 @@ def validate_row_schema(result: object) -> list[str]:
             errors.append(f"{field} must be a Boolean")
     if "selected_source_config" in result and not isinstance(result["selected_source_config"], dict):
         errors.append("selected_source_config must be a JSON object")
+    elif isinstance(result.get("selected_source_config"), dict) and set(
+        result["selected_source_config"]
+    ) != SOURCE_CONFIG_FIELDS:
+        errors.append("selected_source_config must contain exactly the required fields")
     if "source_config_count" in result and type(result["source_config_count"]) is not int:
         errors.append("source_config_count must be an integer")
     for field in ("observed_tools", "successful_tools"):
@@ -122,14 +309,25 @@ def validate_row_schema(result: object) -> list[str]:
             not isinstance(value, list) or not all(isinstance(tool_name, str) for tool_name in value)
         ):
             errors.append(f"{field} must be a list of strings")
+        elif isinstance(value, list):
+            for index, identifier in enumerate(value):
+                errors.extend(_identifier_errors(identifier, f"{field}[{index}]"))
     if "failure_reason" in result and result["failure_reason"] is not None and not isinstance(
         result["failure_reason"], str
     ):
         errors.append("failure_reason must be a string or null")
+    elif isinstance(result.get("failure_reason"), str) and result["failure_reason"] != _sanitize_text(
+        result["failure_reason"]
+    )[0]:
+        errors.append("failure_reason must equal its bounded sanitized canonical form")
     if "event_parse_error" in result and result["event_parse_error"] is not None and not isinstance(
         result["event_parse_error"], str
     ):
         errors.append("event_parse_error must be a string or null")
+    elif isinstance(result.get("event_parse_error"), str) and result["event_parse_error"] != _sanitize_text(
+        result["event_parse_error"]
+    )[0]:
+        errors.append("event_parse_error must equal its bounded sanitized canonical form")
     diagnostics = result.get("diagnostics")
     required_diagnostic_fields = {
         "events",
@@ -144,7 +342,10 @@ def validate_row_schema(result: object) -> list[str]:
     elif set(diagnostics) != required_diagnostic_fields:
         errors.append("diagnostics must contain exactly the required bounded-output fields")
     else:
+        errors.extend(_diagnostic_identifier_errors(diagnostics))
         events = diagnostics["events"]
+        if events != _sanitize_diagnostic_value(events):
+            errors.append("diagnostics.events must equal its sanitized canonical form")
         if not isinstance(events, list):
             errors.append("diagnostics.events must be a list")
         elif len(events) > MAX_DIAGNOSTIC_EVENTS:
@@ -170,6 +371,20 @@ def validate_row_schema(result: object) -> list[str]:
                 errors.append(f"diagnostics.{field} must be a string")
             elif len(excerpt) > max_length:
                 errors.append(f"diagnostics.{field} exceeds its maximum length")
+        if isinstance(diagnostics["stdout_excerpt"], str) and diagnostics["stdout_excerpt"] != _sanitize_text(
+            diagnostics["stdout_excerpt"], max_chars=MAX_STDOUT_EXCERPT
+        )[0]:
+            errors.append("diagnostics.stdout_excerpt must equal its sanitized canonical form")
+        if isinstance(diagnostics["stderr_excerpt"], str) and diagnostics["stderr_excerpt"] != _sanitize_text(
+            diagnostics["stderr_excerpt"], max_chars=MAX_STDERR_EXCERPT
+        )[0]:
+            errors.append("diagnostics.stderr_excerpt must equal its sanitized canonical form")
+    stderr = result.get("stderr")
+    if stderr is not None:
+        if not isinstance(stderr, str):
+            errors.append("stderr must be a string")
+        elif stderr != _sanitize_text(stderr, max_chars=MAX_STDERR_EXCERPT)[0]:
+            errors.append("stderr must equal its bounded sanitized canonical form")
     for field in ("exit_code", "tool_errors"):
         if field in result and type(result[field]) is not int:
             errors.append(f"{field} must be an integer")
@@ -188,10 +403,31 @@ def validate_row_schema(result: object) -> list[str]:
         if not isinstance(rubric, dict):
             errors.append("rubric must be a JSON object")
         else:
+            if set(rubric) != RUBRIC_FIELDS:
+                errors.append("rubric must contain exactly the required fields")
             for field in ("must_mention", "quality_criteria", "expected_docs"):
                 value = rubric.get(field, [])
                 if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
                     errors.append(f"rubric.{field} must be a list of strings")
+                elif any(item != _sanitize_text(item)[0] for item in value):
+                    errors.append(f"rubric.{field} must contain sanitized bounded strings")
+    question = result.get("question")
+    if question is not None:
+        if not isinstance(question, str):
+            errors.append("question must be a string")
+        elif question != _sanitize_text(question)[0]:
+            errors.append("question must equal its bounded sanitized canonical form")
+    timestamp = result.get("timestamp")
+    if timestamp is not None:
+        errors.extend(_identifier_errors(timestamp, "timestamp"))
+    for field in ("premium_requests", "api_duration_ms", "session_duration_ms"):
+        value = result.get(field)
+        if value is not None and (
+            not isinstance(value, (int, float))
+            or isinstance(value, bool)
+            or value < 0
+        ):
+            errors.append(f"{field} must be a non-negative number or null")
     return errors
 
 
@@ -300,8 +536,10 @@ def score_result(result: object) -> dict:
         existing_failure = result.get("failure_reason")
         schema_failure = "row_schema_invalid: " + "; ".join(schema_errors)
         failure_reason = f"{existing_failure}; {schema_failure}" if existing_failure else schema_failure
+        failure_reason = _sanitize_text(failure_reason)[0]
+        sanitized_result = _sanitize_invalid_result_fields(result)
         return {
-            **result,
+            **sanitized_result,
             "response": "",
             "response_present": False,
             "status": "invalid",
@@ -370,7 +608,7 @@ def score_result(result: object) -> dict:
         operational["passed"] = False
         normalized_status = status if status in {"error", "timeout"} else "invalid"
         return {
-            **result,
+            **_sanitize_invalid_result_fields(result),
             "response": "",
             "response_present": False,
             "status": normalized_status,
@@ -402,7 +640,7 @@ def score_result(result: object) -> dict:
         + scores["doc_retrieval"] * 0.3
     )
 
-    return {**result, "row_valid": True, "scores": scores, "operational": operational}
+    return {**_project_result_fields(result), "row_valid": True, "scores": scores, "operational": operational}
 
 
 def aggregate_scores(scored_results: list[dict]) -> dict:
@@ -524,6 +762,10 @@ def validate_required_matrix(
 ) -> dict:
     """Validate required scenario/server/model rows and produce complete denominators."""
     azure_required_servers = azure_required_servers or set()
+    scenario_ids = [_sanitize_identifier(value) for value in scenario_ids] if scenario_ids is not None else None
+    servers = [_sanitize_identifier(value) for value in servers] if servers is not None else None
+    models = [_sanitize_identifier(value) for value in models] if models is not None else None
+    azure_required_servers = {_sanitize_identifier(value) for value in azure_required_servers}
     rows_by_key: dict[tuple[str, str, str], list[dict]] = defaultdict(list)
     malformed_rows: list[dict] = []
     for index, row in enumerate(scored_results):
@@ -542,6 +784,10 @@ def validate_required_matrix(
         expected_keys = set(product(scenario_ids, servers, models))
     else:
         expected_keys = set(rows_by_key)
+    unknown_required_servers = sorted(
+        _sanitize_identifier(server)
+        for server in (set(servers or []) | azure_required_servers) - set(MCP_SERVERS)
+    )
 
     for key, rows in rows_by_key.items():
         if len(rows) > 1:
@@ -591,7 +837,7 @@ def validate_required_matrix(
     unexpected_rows = sorted(" / ".join(key) for key in set(rows_by_key) - expected_keys)
     invalid_rows.extend(malformed_rows)
     status_counts["invalid"] += len(malformed_rows)
-    allowed = not invalid_rows and not duplicate_rows and not unexpected_rows
+    allowed = not invalid_rows and not duplicate_rows and not unexpected_rows and not unknown_required_servers
     failure_reasons = []
     if invalid_rows:
         failure_reasons.append(f"{len(invalid_rows)} required row(s) are invalid or missing")
@@ -599,6 +845,10 @@ def validate_required_matrix(
         failure_reasons.append(f"{len(duplicate_rows)} required row(s) are duplicated")
     if unexpected_rows:
         failure_reasons.append(f"{len(unexpected_rows)} unexpected row(s) were supplied")
+    if unknown_required_servers:
+        failure_reasons.append(
+            "unknown required server(s): " + ", ".join(_sanitize_identifier(server) for server in unknown_required_servers)
+        )
 
     return {
         "allowed": allowed,
@@ -611,6 +861,7 @@ def validate_required_matrix(
         "invalid_rows": invalid_rows,
         "duplicate_rows": duplicate_rows,
         "unexpected_rows": unexpected_rows,
+        "unknown_required_servers": unknown_required_servers,
     }
 
 
@@ -661,17 +912,16 @@ def main():
 
         file_meta = data.get("metadata", {})
         all_results.extend(data.get("results", []))
+        sanitized_meta = _sanitize_metadata(file_meta)
 
         # Merge metadata: keep first run_id, union servers/models, sum counts
         if not merged_metadata:
-            merged_metadata = dict(file_meta)
-            merged_metadata["servers"] = list(file_meta.get("servers", []))
-            merged_metadata["models"] = list(file_meta.get("models", []))
+            merged_metadata = sanitized_meta
         else:
-            for s in file_meta.get("servers", []):
+            for s in sanitized_meta.get("servers", []):
                 if s not in merged_metadata["servers"]:
                     merged_metadata["servers"].append(s)
-            for m in file_meta.get("models", []):
+            for m in sanitized_meta.get("models", []):
                 if m not in merged_metadata["models"]:
                     merged_metadata["models"].append(m)
 

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -16,6 +16,7 @@ Models:
 """
 
 import argparse
+import io
 import json
 import os
 import re
@@ -98,7 +99,11 @@ MAX_DIAGNOSTIC_EVENTS_CHARS = 50_000
 MAX_DIAGNOSTIC_TEXT = 2_000
 MAX_STDOUT_EXCERPT = 12_000
 MAX_STDERR_EXCERPT = 4_000
+MAX_STDOUT_PARSE_BYTES = 128_000
+MAX_STDOUT_PARSE_LINES = 500
+MAX_STDOUT_LINE_BYTES = 32_000
 _SECRET_KEY_PATTERN = re.compile(r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I)
+_AUTHORIZATION_HEADER_PATTERN = re.compile(r"(?im)(authorization\s*:\s*)[^\r\n]+")
 _SECRET_VALUE_PATTERNS = (
     re.compile(r"\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]+\b"),
     re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
@@ -108,9 +113,9 @@ _SECRET_VALUE_PATTERNS = (
     ),
 )
 _ABSOLUTE_PATH_PATTERNS = (
-    re.compile(r"(?i)\\\\[^\\\r\n]+\\[^,\r\n;\"']+"),
-    re.compile(r"(?i)\b[A-Z]:\\[^,\r\n;\"']+"),
-    re.compile(r"(?<![:/\w])/(?:[^/\s]+/)+[^,\s;\"']+"),
+    re.compile(r"(?i)(?:\\\\|//)[^\\/\r\n]+[\\/][^,\r\n;\"']+"),
+    re.compile(r"(?i)\b[A-Z]:[\\/][^,\r\n;\"']+"),
+    re.compile(r"(?<![:/\w])/(?!/)[^,\r\n;\"']+"),
 )
 
 
@@ -226,6 +231,7 @@ def _sanitize_text(value: str, max_chars: int = MAX_DIAGNOSTIC_TEXT) -> tuple[st
         if path:
             sanitized = re.sub(re.escape(path), replacement, sanitized, flags=re.I)
 
+    sanitized = _AUTHORIZATION_HEADER_PATTERN.sub(r"\1[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[2].sub(r"\1[REDACTED]", sanitized)
@@ -277,11 +283,12 @@ def _bounded_excerpt(value: str | bytes | None, max_chars: int) -> tuple[str, bo
 
 def _bounded_stdout_excerpt(value: str | bytes | None) -> tuple[str, bool]:
     sanitized_lines = []
-    per_line_truncated = False
-    for line in _coerce_process_text(value).splitlines():
+    lines, boundary_errors, boundary_truncated = _bounded_event_lines(value)
+    per_line_truncated = boundary_truncated
+    for _line_number, line in lines:
         try:
             parsed_line = json.loads(line)
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, RecursionError):
             sanitized_line, truncated = _sanitize_text(line)
             sanitized_lines.append(sanitized_line)
             per_line_truncated = per_line_truncated or truncated
@@ -290,6 +297,53 @@ def _bounded_stdout_excerpt(value: str | bytes | None) -> tuple[str, bool]:
             sanitized_lines.append(json.dumps(_sanitize_diagnostic_value(parsed_line), ensure_ascii=True))
     excerpt, final_truncated = _sanitize_text("\n".join(sanitized_lines), max_chars=MAX_STDOUT_EXCERPT)
     return excerpt, per_line_truncated or final_truncated
+
+
+def _bounded_event_lines(value: str | bytes | None) -> tuple[list[tuple[int, str]], list[str], bool]:
+    """Bound bytes, lines, and per-line size before any JSON parsing."""
+    is_bytes = isinstance(value, bytes)
+    reader = io.BytesIO(value) if is_bytes else io.StringIO(value or "")
+    accepted: list[tuple[int, str]] = []
+    errors: list[str] = []
+    total_bytes = 0
+    truncated = False
+
+    for line_number in range(1, MAX_STDOUT_PARSE_LINES + 1):
+        line = reader.readline(MAX_STDOUT_LINE_BYTES + 1)
+        if not line:
+            break
+        newline_markers = (b"\n", b"\r") if is_bytes else ("\n", "\r")
+        if len(line) > MAX_STDOUT_LINE_BYTES and not line.endswith(newline_markers):
+            errors.append(
+                f"line {line_number}: event exceeds {MAX_STDOUT_LINE_BYTES} byte pre-parse limit"
+            )
+            truncated = True
+            break
+        line_bytes = len(line) if is_bytes else len(line.encode("utf-8", errors="replace"))
+        if line_bytes > MAX_STDOUT_LINE_BYTES:
+            errors.append(
+                f"line {line_number}: event exceeds {MAX_STDOUT_LINE_BYTES} byte pre-parse limit"
+            )
+            truncated = True
+            break
+        if total_bytes + line_bytes > MAX_STDOUT_PARSE_BYTES:
+            errors.append(f"stdout exceeds {MAX_STDOUT_PARSE_BYTES} byte pre-parse limit")
+            truncated = True
+            break
+        total_bytes += line_bytes
+        text_line = line.decode("utf-8", errors="replace") if is_bytes else line
+        stripped = text_line.strip()
+        if stripped:
+            accepted.append((line_number, stripped))
+    else:
+        if reader.read(1):
+            errors.append(f"stdout exceeds {MAX_STDOUT_PARSE_LINES} line pre-parse limit")
+            truncated = True
+
+    if not truncated and reader.read(1):
+        errors.append("stdout contains data beyond the pre-parse budget")
+        truncated = True
+    return accepted, errors, truncated
 
 
 def _contains_oversized_diagnostic_value(value: object, *, depth: int = 0) -> bool:
@@ -340,7 +394,7 @@ def _build_diagnostics(
     return diagnostics
 
 
-def parse_event_stream(stdout: str) -> dict:
+def parse_event_stream(stdout: str | bytes) -> dict:
     """Parse `copilot --output-format json` JSONL output into operational metrics.
 
     Extracts the final assistant response text plus turn count, tool-call count,
@@ -363,6 +417,9 @@ def parse_event_stream(stdout: str) -> dict:
         "diagnostic_events": [],
         "diagnostic_events_truncated": False,
         "mcp_failure": None,
+        "mcp_statuses": {},
+        "session_failure": None,
+        "stdout_input_truncated": False,
     }
 
     last_message_content = ""
@@ -375,6 +432,7 @@ def parse_event_stream(stdout: str) -> dict:
     final_response_line: int | None = None
     last_successful_tool_line: int | None = None
     diagnostic_event_chars = 0
+    mcp_statuses: dict[str, tuple[str, str | None]] = {}
 
     def add_diagnostic(event_type: str, data: dict) -> None:
         nonlocal diagnostic_event_chars
@@ -392,13 +450,14 @@ def parse_event_stream(stdout: str) -> dict:
         metrics["diagnostic_events"].append(diagnostic)
         diagnostic_event_chars += diagnostic_chars
 
-    for line_number, line in enumerate(stdout.splitlines(), start=1):
-        line = line.strip()
-        if not line:
-            continue
+    lines, boundary_errors, boundary_truncated = _bounded_event_lines(stdout)
+    parse_errors.extend(boundary_errors)
+    metrics["stdout_input_truncated"] = boundary_truncated
+
+    for line_number, line in lines:
         try:
             event = json.loads(line)
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, RecursionError):
             parse_errors.append(f"line {line_number}: invalid JSON event")
             continue
         if not isinstance(event, dict):
@@ -485,12 +544,38 @@ def parse_event_stream(stdout: str) -> dict:
             add_diagnostic(etype, data)
             status = str(data.get("status") or data.get("state") or "").casefold()
             error = data.get("error") or data.get("message")
-            if error or status in {"error", "failed", "failure", "stopped", "unavailable", "disconnected"}:
-                raw_server = data.get("serverName") or data.get("server") or data.get("name") or "selected MCP server"
-                server = _sanitize_text(str(raw_server))[0]
-                detail = error or f"status changed to {status or 'unknown'}"
-                sanitized_detail = _sanitize_text(str(detail))[0]
-                metrics["mcp_failure"] = f"{server}: {sanitized_detail}"
+            raw_server = data.get("serverName") or data.get("server") or data.get("name") or "selected MCP server"
+            server = _sanitize_text(str(raw_server))[0]
+            mcp_statuses[server] = (status, _sanitize_text(str(error))[0] if error else None)
+        elif etype == "session.mcp_servers_loaded":
+            add_diagnostic(etype, data)
+            servers = data.get("servers")
+            if not isinstance(servers, list):
+                parse_errors.append(f"line {line_number}: mcp_servers_loaded servers must be a list")
+            else:
+                for server_data in servers[:MAX_DIAGNOSTIC_EVENTS]:
+                    if not isinstance(server_data, dict):
+                        parse_errors.append(f"line {line_number}: MCP server summary must be an object")
+                        continue
+                    raw_name = server_data.get("name")
+                    raw_status = server_data.get("status")
+                    if not isinstance(raw_name, str) or not isinstance(raw_status, str):
+                        parse_errors.append(f"line {line_number}: MCP server summary missing name or status")
+                        continue
+                    server = _sanitize_text(raw_name)[0]
+                    status = raw_status.casefold()
+                    error = server_data.get("error")
+                    mcp_statuses[server] = (status, _sanitize_text(str(error))[0] if error else None)
+        elif etype == "session.error":
+            add_diagnostic(etype, data)
+            error_type = data.get("errorType")
+            message = data.get("message")
+            if not isinstance(error_type, str) or not isinstance(message, str):
+                parse_errors.append(f"line {line_number}: session.error missing errorType or message")
+            else:
+                metrics["session_failure"] = (
+                    f"{_sanitize_text(error_type)[0]}: {_sanitize_text(message)[0]}"
+                )
         elif etype == "result":
             if result_seen:
                 parse_errors.append(f"line {line_number}: duplicate terminal result")
@@ -523,6 +608,18 @@ def parse_event_stream(stdout: str) -> dict:
     ):
         parse_errors.append("assistant response preceded the final successful documentation tool")
 
+    failing_mcp_statuses = []
+    for server, (status, error) in mcp_statuses.items():
+        if status != "connected":
+            detail = error or f"status is {status or 'unknown'}"
+            failing_mcp_statuses.append(f"{server}: {detail}")
+    if failing_mcp_statuses:
+        metrics["mcp_failure"] = "; ".join(failing_mcp_statuses)
+    metrics["mcp_statuses"] = {
+        server: {"status": status, "error": error}
+        for server, (status, error) in mcp_statuses.items()
+    }
+
     metrics["parse_error"] = "; ".join(dict.fromkeys(parse_errors)) or None
 
     return {"response": last_message_content, **metrics}
@@ -530,8 +627,19 @@ def parse_event_stream(stdout: str) -> dict:
 
 def validate_row_evidence(parsed: dict, tool_prefix: str, azure_required: bool) -> tuple[bool, str | None, bool]:
     """Validate selected-source and optional Azure evidence for one row."""
-    if parsed["mcp_failure"]:
-        return False, f"mcp_initialization_failure: {parsed['mcp_failure']}", False
+    if parsed["session_failure"]:
+        return False, f"session_error: {parsed['session_failure']}", False
+    selected_mcp_status = next(
+        (
+            status
+            for server, status in parsed["mcp_statuses"].items()
+            if server.casefold() == tool_prefix.casefold()
+        ),
+        None,
+    )
+    if selected_mcp_status and selected_mcp_status["status"] != "connected":
+        detail = selected_mcp_status["error"] or f"status is {selected_mcp_status['status'] or 'unknown'}"
+        return False, f"mcp_initialization_failure: {tool_prefix}: {detail}", False
     if parsed["parse_error"]:
         return False, f"event_parse_failure: {parsed['parse_error']}", False
     if parsed["tool_errors"]:
@@ -673,6 +781,8 @@ def run_single_eval(
             failure_reason = f"{failure_reason}; {event_failure}" if failure_reason else event_failure
         else:
             status = "success" if evidence_valid else "invalid"
+        if status != "success":
+            response = ""
 
         result.update({
             "response": response,
@@ -681,7 +791,7 @@ def run_single_eval(
             "response_time_seconds": round(elapsed, 2),
             "status": status,
             "passed": status == "success",
-            "response_present": bool(response),
+            "response_present": status == "success" and bool(response),
             "failure_reason": failure_reason,
             "source_validated": evidence_valid,
             "azure_live_query_proven": azure_live_query_proven,
@@ -699,14 +809,14 @@ def run_single_eval(
                 parsed,
                 proc.stdout,
                 proc.stderr,
-                preserve_stdout=not evidence_valid,
+                preserve_stdout=status != "success",
             ),
         })
 
     except subprocess.TimeoutExpired as exc:
         elapsed = time.monotonic() - start_time
-        partial_stdout = _coerce_process_text(exc.stdout)
-        partial_stderr = _coerce_process_text(exc.stderr)
+        partial_stdout = exc.stdout
+        partial_stderr = exc.stderr
         parsed = parse_event_stream(partial_stdout) if partial_stdout else None
         result.update({
             "response": "",

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -26,6 +26,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import unquote_plus, urlsplit, urlunsplit
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SCENARIOS_FILE = PROJECT_ROOT / "tests" / "docs_eval_scenarios.json"
@@ -97,6 +98,7 @@ KNOWN_TOOL_PREFIXES = tuple(
 MAX_DIAGNOSTIC_EVENTS = 20
 MAX_DIAGNOSTIC_EVENTS_CHARS = 50_000
 MAX_DIAGNOSTIC_TEXT = 2_000
+MAX_RESPONSE_TEXT = 50_000
 MAX_STDOUT_EXCERPT = 12_000
 MAX_STDERR_EXCERPT = 4_000
 MAX_STDOUT_PARSE_BYTES = 128_000
@@ -111,10 +113,30 @@ _SERIALIZED_AUTHORIZATION_KEY_PATTERN = re.compile(
 _SECRET_VALUE_PATTERNS = (
     re.compile(r"\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]+\b"),
     re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
-    re.compile(
-        r"(?i)([\"']?[A-Z0-9_-]{0,128}(?:api[_-]?key|authorization|credential|password|secret|token)"
-        r"[\"']?\s*[:=]\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;}]+)"
-    ),
+    re.compile(r"\b[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+)
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"""(?ix)
+    (?P<prefix>
+        ["']?[A-Z0-9_-]{0,128}
+        (?:
+            api[_-]?key|account[_-]?key|authorization|credential|password|secret|token
+            |sig(?:nature)?|client[_-]?secret|access[_-]?token|refresh[_-]?token|id[_-]?token
+        )
+        ["']?\s*[:=]\s*
+    )
+    (?:
+        "(?P<double>[^"]*)"
+        | '(?P<single>[^']*)'
+        | (?P<bare>[^\s,;}&?!\)#]+)
+    )
+    """
+)
+_OAUTH_CODE_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)(?<![A-Z0-9_-])(?P<prefix>code\s*[:=]\s*)(?P<bare>[^\s,;}&?!\)#]+)"
+)
+_EXACT_SECRET_ALIAS_PATTERN = re.compile(
+    r"(?i)(?<![A-Z0-9_-])(?P<prefix>(?:pat|sas|sharedaccesskey)\s*[:=]\s*)(?P<bare>[^\s,;}&?!\)#]+)"
 )
 _ABSOLUTE_PATH_PATTERNS = (
     re.compile(r"(?i)(?:\\\\|//)[^\\/\r\n]+[\\/][^,\r\n;\"']+"),
@@ -226,6 +248,7 @@ def _sanitize_text(value: str, max_chars: int = MAX_DIAGNOSTIC_TEXT) -> tuple[st
     pre_redaction_limit = max_chars * 4
     truncated = len(value) > pre_redaction_limit
     sanitized = value[:pre_redaction_limit]
+    sanitized = _redact_encoded_sensitive_tokens(sanitized)
     path_replacements = (
         (str(PROJECT_ROOT), "<PROJECT_ROOT>"),
         (str(Path.home()), "<HOME>"),
@@ -239,7 +262,8 @@ def _sanitize_text(value: str, max_chars: int = MAX_DIAGNOSTIC_TEXT) -> tuple[st
     sanitized = _AUTHORIZATION_HEADER_PATTERN.sub(r"\1[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized)
-    sanitized = _SECRET_VALUE_PATTERNS[2].sub(r"\1[REDACTED]", sanitized)
+    sanitized = _SECRET_VALUE_PATTERNS[2].sub("[REDACTED]", sanitized)
+    sanitized = _redact_secret_assignments(sanitized)
     for pattern in _ABSOLUTE_PATH_PATTERNS:
         sanitized = pattern.sub("<PATH>", sanitized)
 
@@ -287,6 +311,24 @@ def _redact_serialized_authorization(value: str) -> str:
     return value
 
 
+def _redact_secret_assignments(value: str) -> str:
+    def redact(match: re.Match) -> str:
+        trailing = ""
+        bare = match.groupdict().get("bare")
+        secret_value = bare or match.groupdict().get("double") or match.groupdict().get("single") or ""
+        if secret_value == "[REDACTED]":
+            return match.group(0)
+        if bare:
+            while bare.endswith("."):
+                trailing += "."
+                bare = bare[:-1]
+        return f"{match.group('prefix')}[REDACTED]{trailing}"
+
+    value = _SECRET_ASSIGNMENT_PATTERN.sub(redact, value)
+    value = _OAUTH_CODE_ASSIGNMENT_PATTERN.sub(redact, value)
+    return _EXACT_SECRET_ALIAS_PATTERN.sub(redact, value)
+
+
 def _sanitize_diagnostic_value(value: object, *, depth: int = 0) -> object:
     if depth >= 4:
         return "[truncated-depth]"
@@ -322,6 +364,313 @@ def _sanitize_diagnostic_value(value: object, *, depth: int = 0) -> object:
 
 def _sanitize_identifier(value: object) -> str:
     return _sanitize_text(str(value), max_chars=MAX_IDENTIFIER_TEXT)[0]
+
+
+def _sanitize_response_text(value: str) -> str:
+    """Sanitize answer text without treating root-relative documentation links as local paths."""
+    pre_redaction_limit = MAX_RESPONSE_TEXT * 4
+    sanitized = value[:pre_redaction_limit]
+    sanitized = _redact_encoded_sensitive_tokens(sanitized)
+    sanitized = re.sub(
+        r"(?i)(https?://)[^/\s@]+@",
+        r"\1redacted-user@",
+        sanitized,
+    )
+    sanitized = _redact_serialized_authorization(sanitized)
+    sanitized = _AUTHORIZATION_HEADER_PATTERN.sub(r"\1[REDACTED]", sanitized)
+    sanitized = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized)
+    sanitized = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized)
+    sanitized = _SECRET_VALUE_PATTERNS[2].sub("[REDACTED]", sanitized)
+    sanitized = _redact_secret_assignments(sanitized)
+    protected_links: list[str] = []
+
+    def protect_link(match: re.Match) -> str:
+        raw_link = match.group(0)
+        link = "<PATH>" if _RESPONSE_LOCAL_PATH_START.match(raw_link) else _sanitize_link_target(raw_link)
+        if len(link) > 2_048:
+            link = link[:2_048] + "...[truncated]"
+        protected_links.append(link)
+        return f"__ROOT_DOC_LINK_{len(protected_links) - 1}__"
+
+    sanitized = re.sub(r"(?<=\]\()/(?!/)[^)\r\n]+(?=\))", protect_link, sanitized)
+    sanitized = re.sub(r"https?://[^\s<>'\")]+", protect_link, sanitized, flags=re.I)
+    sanitized = re.sub(
+        r"(?<![:/\w~}%])/(?!/|home(?:/|\b)|tmp(?:/|\b)|var(?:/|\b)|etc(?:/|\b)|root(?:/|\b)|Users(?:/|\b)"
+        r"|usr(?:/|\b)|opt(?:/|\b)|mnt(?:/|\b)|srv(?:/|\b)|bin(?:/|\b)|sbin(?:/|\b)|lib(?:64)?(?:/|\b)"
+        r"|run(?:/|\b)|dev(?:/|\b)|proc(?:/|\b)|sys(?:/|\b)|workspace(?:/|\b)|app(?:/|\b)|data(?:/|\b)"
+        r"|boot(?:/|\b)|private(?:/|\b)|media(?:/|\b))"
+        r"[^\s,;!)]+",
+        protect_link,
+        sanitized,
+        flags=re.I,
+    )
+    sanitized = _redact_response_local_paths(sanitized)
+    for index, link in enumerate(protected_links):
+        sanitized = sanitized.replace(f"__ROOT_DOC_LINK_{index}__", link)
+    sanitized = sanitized.replace("https://redacted-user@", "https://[REDACTED]@")
+
+    if len(sanitized) > MAX_RESPONSE_TEXT:
+        sanitized = sanitized[:MAX_RESPONSE_TEXT] + "...[truncated]"
+    return sanitized
+
+
+def _redact_encoded_sensitive_tokens(value: str) -> str:
+    encoded_token = re.compile(r"\S*%[0-9A-Fa-f]{2}\S*")
+
+    def inspect(match: re.Match) -> str:
+        original = match.group(0)
+        trailing = ""
+        core = original
+        while core and core[-1] in ".,;!?)]":
+            trailing = core[-1] + trailing
+            core = core[:-1]
+        decoded = core
+        for _ in range(3):
+            next_value = unquote_plus(decoded)
+            if next_value == decoded:
+                break
+            decoded = next_value
+        if len(decoded) > 8_192:
+            return "[REDACTED]" + trailing
+        if decoded.lower().startswith(("http://", "https://")):
+            sanitized_url = _sanitize_link_target(decoded)
+            return sanitized_url + trailing if sanitized_url != decoded else original
+        if _RESPONSE_LOCAL_PATH_START.search(decoded):
+            return "<PATH>" + trailing
+        sanitized_decoded = _redact_serialized_authorization(decoded)
+        sanitized_decoded = _AUTHORIZATION_HEADER_PATTERN.sub(r"\1[REDACTED]", sanitized_decoded)
+        sanitized_decoded = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized_decoded)
+        sanitized_decoded = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized_decoded)
+        sanitized_decoded = _SECRET_VALUE_PATTERNS[2].sub("[REDACTED]", sanitized_decoded)
+        sanitized_decoded = _redact_secret_assignments(sanitized_decoded)
+        if sanitized_decoded != decoded:
+            return "[REDACTED]" + trailing
+        return original
+
+    return encoded_token.sub(inspect, value)
+
+
+def _sanitize_link_target(target: str) -> str:
+    trailing = ""
+    while target and target[-1] in ".,;!?":
+        trailing = target[-1] + trailing
+        target = target[:-1]
+    try:
+        parsed = urlsplit(target)
+    except ValueError:
+        fallback = _redact_serialized_authorization(target)
+        fallback = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", fallback)
+        fallback = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", fallback)
+        fallback = _redact_secret_assignments(fallback)
+        return fallback[:2_048] + ("...[truncated]" if len(fallback) > 2_048 else "") + trailing
+    sensitive_keys = {
+        "api_key",
+        "apikey",
+        "authorization",
+        "client_assertion",
+        "code_verifier",
+        "client_assertion",
+        "client_secret",
+        "code_verifier",
+        "code",
+        "credential",
+        "id_token",
+        "key",
+        "password",
+        "secret",
+        "sig",
+        "signature",
+        "subscription_key",
+        "token",
+        "x_api_key",
+    }
+
+    def sanitize_url_component(component: str) -> str:
+        decoded = unquote_plus(component)
+        sanitized_component = _redact_serialized_authorization(decoded)
+        sanitized_component = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized_component)
+        sanitized_component = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized_component)
+        sanitized_component = _SECRET_VALUE_PATTERNS[2].sub("[REDACTED]", sanitized_component)
+        sanitized_component = _redact_secret_assignments(sanitized_component)
+        return component if sanitized_component == decoded else sanitized_component
+
+    def sanitize_parameters(parameters: str) -> str:
+        parts = []
+        for part in parameters.split("&") if parameters else []:
+            key, separator, value = part.partition("=")
+            normalized_key = unquote_plus(key).casefold().replace("-", "_")
+            is_sensitive = (
+                normalized_key in sensitive_keys
+                or normalized_key.endswith("_token")
+                or normalized_key.endswith("_key")
+            )
+            decoded_value = unquote_plus(value)
+            sanitized_value = sanitize_url_component(decoded_value)
+            embedded_secret = sanitized_value != decoded_value
+            parts.append(
+                f"{key}{separator}[REDACTED]"
+                if separator and (is_sensitive or embedded_secret)
+                else (
+                    f"{key}{separator}{value}"
+                    if separator
+                    else sanitize_url_component(part)
+                )
+            )
+        return "&".join(parts)
+
+    netloc = parsed.netloc
+    if "@" in netloc:
+        _userinfo, host = netloc.rsplit("@", 1)
+        netloc = f"[REDACTED]@{host}"
+    fragment = parsed.fragment
+    if "?" in fragment:
+        fragment_path, fragment_query = fragment.split("?", 1)
+        fragment = f"{fragment_path}?{sanitize_parameters(fragment_query)}"
+    else:
+        fragment = sanitize_parameters(fragment)
+
+    return urlunsplit(
+        (
+            parsed.scheme,
+            sanitize_url_component(netloc),
+            sanitize_url_component(parsed.path),
+            sanitize_parameters(parsed.query),
+            fragment,
+        )
+    ) + trailing
+
+
+_RESPONSE_LOCAL_PATH_START = re.compile(
+    r"""(?ix)
+    (?:
+        [A-Z]:[\\/]
+        | (?<!:)\\\\[^\\/\r\n]+[\\/]
+        | (?<!:)//[^/\r\n]+/
+        | /(?:home|tmp|var|etc|root|Users)(?:/|$)
+        | /(?:usr|opt|mnt|srv|bin|sbin|lib|lib64|run|dev|proc|sys)(?:/|$)
+        | /(?:workspace|boot|private|media|app|data)(?:/|$)
+        | \$HOME[\\/]
+        | \$\{HOME\}[\\/]
+        | ~[A-Za-z0-9._-]*[\\/]
+        | %USERPROFILE%[\\/]
+    )
+    """
+)
+
+
+def _redact_response_local_paths(value: str) -> str:
+    value = _redact_quoted_response_paths(value)
+    cursor = 0
+    while match := _RESPONSE_LOCAL_PATH_START.search(value, cursor):
+        end = _scan_unquoted_path_end(value, match.start(), match.end())
+        if end <= match.start():
+            cursor = match.end()
+            continue
+        value = value[:match.start()] + "<PATH>" + value[end:]
+        cursor = match.start() + len("<PATH>")
+    return value
+
+
+def _redact_quoted_response_paths(value: str) -> str:
+    cursor = 0
+    while cursor < len(value):
+        if value[cursor] not in {'"', "'"}:
+            cursor += 1
+            continue
+        quote = value[cursor]
+        start_match = _RESPONSE_LOCAL_PATH_START.match(value, cursor + 1)
+        if not start_match:
+            cursor += 1
+            continue
+        scan = start_match.end()
+        while scan < len(value) and value[scan] not in "\r\n":
+            if value[scan] == quote:
+                following = value[scan + 1] if scan + 1 < len(value) else ""
+                if not following or following.isspace() or following in ".,;:!?)]}":
+                    value = value[:cursor + 1] + "<PATH>" + value[scan:]
+                    cursor += len('"<PATH>"')
+                    break
+            scan += 1
+        else:
+            cursor += 1
+            continue
+    return value
+
+
+def _scan_unquoted_path_end(value: str, start: int, prefix_end: int) -> int:
+    scan = prefix_end
+    while scan < len(value):
+        char = value[scan]
+        if char in "\r\n,;!?\"()[]{}":
+            break
+        if char == "." and (scan + 1 == len(value) or value[scan + 1].isspace()):
+            break
+        if char.isspace():
+            final_component = re.split(r"[\\/]", value[start:scan])[-1]
+            if "." in final_component:
+                break
+            token_start = scan + 1
+            token_end = token_start
+            while token_end < len(value) and not value[token_end].isspace():
+                if value[token_end] in "\r\n,;!?\"()[]{}":
+                    break
+                token_end += 1
+            token = value[token_start:token_end]
+            previous = value[scan - 1] if scan > start else ""
+            following = value[token_end:]
+            if re.fullmatch(
+                r"(?i)(?:and|or|before|then|for|from|with|at|in|on|to|using|should|must|via|exists)",
+                token,
+            ):
+                break
+            extension_ahead = bool(
+                re.match(
+                    r"(?i)^\s+(?:(?!\s+(?:and|or|before|then|for|from|with|at|in|on|to|using|should|must|via)\b)"
+                    r"[^,;!?\"()\[\]{}])*\.[A-Za-z0-9]{1,10}(?=\s|[.,;!?]|$)",
+                    following,
+                )
+            )
+            next_is_boundary = (
+                not following
+                or following[0] in ".,;!?\"()[]{}"
+                or bool(
+                    re.match(
+                        r"\s+(?:and|or|before|then|for|from|with|at|in|on|to|using|should|must|via|exists)\b",
+                        following,
+                        flags=re.I,
+                    )
+                )
+            )
+            if (
+                previous not in "\\/"
+                and not any(separator in token for separator in ("\\", "/"))
+                and "." not in token
+                and not extension_ahead
+                and not next_is_boundary
+            ):
+                break
+        scan += 1
+    return scan
+
+
+def select_servers(server: str | None, servers: list[str] | None) -> dict:
+    """Resolve an explicit server selection without silent fallback."""
+    if server is not None and servers is not None:
+        raise ValueError("--server and --servers cannot be used together")
+    if server is not None:
+        if server not in MCP_SERVERS:
+            raise ValueError(f"unknown server '{_sanitize_identifier(server)}'")
+        return {server: MCP_SERVERS[server]}
+    if servers is not None:
+        if not servers:
+            raise ValueError("--servers requires at least one server")
+        unknown = [name for name in servers if name not in MCP_SERVERS]
+        if unknown:
+            raise ValueError(
+                "unknown server(s): " + ", ".join(_sanitize_identifier(name) for name in unknown)
+            )
+        return {name: MCP_SERVERS[name] for name in servers}
+    return MCP_SERVERS
 
 
 def _bounded_excerpt(value: str | bytes | None, max_chars: int) -> tuple[str, bool]:
@@ -842,6 +1191,8 @@ def run_single_eval(
             status = "success" if evidence_valid else "invalid"
         if status != "success":
             response = ""
+        else:
+            response = _sanitize_response_text(response)
 
         result.update({
             "response": response,
@@ -1119,16 +1470,16 @@ def main():
     scenarios = load_scenarios(Path(args.scenarios))
     print(f"Loaded {len(scenarios)} scenarios from {args.scenarios}")
 
-    servers = MCP_SERVERS
-    if args.server:
-        if args.server not in MCP_SERVERS:
-            print(f"Error: unknown server '{args.server}'. Available: {list(MCP_SERVERS.keys())}", file=sys.stderr)
-            raise SystemExit(1)
-        servers = {args.server: MCP_SERVERS[args.server]}
-    elif args.servers:
-        servers = {k: v for k, v in MCP_SERVERS.items() if k in args.servers}
+    try:
+        servers = select_servers(args.server, args.servers)
+    except ValueError as exc:
+        print(f"Error: {exc}. Available: {list(MCP_SERVERS.keys())}", file=sys.stderr)
+        raise SystemExit(1) from exc
 
-    models = args.models or MODELS
+    if args.models is not None and not args.models:
+        print("Error: --models requires at least one model", file=sys.stderr)
+        raise SystemExit(1)
+    models = args.models if args.models is not None else MODELS
 
     if args.dry_run:
         total = len(scenarios) * len(servers) * len(models)

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -115,8 +115,8 @@ _AUTHORIZATION_ASSIGNMENT_PATTERN = re.compile(
     r"""(?imx)
     \{?
     (?:
-        \\?["']?authorization\\?["']?\s*=\s*
-        | \\?["']authorization\\?["']\s*:\s*
+        (?:\\)*["']?authorization(?:\\)*["']?\s*=\s*
+        | (?:\\)*["']authorization(?:\\)*["']\s*:\s*
     )
     [^\r\n]+(?:\r?\n[ \t]+[^\r\n]*)*
     """
@@ -1397,6 +1397,47 @@ def compare_results(current: dict, baseline_path: str) -> int:
     except json.JSONDecodeError as e:
         print(f"Error: Invalid JSON in baseline file: {e}", file=sys.stderr)
         return 2
+
+    from eval_scorer import score_result, validate_required_matrix
+
+    baseline_results = baseline.get("results", [])
+    required_scenarios = sorted({
+        row.get("scenario_id")
+        for row in baseline_results
+        if isinstance(row, dict) and isinstance(row.get("scenario_id"), str)
+    })
+    required_servers = sorted({
+        row.get("server")
+        for row in baseline_results
+        if isinstance(row, dict) and isinstance(row.get("server"), str)
+    })
+    required_models = sorted({
+        row.get("model")
+        for row in baseline_results
+        if isinstance(row, dict) and isinstance(row.get("model"), str)
+    })
+    azure_required_servers = {
+        row.get("server")
+        for row in baseline_results
+        if isinstance(row, dict)
+        and row.get("azure_required") is True
+        and isinstance(row.get("server"), str)
+    }
+    current_scored = [score_result(row) for row in current.get("results", [])]
+    publication = validate_required_matrix(
+        current_scored,
+        scenario_ids=required_scenarios,
+        servers=required_servers,
+        models=required_models,
+        azure_required_servers=azure_required_servers,
+    )
+    if not publication["allowed"]:
+        print(
+            "Error: Baseline comparison blocked by invalid or incomplete current matrix: "
+            + "; ".join(publication["failure_reasons"]),
+            file=sys.stderr,
+        )
+        return 1
 
     def _success_rates(data: dict) -> dict[str, dict[str, float]]:
         """Compute per-scenario, per-server success rates."""

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -18,6 +18,7 @@ Models:
 import argparse
 import io
 import json
+import math
 import os
 import re
 import subprocess
@@ -105,8 +106,21 @@ MAX_STDOUT_PARSE_BYTES = 128_000
 MAX_STDOUT_PARSE_LINES = 500
 MAX_STDOUT_LINE_BYTES = 64_000
 MAX_IDENTIFIER_TEXT = 256
+MAX_USAGE_METRIC = 10**15
 _SECRET_KEY_PATTERN = re.compile(r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I)
-_AUTHORIZATION_HEADER_PATTERN = re.compile(r"(?im)(authorization\s*:\s*)[^\r\n]+")
+_AUTHORIZATION_HEADER_PATTERN = re.compile(
+    r"(?im)(authorization\s*:\s*)[^\r\n]+(?:\r?\n[ \t]+[^\r\n]*)*"
+)
+_AUTHORIZATION_ASSIGNMENT_PATTERN = re.compile(
+    r"""(?imx)
+    \{?
+    (?:
+        \\?["']?authorization\\?["']?\s*=\s*
+        | \\?["']authorization\\?["']\s*:\s*
+    )
+    [^\r\n]+(?:\r?\n[ \t]+[^\r\n]*)*
+    """
+)
 _SERIALIZED_AUTHORIZATION_KEY_PATTERN = re.compile(
     r"(?i)(?:\\?[\"'])authorization(?:\\?[\"'])\s*[:=]\s*"
 )
@@ -260,6 +274,7 @@ def _sanitize_text(value: str, max_chars: int = MAX_DIAGNOSTIC_TEXT) -> tuple[st
 
     sanitized = _redact_serialized_authorization(sanitized)
     sanitized = _AUTHORIZATION_HEADER_PATTERN.sub(r"\1[REDACTED]", sanitized)
+    sanitized = _AUTHORIZATION_ASSIGNMENT_PATTERN.sub("Authorization=[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[2].sub("[REDACTED]", sanitized)
@@ -357,6 +372,8 @@ def _sanitize_diagnostic_value(value: object, *, depth: int = 0) -> object:
         return sanitized_items
     if isinstance(value, str):
         return _sanitize_text(value)[0]
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
     if value is None or isinstance(value, (bool, int, float)):
         return value
     return _sanitize_text(str(value))[0]
@@ -378,6 +395,7 @@ def _sanitize_response_text(value: str) -> str:
     )
     sanitized = _redact_serialized_authorization(sanitized)
     sanitized = _AUTHORIZATION_HEADER_PATTERN.sub(r"\1[REDACTED]", sanitized)
+    sanitized = _AUTHORIZATION_ASSIGNMENT_PATTERN.sub("Authorization=[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[2].sub("[REDACTED]", sanitized)
@@ -439,6 +457,7 @@ def _redact_encoded_sensitive_tokens(value: str) -> str:
             return "<PATH>" + trailing
         sanitized_decoded = _redact_serialized_authorization(decoded)
         sanitized_decoded = _AUTHORIZATION_HEADER_PATTERN.sub(r"\1[REDACTED]", sanitized_decoded)
+        sanitized_decoded = _AUTHORIZATION_ASSIGNMENT_PATTERN.sub("Authorization=[REDACTED]", sanitized_decoded)
         sanitized_decoded = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized_decoded)
         sanitized_decoded = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized_decoded)
         sanitized_decoded = _SECRET_VALUE_PATTERNS[2].sub("[REDACTED]", sanitized_decoded)
@@ -886,9 +905,14 @@ def parse_event_stream(stdout: str | bytes) -> dict:
                 final_response_line = line_number
             elif content is not None and not isinstance(content, str):
                 parse_errors.append(f"line {line_number}: assistant content must be a string")
-            output_tokens = data.get("outputTokens", 0) or 0
-            if type(output_tokens) is int and output_tokens >= 0:
-                metrics["output_tokens"] += output_tokens
+            output_tokens = data["outputTokens"] if "outputTokens" in data else 0
+            if type(output_tokens) is int and 0 <= output_tokens <= MAX_USAGE_METRIC:
+                if metrics["output_tokens"] + output_tokens <= MAX_USAGE_METRIC:
+                    metrics["output_tokens"] += output_tokens
+                else:
+                    parse_errors.append(
+                        f"line {line_number}: cumulative output token count exceeds {MAX_USAGE_METRIC}"
+                    )
             else:
                 parse_errors.append(f"line {line_number}: output token count must be a non-negative integer")
         elif etype == "tool.execution_start":
@@ -988,11 +1012,28 @@ def parse_event_stream(stdout: str | bytes) -> dict:
                 parse_errors.append(f"line {line_number}: duplicate terminal result")
             result_seen = True
             metrics["result_exit_code"] = event.get("exitCode")
-            usage = event.get("usage", {}) or {}
+            usage = event["usage"] if "usage" in event else {}
             if isinstance(usage, dict):
-                metrics["premium_requests"] = usage.get("premiumRequests")
-                metrics["api_duration_ms"] = usage.get("totalApiDurationMs")
-                metrics["session_duration_ms"] = usage.get("sessionDurationMs")
+                for key, metric_name in (
+                    ("premiumRequests", "premium_requests"),
+                    ("totalApiDurationMs", "api_duration_ms"),
+                    ("sessionDurationMs", "session_duration_ms"),
+                ):
+                    value = usage.get(key)
+                    if value is None:
+                        continue
+                    if (
+                        not isinstance(value, (int, float))
+                        or isinstance(value, bool)
+                        or (isinstance(value, float) and not math.isfinite(value))
+                        or value < 0
+                        or value > MAX_USAGE_METRIC
+                    ):
+                        parse_errors.append(
+                            f"line {line_number}: usage.{key} must be a finite non-negative number"
+                        )
+                        continue
+                    metrics[metric_name] = value
             else:
                 parse_errors.append(f"line {line_number}: result usage must be a JSON object")
 
@@ -1283,15 +1324,22 @@ def run_single_eval(
 
 
 def run_evaluation(
-    scenarios: list[dict],
+    scenarios: list[dict] | None,
     servers: dict | None = None,
     models: list[str] | None = None,
     timeout: int = 120,
     require_azure: bool = False,
 ) -> dict:
     """Run the full evaluation matrix."""
-    servers = servers or MCP_SERVERS
-    models = models or MODELS
+    scenarios = load_scenarios(SCENARIOS_FILE) if scenarios is None else scenarios
+    servers = MCP_SERVERS if servers is None else servers
+    models = MODELS if models is None else models
+    if not scenarios:
+        raise ValueError("scenarios must not be empty")
+    if not servers:
+        raise ValueError("servers must not be empty")
+    if not models:
+        raise ValueError("models must not be empty")
 
     total = len(scenarios) * len(servers) * len(models)
     print(f"Running {total} evaluations: {len(scenarios)} scenarios × "
@@ -1505,7 +1553,7 @@ def main():
     output_path = output_dir / f"run-{run_id}{suffix}.json"
 
     with open(output_path, "w") as f:
-        json.dump(output, f, indent=2)
+        json.dump(output, f, indent=2, allow_nan=False)
 
     print(f"\nResults saved to {output_path}")
     print(f"Total evaluations: {output['metadata']['total_evaluations']}")

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -1452,7 +1452,7 @@ def run_evaluation(
     return {"metadata": run_metadata, "results": results}
 
 
-def compare_results(current: dict, baseline_path: str) -> int:
+def compare_results(current: dict, baseline_path: str, trusted_scenario_definitions: list[dict]) -> int:
     """Compare current results against a baseline run.
 
     Returns exit code 0 for improvement/inconclusive, 1 for regression.
@@ -1468,13 +1468,19 @@ def compare_results(current: dict, baseline_path: str) -> int:
         print(f"Error: Invalid JSON in baseline file: {e}", file=sys.stderr)
         return 2
 
-    from eval_scorer import score_result, validate_required_matrix
+    from eval_scorer import score_result, validate_required_matrix, validate_trusted_scenarios
+
+    try:
+        trusted_scenarios = validate_trusted_scenarios(trusted_scenario_definitions)
+    except ValueError as exc:
+        print(f"Error: Invalid trusted scenarios for baseline comparison: {exc}", file=sys.stderr)
+        return 2
 
     if not isinstance(baseline, dict) or not isinstance(baseline.get("results"), list):
         print("Error: Baseline JSON must be an object with a results array", file=sys.stderr)
         return 2
     baseline_results = baseline["results"]
-    baseline_scored = [score_result(row) for row in baseline_results]
+    baseline_scored = [score_result(row, trusted_scenarios) for row in baseline_results]
     required_scenarios = sorted({
         row.get("scenario_id")
         for row in baseline_scored
@@ -1511,7 +1517,7 @@ def compare_results(current: dict, baseline_path: str) -> int:
             file=sys.stderr,
         )
         return 2
-    current_scored = [score_result(row) for row in current.get("results", [])]
+    current_scored = [score_result(row, trusted_scenarios) for row in current.get("results", [])]
     publication = validate_required_matrix(
         current_scored,
         scenario_ids=required_scenarios,
@@ -1688,7 +1694,7 @@ def main():
     print(f"Total evaluations: {output['metadata']['total_evaluations']}")
 
     if args.baseline:
-        exit_code = compare_results(output, args.baseline)
+        exit_code = compare_results(output, args.baseline, scenarios)
         raise SystemExit(exit_code)
 
 

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -104,6 +104,9 @@ MAX_STDOUT_PARSE_LINES = 500
 MAX_STDOUT_LINE_BYTES = 32_000
 _SECRET_KEY_PATTERN = re.compile(r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I)
 _AUTHORIZATION_HEADER_PATTERN = re.compile(r"(?im)(authorization\s*:\s*)[^\r\n]+")
+_SERIALIZED_AUTHORIZATION_KEY_PATTERN = re.compile(
+    r"(?i)(?:\\?[\"'])authorization(?:\\?[\"'])\s*[:=]\s*"
+)
 _SECRET_VALUE_PATTERNS = (
     re.compile(r"\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]+\b"),
     re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
@@ -231,6 +234,7 @@ def _sanitize_text(value: str, max_chars: int = MAX_DIAGNOSTIC_TEXT) -> tuple[st
         if path:
             sanitized = re.sub(re.escape(path), replacement, sanitized, flags=re.I)
 
+    sanitized = _redact_serialized_authorization(sanitized)
     sanitized = _AUTHORIZATION_HEADER_PATTERN.sub(r"\1[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized)
     sanitized = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized)
@@ -242,6 +246,44 @@ def _sanitize_text(value: str, max_chars: int = MAX_DIAGNOSTIC_TEXT) -> tuple[st
         truncated = True
         sanitized = sanitized[:max_chars] + "...[truncated]"
     return sanitized, truncated
+
+
+def _redact_serialized_authorization(value: str) -> str:
+    """Redact quoted Authorization values, including double-escaped JSON strings."""
+    cursor = 0
+    while match := _SERIALIZED_AUTHORIZATION_KEY_PATTERN.search(value, cursor):
+        value_start = match.end()
+        opening_slashes = 0
+        if value_start < len(value) and value[value_start] == "\\":
+            opening_slashes = 1
+            value_start += 1
+        if value_start >= len(value) or value[value_start] not in {'"', "'"}:
+            cursor = match.end()
+            continue
+
+        quote = value[value_start]
+        value_content_start = value_start + 1
+        scan = value_content_start
+        while scan < len(value):
+            if value[scan] == quote:
+                slash_count = 0
+                slash_index = scan - 1
+                while slash_index >= value_content_start and value[slash_index] == "\\":
+                    slash_count += 1
+                    slash_index -= 1
+                if slash_count == opening_slashes:
+                    value = value[:value_content_start] + "[REDACTED]" + value[scan:]
+                    cursor = value_content_start + len("[REDACTED]") + 1
+                    break
+            if value[scan] in "\r\n":
+                value = value[:value_content_start] + "[REDACTED]" + value[scan:]
+                cursor = value_content_start + len("[REDACTED]")
+                break
+            scan += 1
+        else:
+            value = value[:value_content_start] + "[REDACTED]"
+            cursor = len(value)
+    return value
 
 
 def _sanitize_diagnostic_value(value: object, *, depth: int = 0) -> object:
@@ -363,6 +405,11 @@ def _contains_oversized_diagnostic_value(value: object, *, depth: int = 0) -> bo
     return isinstance(value, str) and len(value) > MAX_DIAGNOSTIC_TEXT
 
 
+def serialized_diagnostic_events_size(events: list[dict]) -> int:
+    """Return the exact persisted JSON list-envelope size for diagnostics events."""
+    return len(json.dumps(events, ensure_ascii=True, separators=(",", ":")))
+
+
 def _empty_diagnostics() -> dict:
     return {
         "events": [],
@@ -431,11 +478,9 @@ def parse_event_stream(stdout: str | bytes) -> dict:
     completed_tool_calls: set[str] = set()
     final_response_line: int | None = None
     last_successful_tool_line: int | None = None
-    diagnostic_event_chars = 0
     mcp_statuses: dict[str, tuple[str, str | None]] = {}
 
     def add_diagnostic(event_type: str, data: dict) -> None:
-        nonlocal diagnostic_event_chars
         if len(metrics["diagnostic_events"]) >= MAX_DIAGNOSTIC_EVENTS:
             metrics["diagnostic_events_truncated"] = True
             return
@@ -443,12 +488,11 @@ def parse_event_stream(stdout: str | bytes) -> dict:
             "event_type": event_type,
             "data": _sanitize_diagnostic_value(data),
         }
-        diagnostic_chars = len(json.dumps(diagnostic, ensure_ascii=True))
-        if diagnostic_event_chars + diagnostic_chars > MAX_DIAGNOSTIC_EVENTS_CHARS:
+        candidate_events = [*metrics["diagnostic_events"], diagnostic]
+        if serialized_diagnostic_events_size(candidate_events) > MAX_DIAGNOSTIC_EVENTS_CHARS:
             metrics["diagnostic_events_truncated"] = True
             return
         metrics["diagnostic_events"].append(diagnostic)
-        diagnostic_event_chars += diagnostic_chars
 
     lines, boundary_errors, boundary_truncated = _bounded_event_lines(stdout)
     parse_errors.extend(boundary_errors)

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -1481,11 +1481,7 @@ def compare_results(current: dict, baseline_path: str, trusted_scenario_definiti
         return 2
     baseline_results = baseline["results"]
     baseline_scored = [score_result(row, trusted_scenarios) for row in baseline_results]
-    required_scenarios = sorted({
-        row.get("scenario_id")
-        for row in baseline_scored
-        if isinstance(row, dict) and isinstance(row.get("scenario_id"), str)
-    })
+    required_scenarios = sorted(trusted_scenarios)
     required_servers = sorted({
         row.get("server")
         for row in baseline_scored

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -101,7 +101,8 @@ MAX_STDOUT_EXCERPT = 12_000
 MAX_STDERR_EXCERPT = 4_000
 MAX_STDOUT_PARSE_BYTES = 128_000
 MAX_STDOUT_PARSE_LINES = 500
-MAX_STDOUT_LINE_BYTES = 32_000
+MAX_STDOUT_LINE_BYTES = 64_000
+MAX_IDENTIFIER_TEXT = 256
 _SECRET_KEY_PATTERN = re.compile(r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I)
 _AUTHORIZATION_HEADER_PATTERN = re.compile(r"(?im)(authorization\s*:\s*)[^\r\n]+")
 _SERIALIZED_AUTHORIZATION_KEY_PATTERN = re.compile(
@@ -319,6 +320,10 @@ def _sanitize_diagnostic_value(value: object, *, depth: int = 0) -> object:
     return _sanitize_text(str(value))[0]
 
 
+def _sanitize_identifier(value: object) -> str:
+    return _sanitize_text(str(value), max_chars=MAX_IDENTIFIER_TEXT)[0]
+
+
 def _bounded_excerpt(value: str | bytes | None, max_chars: int) -> tuple[str, bool]:
     return _sanitize_text(_coerce_process_text(value), max_chars=max_chars)
 
@@ -461,6 +466,8 @@ def parse_event_stream(stdout: str | bytes) -> dict:
         "parse_error": None,
         "observed_tools": [],
         "successful_tools": [],
+        "_observed_tools_raw": [],
+        "_successful_tools_raw": [],
         "diagnostic_events": [],
         "diagnostic_events_truncated": False,
         "mcp_failure": None,
@@ -542,11 +549,14 @@ def parse_event_stream(stdout: str | bytes) -> dict:
                 parse_errors.append(f"line {line_number}: tool start missing identity")
                 continue
             if tool_call_id in started_tools:
-                parse_errors.append(f"line {line_number}: duplicate tool start for {tool_call_id}")
+                parse_errors.append(
+                    f"line {line_number}: duplicate tool start for {_sanitize_identifier(tool_call_id)}"
+                )
                 continue
             started_tools[tool_call_id] = tool_name
-            if tool_name not in metrics["observed_tools"]:
-                metrics["observed_tools"].append(tool_name)
+            if tool_name not in metrics["_observed_tools_raw"]:
+                metrics["_observed_tools_raw"].append(tool_name)
+                metrics["observed_tools"].append(_sanitize_identifier(tool_name))
         elif etype == "tool.execution_complete":
             metrics["tool_calls"] += 1
             tool_call_id = data.get("toolCallId")
@@ -558,20 +568,24 @@ def parse_event_stream(stdout: str | bytes) -> dict:
             ):
                 parse_errors.append(f"line {line_number}: tool completion missing matching start")
             elif tool_call_id in completed_tool_calls:
-                parse_errors.append(f"line {line_number}: duplicate tool completion for {tool_call_id}")
+                parse_errors.append(
+                    f"line {line_number}: duplicate tool completion for {_sanitize_identifier(tool_call_id)}"
+                )
             elif tool_name != started_tools[tool_call_id]:
                 parse_errors.append(
-                    f"line {line_number}: tool completion name {tool_name} does not match "
-                    f"start name {started_tools[tool_call_id]}"
+                    f"line {line_number}: tool completion name {_sanitize_identifier(tool_name)} does not match "
+                    f"start name {_sanitize_identifier(started_tools[tool_call_id])}"
                 )
             else:
                 completed_tool_calls.add(tool_call_id)
-                if tool_name not in metrics["observed_tools"]:
-                    metrics["observed_tools"].append(tool_name)
+                if tool_name not in metrics["_observed_tools_raw"]:
+                    metrics["_observed_tools_raw"].append(tool_name)
+                    metrics["observed_tools"].append(_sanitize_identifier(tool_name))
                 if type(data.get("success")) is not bool:
                     parse_errors.append(f"line {line_number}: tool completion missing Boolean success")
-                elif data["success"] is True and tool_name not in metrics["successful_tools"]:
-                    metrics["successful_tools"].append(tool_name)
+                elif data["success"] is True and tool_name not in metrics["_successful_tools_raw"]:
+                    metrics["_successful_tools_raw"].append(tool_name)
+                    metrics["successful_tools"].append(_sanitize_identifier(tool_name))
                     last_successful_tool_line = line_number
             if data.get("success") is False:
                 metrics["tool_errors"] += 1
@@ -689,13 +703,14 @@ def validate_row_evidence(parsed: dict, tool_prefix: str, azure_required: bool) 
     if parsed["tool_errors"]:
         return False, f"tool_error: {parsed['tool_errors']} tool execution(s) failed", False
 
-    observed_tools = parsed["observed_tools"]
+    observed_tools = parsed["_observed_tools_raw"]
     cross_source_tools = [name for name in observed_tools if _source_for_tool(name) != tool_prefix]
     if cross_source_tools:
-        return False, f"cross_source_tool_call: {', '.join(cross_source_tools)}", False
+        sanitized_tools = [_sanitize_identifier(name) for name in cross_source_tools]
+        return False, f"cross_source_tool_call: {', '.join(sanitized_tools)}", False
     if not observed_tools:
         return False, "source_selection_unproven: no documentation tool calls observed", False
-    if not any(_source_for_tool(name) == tool_prefix for name in parsed["successful_tools"]):
+    if not any(_source_for_tool(name) == tool_prefix for name in parsed["_successful_tools_raw"]):
         return False, "source_selection_unproven: no selected-source tool completed successfully", False
     if not parsed["response"]:
         return False, "missing_response: no assistant response event contained content", False
@@ -704,7 +719,7 @@ def validate_row_evidence(parsed: dict, tool_prefix: str, azure_required: bool) 
         azure_required
         and any(
             _tool_matches_source(name, tool_prefix) and _is_search_tool(name)
-            for name in parsed["successful_tools"]
+            for name in parsed["_successful_tools_raw"]
         )
     )
     if azure_required and not azure_live_query_proven:

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -18,6 +18,7 @@ Models:
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -91,6 +92,25 @@ KNOWN_TOOL_PREFIXES = tuple(
         key=len,
         reverse=True,
     )
+)
+MAX_DIAGNOSTIC_EVENTS = 20
+MAX_DIAGNOSTIC_EVENTS_CHARS = 50_000
+MAX_DIAGNOSTIC_TEXT = 2_000
+MAX_STDOUT_EXCERPT = 12_000
+MAX_STDERR_EXCERPT = 4_000
+_SECRET_KEY_PATTERN = re.compile(r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I)
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"\b(?:github_pat_|gh[pousr]_)[A-Za-z0-9_]+\b"),
+    re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
+    re.compile(
+        r"(?i)([\"']?[A-Z0-9_-]{0,128}(?:api[_-]?key|authorization|credential|password|secret|token)"
+        r"[\"']?\s*[:=]\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;}]+)"
+    ),
+)
+_ABSOLUTE_PATH_PATTERNS = (
+    re.compile(r"(?i)\\\\[^\\\r\n]+\\[^,\r\n;\"']+"),
+    re.compile(r"(?i)\b[A-Z]:\\[^,\r\n;\"']+"),
+    re.compile(r"(?<![:/\w])/(?:[^/\s]+/)+[^,\s;\"']+"),
 )
 
 
@@ -184,6 +204,142 @@ def _is_search_tool(tool_name: str) -> bool:
     return "search_docs" in normalized or normalized.endswith("_search")
 
 
+def _coerce_process_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _sanitize_text(value: str, max_chars: int = MAX_DIAGNOSTIC_TEXT) -> tuple[str, bool]:
+    """Redact common secrets and local paths, then bound diagnostic text."""
+    pre_redaction_limit = max_chars * 4
+    truncated = len(value) > pre_redaction_limit
+    sanitized = value[:pre_redaction_limit]
+    path_replacements = (
+        (str(PROJECT_ROOT), "<PROJECT_ROOT>"),
+        (str(Path.home()), "<HOME>"),
+        (tempfile.gettempdir(), "<TEMP>"),
+    )
+    for path, replacement in path_replacements:
+        if path:
+            sanitized = re.sub(re.escape(path), replacement, sanitized, flags=re.I)
+
+    sanitized = _SECRET_VALUE_PATTERNS[0].sub("[REDACTED]", sanitized)
+    sanitized = _SECRET_VALUE_PATTERNS[1].sub(r"\1[REDACTED]", sanitized)
+    sanitized = _SECRET_VALUE_PATTERNS[2].sub(r"\1[REDACTED]", sanitized)
+    for pattern in _ABSOLUTE_PATH_PATTERNS:
+        sanitized = pattern.sub("<PATH>", sanitized)
+
+    if len(sanitized) > max_chars:
+        truncated = True
+        sanitized = sanitized[:max_chars] + "...[truncated]"
+    return sanitized, truncated
+
+
+def _sanitize_diagnostic_value(value: object, *, depth: int = 0) -> object:
+    if depth >= 4:
+        return "[truncated-depth]"
+    if isinstance(value, dict):
+        sanitized = {}
+        for index, (key, child) in enumerate(value.items()):
+            if index >= 20:
+                sanitized["_truncated_fields"] = True
+                break
+            raw_key_text = str(key)
+            key_text = _sanitize_text(raw_key_text)[0]
+            lowered_key = key_text.casefold()
+            if lowered_key in {"arguments", "input", "request", "headers", "env", "environment"}:
+                sanitized[key_text] = "[OMITTED]"
+                continue
+            sanitized[key_text] = (
+                "[REDACTED]"
+                if _SECRET_KEY_PATTERN.search(raw_key_text)
+                else _sanitize_diagnostic_value(child, depth=depth + 1)
+            )
+        return sanitized
+    if isinstance(value, list):
+        sanitized_items = [_sanitize_diagnostic_value(item, depth=depth + 1) for item in value[:20]]
+        if len(value) > 20:
+            sanitized_items.append("[truncated-items]")
+        return sanitized_items
+    if isinstance(value, str):
+        return _sanitize_text(value)[0]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return _sanitize_text(str(value))[0]
+
+
+def _bounded_excerpt(value: str | bytes | None, max_chars: int) -> tuple[str, bool]:
+    return _sanitize_text(_coerce_process_text(value), max_chars=max_chars)
+
+
+def _bounded_stdout_excerpt(value: str | bytes | None) -> tuple[str, bool]:
+    sanitized_lines = []
+    per_line_truncated = False
+    for line in _coerce_process_text(value).splitlines():
+        try:
+            parsed_line = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            sanitized_line, truncated = _sanitize_text(line)
+            sanitized_lines.append(sanitized_line)
+            per_line_truncated = per_line_truncated or truncated
+        else:
+            per_line_truncated = per_line_truncated or _contains_oversized_diagnostic_value(parsed_line)
+            sanitized_lines.append(json.dumps(_sanitize_diagnostic_value(parsed_line), ensure_ascii=True))
+    excerpt, final_truncated = _sanitize_text("\n".join(sanitized_lines), max_chars=MAX_STDOUT_EXCERPT)
+    return excerpt, per_line_truncated or final_truncated
+
+
+def _contains_oversized_diagnostic_value(value: object, *, depth: int = 0) -> bool:
+    if depth >= 4:
+        return True
+    if isinstance(value, dict):
+        return len(value) > 20 or any(
+            len(str(key)) > MAX_DIAGNOSTIC_TEXT
+            or _contains_oversized_diagnostic_value(child, depth=depth + 1)
+            for key, child in value.items()
+        )
+    if isinstance(value, list):
+        return len(value) > 20 or any(
+            _contains_oversized_diagnostic_value(item, depth=depth + 1)
+            for item in value
+        )
+    return isinstance(value, str) and len(value) > MAX_DIAGNOSTIC_TEXT
+
+
+def _empty_diagnostics() -> dict:
+    return {
+        "events": [],
+        "events_truncated": False,
+        "stdout_excerpt": "",
+        "stdout_truncated": False,
+        "stderr_excerpt": "",
+        "stderr_truncated": False,
+    }
+
+
+def _build_diagnostics(
+    parsed: dict | None,
+    stdout: str | bytes | None,
+    stderr: str | bytes | None,
+    *,
+    preserve_stdout: bool,
+) -> dict:
+    diagnostics = _empty_diagnostics()
+    if parsed is not None:
+        diagnostics["events"] = parsed["diagnostic_events"]
+        diagnostics["events_truncated"] = parsed["diagnostic_events_truncated"]
+    if preserve_stdout:
+        diagnostics["stdout_excerpt"], diagnostics["stdout_truncated"] = _bounded_stdout_excerpt(stdout)
+    diagnostics["stderr_excerpt"], diagnostics["stderr_truncated"] = _bounded_excerpt(
+        stderr,
+        MAX_STDERR_EXCERPT,
+    )
+    return diagnostics
+
+
 def parse_event_stream(stdout: str) -> dict:
     """Parse `copilot --output-format json` JSONL output into operational metrics.
 
@@ -204,6 +360,9 @@ def parse_event_stream(stdout: str) -> dict:
         "parse_error": None,
         "observed_tools": [],
         "successful_tools": [],
+        "diagnostic_events": [],
+        "diagnostic_events_truncated": False,
+        "mcp_failure": None,
     }
 
     last_message_content = ""
@@ -215,6 +374,23 @@ def parse_event_stream(stdout: str) -> dict:
     completed_tool_calls: set[str] = set()
     final_response_line: int | None = None
     last_successful_tool_line: int | None = None
+    diagnostic_event_chars = 0
+
+    def add_diagnostic(event_type: str, data: dict) -> None:
+        nonlocal diagnostic_event_chars
+        if len(metrics["diagnostic_events"]) >= MAX_DIAGNOSTIC_EVENTS:
+            metrics["diagnostic_events_truncated"] = True
+            return
+        diagnostic = {
+            "event_type": event_type,
+            "data": _sanitize_diagnostic_value(data),
+        }
+        diagnostic_chars = len(json.dumps(diagnostic, ensure_ascii=True))
+        if diagnostic_event_chars + diagnostic_chars > MAX_DIAGNOSTIC_EVENTS_CHARS:
+            metrics["diagnostic_events_truncated"] = True
+            return
+        metrics["diagnostic_events"].append(diagnostic)
+        diagnostic_event_chars += diagnostic_chars
 
     for line_number, line in enumerate(stdout.splitlines(), start=1):
         line = line.strip()
@@ -296,6 +472,25 @@ def parse_event_stream(stdout: str) -> dict:
                     last_successful_tool_line = line_number
             if data.get("success") is False:
                 metrics["tool_errors"] += 1
+                add_diagnostic(
+                    etype,
+                    {
+                        "toolName": tool_name,
+                        "success": False,
+                        "error": data.get("error"),
+                        "result": data.get("result"),
+                    },
+                )
+        elif etype == "session.mcp_server_status_changed":
+            add_diagnostic(etype, data)
+            status = str(data.get("status") or data.get("state") or "").casefold()
+            error = data.get("error") or data.get("message")
+            if error or status in {"error", "failed", "failure", "stopped", "unavailable", "disconnected"}:
+                raw_server = data.get("serverName") or data.get("server") or data.get("name") or "selected MCP server"
+                server = _sanitize_text(str(raw_server))[0]
+                detail = error or f"status changed to {status or 'unknown'}"
+                sanitized_detail = _sanitize_text(str(detail))[0]
+                metrics["mcp_failure"] = f"{server}: {sanitized_detail}"
         elif etype == "result":
             if result_seen:
                 parse_errors.append(f"line {line_number}: duplicate terminal result")
@@ -335,6 +530,8 @@ def parse_event_stream(stdout: str) -> dict:
 
 def validate_row_evidence(parsed: dict, tool_prefix: str, azure_required: bool) -> tuple[bool, str | None, bool]:
     """Validate selected-source and optional Azure evidence for one row."""
+    if parsed["mcp_failure"]:
+        return False, f"mcp_initialization_failure: {parsed['mcp_failure']}", False
     if parsed["parse_error"]:
         return False, f"event_parse_failure: {parsed['parse_error']}", False
     if parsed["tool_errors"]:
@@ -395,6 +592,7 @@ def run_single_eval(
         "source_validated": False,
         "azure_required": False,
         "azure_live_query_proven": False,
+        "diagnostics": _empty_diagnostics(),
     }
 
     start_time = time.monotonic()
@@ -422,6 +620,7 @@ def run_single_eval(
             "api_duration_ms": None,
             "session_duration_ms": None,
             "event_parse_error": None,
+            "diagnostics": _build_diagnostics(None, None, str(exc), preserve_stdout=False),
         })
         return result
 
@@ -457,7 +656,7 @@ def run_single_eval(
             )
 
         elapsed = time.monotonic() - start_time
-        parsed = parse_event_stream(proc.stdout)
+        parsed = parse_event_stream(_coerce_process_text(proc.stdout))
         response = parsed["response"]
         evidence_valid, failure_reason, azure_live_query_proven = validate_row_evidence(
             parsed,
@@ -466,16 +665,18 @@ def run_single_eval(
         )
         if proc.returncode != 0:
             status = "error"
-            failure_reason = f"process_exit_code: {proc.returncode}"
+            process_failure = f"process_exit_code: {proc.returncode}"
+            failure_reason = f"{failure_reason}; {process_failure}" if failure_reason else process_failure
         elif parsed["result_exit_code"] not in (0, None):
             status = "invalid"
-            failure_reason = f"event_result_exit_code: {parsed['result_exit_code']}"
+            event_failure = f"event_result_exit_code: {parsed['result_exit_code']}"
+            failure_reason = f"{failure_reason}; {event_failure}" if failure_reason else event_failure
         else:
             status = "success" if evidence_valid else "invalid"
 
         result.update({
             "response": response,
-            "stderr": proc.stderr.strip() if proc.stderr else "",
+            "stderr": _bounded_excerpt(proc.stderr, MAX_STDERR_EXCERPT)[0],
             "exit_code": proc.returncode,
             "response_time_seconds": round(elapsed, 2),
             "status": status,
@@ -494,26 +695,47 @@ def run_single_eval(
             "api_duration_ms": parsed["api_duration_ms"],
             "session_duration_ms": parsed["session_duration_ms"],
             "event_parse_error": parsed["parse_error"],
+            "diagnostics": _build_diagnostics(
+                parsed,
+                proc.stdout,
+                proc.stderr,
+                preserve_stdout=not evidence_valid,
+            ),
         })
 
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
         elapsed = time.monotonic() - start_time
+        partial_stdout = _coerce_process_text(exc.stdout)
+        partial_stderr = _coerce_process_text(exc.stderr)
+        parsed = parse_event_stream(partial_stdout) if partial_stdout else None
         result.update({
             "response": "",
-            "stderr": f"Timed out after {timeout}s",
+            "stderr": _bounded_excerpt(
+                partial_stderr or f"Timed out after {timeout}s",
+                MAX_STDERR_EXCERPT,
+            )[0],
             "exit_code": -1,
             "response_time_seconds": round(elapsed, 2),
             "status": "timeout",
             "passed": False,
+            "response_present": False,
             "failure_reason": f"timeout: exceeded {timeout}s",
-            "turns": 0,
-            "tool_calls": 0,
-            "tool_errors": 0,
-            "output_tokens": 0,
-            "premium_requests": None,
-            "api_duration_ms": None,
-            "session_duration_ms": None,
-            "event_parse_error": None,
+            "observed_tools": parsed["observed_tools"] if parsed else [],
+            "successful_tools": parsed["successful_tools"] if parsed else [],
+            "turns": parsed["turns"] if parsed else 0,
+            "tool_calls": parsed["tool_calls"] if parsed else 0,
+            "tool_errors": parsed["tool_errors"] if parsed else 0,
+            "output_tokens": parsed["output_tokens"] if parsed else 0,
+            "premium_requests": parsed["premium_requests"] if parsed else None,
+            "api_duration_ms": parsed["api_duration_ms"] if parsed else None,
+            "session_duration_ms": parsed["session_duration_ms"] if parsed else None,
+            "event_parse_error": parsed["parse_error"] if parsed else None,
+            "diagnostics": _build_diagnostics(
+                parsed,
+                partial_stdout,
+                partial_stderr,
+                preserve_stdout=True,
+            ),
         })
     except OSError as exc:
         elapsed = time.monotonic() - start_time
@@ -533,6 +755,7 @@ def run_single_eval(
             "api_duration_ms": None,
             "session_duration_ms": None,
             "event_parse_error": None,
+            "diagnostics": _build_diagnostics(None, None, str(exc), preserve_stdout=False),
         })
 
     return result

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -107,6 +107,9 @@ MAX_STDOUT_PARSE_LINES = 500
 MAX_STDOUT_LINE_BYTES = 64_000
 MAX_IDENTIFIER_TEXT = 256
 MAX_USAGE_METRIC = 10**15
+MAX_ENCODED_TOKEN_BYTES = 8_192
+MAX_ENCODED_DECODE_ITERATIONS = 8
+MAX_ENCODED_DECODE_SECONDS = 0.02
 _SECRET_KEY_PATTERN = re.compile(r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I)
 _AUTHORIZATION_HEADER_PATTERN = re.compile(
     r"(?im)(authorization\s*:\s*)[^\r\n]+(?:\r?\n[ \t]+[^\r\n]*)*"
@@ -434,6 +437,28 @@ def _sanitize_response_text(value: str) -> str:
 
 def _redact_encoded_sensitive_tokens(value: str) -> str:
     encoded_token = re.compile(r"\S*%[0-9A-Fa-f]{2}\S*")
+    lines = value.splitlines(keepends=True)
+    redacted_lines = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        decoded = _bounded_stable_decode(line.rstrip("\r\n"))
+        redacted_lines.append(_redact_encoded_authorization_line(line))
+        if decoded is not None:
+            key_only = bool(
+                re.search(
+                    r"""(?ix)\{?(?:\\)*["']?authorization(?:\\)*["']?\s*[:=]\s*$""",
+                    decoded,
+                )
+            )
+            if key_only:
+                redacted_lines[-1] = "[REDACTED]" + line[len(line.rstrip("\r\n")):]
+                index += 1
+                while index < len(lines) and lines[index].startswith((" ", "\t")):
+                    index += 1
+                continue
+        index += 1
+    value = "".join(redacted_lines)
 
     def inspect(match: re.Match) -> str:
         original = match.group(0)
@@ -442,13 +467,22 @@ def _redact_encoded_sensitive_tokens(value: str) -> str:
         while core and core[-1] in ".,;!?)]":
             trailing = core[-1] + trailing
             core = core[:-1]
+        if len(core.encode("utf-8", errors="replace")) > MAX_ENCODED_TOKEN_BYTES:
+            return "[REDACTED]" + trailing
         decoded = core
-        for _ in range(3):
+        deadline = time.monotonic() + MAX_ENCODED_DECODE_SECONDS
+        stable = False
+        for _ in range(MAX_ENCODED_DECODE_ITERATIONS):
+            if time.monotonic() > deadline:
+                return "[REDACTED]" + trailing
             next_value = unquote_plus(decoded)
+            if len(next_value.encode("utf-8", errors="replace")) > MAX_ENCODED_TOKEN_BYTES:
+                return "[REDACTED]" + trailing
             if next_value == decoded:
+                stable = True
                 break
             decoded = next_value
-        if len(decoded) > 8_192:
+        if not stable:
             return "[REDACTED]" + trailing
         if decoded.lower().startswith(("http://", "https://")):
             sanitized_url = _sanitize_link_target(decoded)
@@ -467,6 +501,42 @@ def _redact_encoded_sensitive_tokens(value: str) -> str:
         return original
 
     return encoded_token.sub(inspect, value)
+
+
+def _redact_encoded_authorization_line(line: str) -> str:
+    if "%" not in line:
+        return line
+    core = line.rstrip("\r\n")
+    newline = line[len(core):]
+    if len(core.encode("utf-8", errors="replace")) > MAX_ENCODED_TOKEN_BYTES:
+        return "[REDACTED]" + newline
+    decoded = _bounded_stable_decode(core)
+    if decoded is None:
+        return "[REDACTED]" + newline
+    if (
+        _AUTHORIZATION_HEADER_PATTERN.search(decoded)
+        or _AUTHORIZATION_ASSIGNMENT_PATTERN.search(decoded)
+        or _SERIALIZED_AUTHORIZATION_KEY_PATTERN.search(decoded)
+    ):
+        return "[REDACTED]" + newline
+    return line
+
+
+def _bounded_stable_decode(value: str) -> str | None:
+    if len(value.encode("utf-8", errors="replace")) > MAX_ENCODED_TOKEN_BYTES:
+        return None
+    decoded = value
+    deadline = time.monotonic() + MAX_ENCODED_DECODE_SECONDS
+    for _ in range(MAX_ENCODED_DECODE_ITERATIONS):
+        if time.monotonic() > deadline:
+            return None
+        next_value = unquote_plus(decoded)
+        if len(next_value.encode("utf-8", errors="replace")) > MAX_ENCODED_TOKEN_BYTES:
+            return None
+        if next_value == decoded:
+            return decoded
+        decoded = next_value
+    return None
 
 
 def _sanitize_link_target(target: str) -> str:
@@ -1400,29 +1470,47 @@ def compare_results(current: dict, baseline_path: str) -> int:
 
     from eval_scorer import score_result, validate_required_matrix
 
-    baseline_results = baseline.get("results", [])
+    if not isinstance(baseline, dict) or not isinstance(baseline.get("results"), list):
+        print("Error: Baseline JSON must be an object with a results array", file=sys.stderr)
+        return 2
+    baseline_results = baseline["results"]
+    baseline_scored = [score_result(row) for row in baseline_results]
     required_scenarios = sorted({
         row.get("scenario_id")
-        for row in baseline_results
+        for row in baseline_scored
         if isinstance(row, dict) and isinstance(row.get("scenario_id"), str)
     })
     required_servers = sorted({
         row.get("server")
-        for row in baseline_results
+        for row in baseline_scored
         if isinstance(row, dict) and isinstance(row.get("server"), str)
     })
     required_models = sorted({
         row.get("model")
-        for row in baseline_results
+        for row in baseline_scored
         if isinstance(row, dict) and isinstance(row.get("model"), str)
     })
     azure_required_servers = {
         row.get("server")
-        for row in baseline_results
+        for row in baseline_scored
         if isinstance(row, dict)
         and row.get("azure_required") is True
         and isinstance(row.get("server"), str)
     }
+    baseline_publication = validate_required_matrix(
+        baseline_scored,
+        scenario_ids=required_scenarios,
+        servers=required_servers,
+        models=required_models,
+        azure_required_servers=azure_required_servers,
+    )
+    if not baseline_publication["allowed"]:
+        print(
+            "Error: Baseline comparison blocked by invalid baseline matrix: "
+            + "; ".join(baseline_publication["failure_reasons"]),
+            file=sys.stderr,
+        )
+        return 2
     current_scored = [score_result(row) for row in current.get("results", [])]
     publication = validate_required_matrix(
         current_scored,
@@ -1456,8 +1544,8 @@ def compare_results(current: dict, baseline_path: str) -> int:
             for scenario, servers in rates.items()
         }
 
-    baseline_rates = _success_rates(baseline)
-    current_rates = _success_rates(current)
+    baseline_rates = _success_rates({"results": baseline_scored})
+    current_rates = _success_rates({"results": current_scored})
 
     THRESHOLD = 0.05
     verdicts: list[dict] = []

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -893,14 +893,15 @@ def run_single_eval(
         })
     except OSError as exc:
         elapsed = time.monotonic() - start_time
+        sanitized_error = _sanitize_text(str(exc), max_chars=MAX_STDERR_EXCERPT)[0]
         result.update({
             "response": "",
-            "stderr": str(exc),
+            "stderr": sanitized_error,
             "exit_code": -1,
             "response_time_seconds": round(elapsed, 2),
             "status": "error",
             "passed": False,
-            "failure_reason": f"process_launch_error: {exc}",
+            "failure_reason": f"process_launch_error: {sanitized_error}",
             "turns": 0,
             "tool_calls": 0,
             "tool_errors": 0,
@@ -909,7 +910,7 @@ def run_single_eval(
             "api_duration_ms": None,
             "session_duration_ms": None,
             "event_parse_error": None,
-            "diagnostics": _build_diagnostics(None, None, str(exc), preserve_stdout=False),
+            "diagnostics": _build_diagnostics(None, None, sanitized_error, preserve_stdout=False),
         })
 
     return result

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -15,7 +15,7 @@ from fastmcp import Client
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from eval_report import generate_report  # noqa: E402
-from eval_scorer import aggregate_scores, score_result, validate_required_matrix  # noqa: E402
+from eval_scorer import aggregate_scores, score_result, validate_required_matrix, validate_row_schema  # noqa: E402
 from foundry_docs_mcp._server_factory import DOCS_CONFIG, build_server  # noqa: E402
 from run_docs_eval import MCP_SERVERS, build_mcp_config, parse_event_stream, run_single_eval  # noqa: E402
 
@@ -95,6 +95,14 @@ def _raw_row(
         "azure_live_query_proven": False,
         "failure_reason": failure_reason,
         "event_parse_error": None,
+        "diagnostics": {
+            "events": [],
+            "events_truncated": False,
+            "stdout_excerpt": "",
+            "stdout_truncated": False,
+            "stderr_excerpt": "",
+            "stderr_truncated": False,
+        },
         "exit_code": 0 if valid else -1,
         "rubric": SCENARIO["rubric"],
         "turns": 1,
@@ -252,7 +260,26 @@ def test_azure_required_row_needs_successful_selected_search(monkeypatch):
 
 def test_timeout_is_preserved_as_invalid_row_diagnostics(monkeypatch):
     def time_out(cmd, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+        partial_events = "\n".join([
+            json.dumps({
+                "type": "session.mcp_server_status_changed",
+                "data": {
+                    "serverName": "foundry_docs",
+                    "status": "failed",
+                    "error": "API_KEY=super-secret at C:\\Users\\someone\\repo",
+                },
+            }),
+            json.dumps({
+                "type": "tool.execution_start",
+                "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+            }),
+        ])
+        raise subprocess.TimeoutExpired(
+            cmd=cmd,
+            timeout=kwargs["timeout"],
+            output=partial_events.encode(),
+            stderr=b"Bearer abc.def.ghi from C:\\Users\\someone\\repo",
+        )
 
     monkeypatch.setattr(subprocess, "run", time_out)
 
@@ -268,6 +295,328 @@ def test_timeout_is_preserved_as_invalid_row_diagnostics(monkeypatch):
     assert result["response_present"] is False
     assert result["failure_reason"] == "timeout: exceeded 3s"
     assert result["response_time_seconds"] >= 0
+    assert result["observed_tools"] == ["foundry_docs-search_docs"]
+    assert result["diagnostics"]["events"][0]["event_type"] == "session.mcp_server_status_changed"
+    assert "API_KEY=[REDACTED]" in result["diagnostics"]["events"][0]["data"]["error"]
+    assert "<PATH>" in result["diagnostics"]["events"][0]["data"]["error"]
+    assert "super-secret" not in result["diagnostics"]["stdout_excerpt"]
+    assert "Bearer [REDACTED]" in result["diagnostics"]["stderr_excerpt"]
+    assert result["response"] == ""
+
+    scored = score_result(result)
+    publication = validate_required_matrix(
+        [scored],
+        scenario_ids=["scenario-1"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+    )
+    assert publication["allowed"] is False
+
+
+def test_mcp_initialization_failure_preserves_sanitized_lifecycle_diagnostics(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_server_status_changed",
+            "data": {
+                "serverName": "foundry_docs",
+                "status": "failed",
+                "error": "token=top-secret failed in C:\\Users\\someone\\repo",
+                "authorization": "Bearer should-never-survive",
+            },
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["failure_reason"].startswith("mcp_initialization_failure:")
+    assert "source_selection_unproven" not in result["failure_reason"]
+    diagnostic = result["diagnostics"]["events"][0]
+    assert diagnostic["event_type"] == "session.mcp_server_status_changed"
+    assert diagnostic["data"]["status"] == "failed"
+    assert "token=[REDACTED]" in diagnostic["data"]["error"]
+    assert "<PATH>" in diagnostic["data"]["error"]
+    assert diagnostic["data"]["authorization"] == "[REDACTED]"
+
+
+def test_diagnostic_output_is_bounded(monkeypatch):
+    long_error = "failure " + ("x" * 20_000)
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_server_status_changed",
+            "data": {"serverName": "foundry_docs", "status": "failed", "error": long_error},
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=long_error),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["diagnostics"]["stdout_truncated"] is True
+    assert result["diagnostics"]["stderr_truncated"] is True
+    assert len(result["diagnostics"]["stdout_excerpt"]) < 12_100
+    assert len(result["diagnostics"]["stderr_excerpt"]) < 4_100
+
+
+def test_sanitizer_redacts_prefixed_secrets_and_windows_paths(monkeypatch):
+    stderr = (
+        'AZURE_SEARCH_API_KEY="super secret" GITHUB_TOKEN=github_pat_abc '
+        "at C:\\Users\\Jane Doe\\repo and \\\\server\\share\\private"
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout="not-json",
+            stderr=stderr,
+        ),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    excerpt = result["diagnostics"]["stderr_excerpt"]
+    assert "super secret" not in excerpt
+    assert "github_pat_abc" not in excerpt
+    assert "Jane Doe" not in excerpt
+    assert "server\\share" not in excerpt
+    assert "<PATH>" in excerpt
+
+
+def test_sanitizer_redacts_json_style_secret_keys(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_server_status_changed",
+            "data": {
+                "serverName": "foundry_docs",
+                "status": "failed",
+                "api_key": "json-secret-value",
+            },
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert "json-secret-value" not in result["diagnostics"]["stdout_excerpt"]
+    assert result["diagnostics"]["events"][0]["data"]["api_key"] == "[REDACTED]"
+
+
+def test_sanitizer_redacts_escaped_nested_json_secrets(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_server_status_changed",
+            "data": {
+                "serverName": "foundry_docs",
+                "status": "failed",
+                "message": json.dumps({"AZURE_SEARCH_API_KEY": "nested-json-secret"}),
+            },
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert "nested-json-secret" not in result["diagnostics"]["stdout_excerpt"]
+
+
+def test_process_exit_preserves_specific_mcp_failure_reason(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_server_status_changed",
+            "data": {"serverName": "foundry_docs", "status": "failed", "error": "startup failed"},
+        }),
+        json.dumps({"type": "result", "exitCode": 1}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert "mcp_initialization_failure:" in result["failure_reason"]
+    assert "process_exit_code: 1" in result["failure_reason"]
+
+
+def test_mcp_failure_server_name_is_sanitized_and_bounded(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_server_status_changed",
+            "data": {
+                "serverName": "token=server-secret C:\\Users\\alice\\private " + ("x" * 20_000),
+                "status": "failed",
+                "error": "startup failed",
+            },
+        }),
+        json.dumps({"type": "result", "exitCode": 1}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert "server-secret" not in result["failure_reason"]
+    assert "alice" not in result["failure_reason"]
+    assert len(result["failure_reason"]) < 2_200
+
+
+def test_size_based_event_truncation_is_schema_valid():
+    row = _raw_row()
+    row["diagnostics"]["events"] = [{"event_type": "status", "data": {"message": "x" * 40_000}}]
+    row["diagnostics"]["events_truncated"] = True
+
+    assert validate_row_schema(row) == []
+
+
+def test_nested_stdout_truncation_flag_is_schema_valid():
+    row = _raw_row()
+    row["diagnostics"]["stdout_excerpt"] = "x" * 2_000 + "...[truncated]"
+    row["diagnostics"]["stdout_truncated"] = True
+
+    assert validate_row_schema(row) == []
+
+
+def test_diagnostic_path_keys_are_sanitized(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+        }),
+        json.dumps({
+            "type": "tool.execution_complete",
+            "data": {
+                "toolCallId": "call-1",
+                "success": False,
+                "result": {"C:\\Users\\someone\\private.txt": "failed"},
+            },
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    serialized = json.dumps(result["diagnostics"])
+    assert "private.txt" not in serialized
+    assert "<PATH>" in serialized
+
+
+@pytest.mark.parametrize(
+    "diagnostics",
+    [
+        None,
+        {
+            "events": [{}] * 21,
+            "events_truncated": True,
+            "stdout_excerpt": "",
+            "stdout_truncated": False,
+            "stderr_excerpt": "",
+            "stderr_truncated": False,
+        },
+        {
+            "events": [],
+            "events_truncated": False,
+            "stdout_excerpt": "x" * 20_000,
+            "stdout_truncated": False,
+            "stderr_excerpt": "",
+            "stderr_truncated": False,
+        },
+        {
+            "events": [{"event_type": "status", "data": {"message": "x" * 1_000_000}}],
+            "events_truncated": False,
+            "stdout_excerpt": "",
+            "stdout_truncated": False,
+            "stderr_excerpt": "",
+            "stderr_truncated": False,
+        },
+        {
+            "events": [],
+            "events_truncated": False,
+            "stdout_excerpt": "",
+            "stdout_truncated": False,
+            "stderr_excerpt": "",
+            "stderr_truncated": False,
+            "raw_stdout": "x" * 1_000_000,
+        },
+    ],
+)
+def test_scorer_rejects_missing_or_unbounded_diagnostics(diagnostics):
+    row = _raw_row()
+    row["diagnostics"] = diagnostics
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
 
 
 def test_parse_event_stream_rejects_incomplete_tool_call():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -17,7 +18,13 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 from eval_report import generate_report  # noqa: E402
 from eval_scorer import aggregate_scores, score_result, validate_required_matrix, validate_row_schema  # noqa: E402
 from foundry_docs_mcp._server_factory import DOCS_CONFIG, build_server  # noqa: E402
-from run_docs_eval import MCP_SERVERS, build_mcp_config, parse_event_stream, run_single_eval  # noqa: E402
+from run_docs_eval import (  # noqa: E402
+    MCP_SERVERS,
+    _sanitize_text,
+    build_mcp_config,
+    parse_event_stream,
+    run_single_eval,
+)
 
 
 SCENARIO = {
@@ -350,6 +357,98 @@ def test_mcp_initialization_failure_preserves_sanitized_lifecycle_diagnostics(mo
     assert diagnostic["data"]["authorization"] == "[REDACTED]"
 
 
+def test_real_mcp_servers_loaded_schema_preserves_statuses_and_selected_failure(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_servers_loaded",
+            "ephemeral": True,
+            "data": {
+                "servers": [
+                    {
+                        "name": "foundry_docs",
+                        "status": "failed",
+                        "error": "Authorization: Digest username=alice response=secret",
+                        "source": "user",
+                        "transport": "stdio",
+                    },
+                    {
+                        "name": "disabled_builtin",
+                        "status": "disabled",
+                        "source": "builtin",
+                        "transport": "memory",
+                    },
+                ]
+            },
+        }),
+        json.dumps({"type": "assistant.message", "data": {"content": "untrusted answer"}}),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["response"] == ""
+    assert result["response_present"] is False
+    assert result["failure_reason"].startswith("mcp_initialization_failure:")
+    assert "secret" not in result["failure_reason"]
+    diagnostic = result["diagnostics"]["events"][0]
+    assert diagnostic["event_type"] == "session.mcp_servers_loaded"
+    assert diagnostic["data"]["servers"][0]["status"] == "failed"
+    assert "[REDACTED]" in diagnostic["data"]["servers"][0]["error"]
+
+
+def test_real_session_error_schema_preserves_diagnostics_and_invalidates_answer(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.error",
+            "data": {
+                "errorType": "authentication",
+                "errorCode": "invalid_token",
+                "message": "Authorization: Custom opaque-secret",
+                "providerCallId": "request-123",
+                "serviceRequestId": "service-456",
+                "stack": "at C:/Users/Jane Doe/private/module.js",
+                "statusCode": 401,
+                "url": "https://example.invalid/login",
+            },
+        }),
+        json.dumps({"type": "assistant.message", "data": {"content": "untrusted answer"}}),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["response"] == ""
+    assert result["response_present"] is False
+    assert result["failure_reason"].startswith("session_error: authentication:")
+    assert "opaque-secret" not in result["failure_reason"]
+    diagnostic = result["diagnostics"]["events"][0]
+    assert diagnostic["event_type"] == "session.error"
+    assert diagnostic["data"]["statusCode"] == 401
+    assert diagnostic["data"]["stack"] == "at <PATH>"
+
+
 def test_diagnostic_output_is_bounded(monkeypatch):
     long_error = "failure " + ("x" * 20_000)
     stdout = "\n".join([
@@ -407,6 +506,39 @@ def test_sanitizer_redacts_prefixed_secrets_and_windows_paths(monkeypatch):
     assert "Jane Doe" not in excerpt
     assert "server\\share" not in excerpt
     assert "<PATH>" in excerpt
+
+
+@pytest.mark.parametrize(
+    ("raw", "secret"),
+    [
+        ("Authorization: Basic dXNlcjpwYXNz", "dXNlcjpwYXNz"),
+        ('Authorization: Digest username="alice", response="digest-secret"', "digest-secret"),
+        ("Authorization: CustomScheme opaque custom value", "opaque custom value"),
+    ],
+)
+def test_authorization_header_redacts_entire_value_for_every_scheme(raw, secret):
+    sanitized, _truncated = _sanitize_text(raw)
+
+    assert sanitized == "Authorization: [REDACTED]"
+    assert secret not in sanitized
+
+
+@pytest.mark.parametrize(
+    "raw_path",
+    [
+        "C:/Users/Jane Doe/private/file.txt",
+        "C:\\Users\\Jane Doe\\private\\file.txt",
+        "\\\\server\\share\\Jane Doe\\private.txt",
+        "//server/share/Jane Doe/private.txt",
+        "/root",
+        "/var/lib/My App/private.txt",
+    ],
+)
+def test_absolute_path_leak_probes_cover_windows_unc_and_unix(raw_path):
+    sanitized, _truncated = _sanitize_text(f"failed at {raw_path}")
+
+    assert raw_path not in sanitized
+    assert sanitized == "failed at <PATH>"
 
 
 def test_sanitizer_redacts_json_style_secret_keys(monkeypatch):
@@ -491,6 +623,61 @@ def test_process_exit_preserves_specific_mcp_failure_reason(monkeypatch):
     assert "process_exit_code: 1" in result["failure_reason"]
 
 
+def test_non_success_preserves_stdout_even_when_tool_evidence_was_valid(monkeypatch):
+    stdout = _event_stream(response="untrusted answer")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "error"
+    assert result["response"] == ""
+    assert result["response_present"] is False
+    assert "untrusted answer" in result["diagnostics"]["stdout_excerpt"]
+
+
+def test_failed_tool_clears_untrusted_answer_and_preserves_diagnostics(monkeypatch):
+    stdout = _event_stream(tool_success=False, response="untrusted answer")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["response"] == ""
+    assert result["response_present"] is False
+    assert result["failure_reason"].startswith("tool_error:")
+    assert "untrusted answer" in result["diagnostics"]["stdout_excerpt"]
+    assert result["diagnostics"]["events"][0]["event_type"] == "tool.execution_complete"
+
+
+@pytest.mark.parametrize("status", ["invalid", "error", "timeout"])
+def test_scorer_clears_response_for_every_non_success_status(status):
+    row = _raw_row(status=status, response="untrusted answer", failure_reason="failed")
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert scored["response"] == ""
+    assert scored["response_present"] is False
+
+
 def test_mcp_failure_server_name_is_sanitized_and_bounded(monkeypatch):
     stdout = "\n".join([
         json.dumps({
@@ -535,6 +722,31 @@ def test_nested_stdout_truncation_flag_is_schema_valid():
     row["diagnostics"]["stdout_truncated"] = True
 
     assert validate_row_schema(row) == []
+
+
+def test_large_event_is_stopped_before_json_parse_and_remains_bounded():
+    huge_event = b'{"type":"session.error","data":{"message":"' + (b"x" * 5_000_000) + b'"}}'
+
+    started = time.perf_counter()
+    parsed = parse_event_stream(huge_event)
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 1.0
+    assert parsed["stdout_input_truncated"] is True
+    assert "pre-parse limit" in parsed["parse_error"]
+    assert parsed["diagnostic_events"] == []
+    assert parsed["response"] == ""
+
+
+def test_deeply_nested_bounded_json_fails_closed_without_recursion_crash():
+    nested = "[" * 5_000 + "null" + "]" * 5_000
+    stdout = f'{{"type":"session.error","data":{{"message":{nested}}}}}'
+
+    parsed = parse_event_stream(stdout)
+
+    assert "invalid JSON event" in parsed["parse_error"]
+    assert parsed["diagnostic_events"] == []
+    assert parsed["response"] == ""
 
 
 def test_diagnostic_path_keys_are_sanitized(monkeypatch):

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -836,8 +836,8 @@ def _session_error_events_at_serialized_size(target_size: int) -> list[dict]:
     return source_events
 
 
-def test_runner_accepts_exact_event_envelope_limit():
-    source_events = _session_error_events_at_serialized_size(50_000)
+def test_runner_accepts_event_envelope_at_49_998():
+    source_events = _session_error_events_at_serialized_size(49_998)
     stdout = "\n".join([
         *(json.dumps(event, separators=(",", ":")) for event in source_events),
         json.dumps({"type": "result", "exitCode": 0}),
@@ -847,11 +847,11 @@ def test_runner_accepts_exact_event_envelope_limit():
 
     assert parsed["diagnostic_events_truncated"] is False
     assert len(parsed["diagnostic_events"]) == 5
-    assert serialized_diagnostic_events_size(parsed["diagnostic_events"]) == 50_000
+    assert serialized_diagnostic_events_size(parsed["diagnostic_events"]) == 49_998
 
 
-def test_runner_truncates_event_envelope_one_byte_over_limit():
-    source_events = _session_error_events_at_serialized_size(50_001)
+def test_runner_truncates_event_envelope_at_50_002():
+    source_events = _session_error_events_at_serialized_size(50_002)
     stdout = "\n".join([
         *(json.dumps(event, separators=(",", ":")) for event in source_events),
         json.dumps({"type": "result", "exitCode": 0}),
@@ -881,6 +881,23 @@ def test_scorer_accepts_exact_event_envelope_limit_and_rejects_one_byte_over():
     }]
     assert serialized_diagnostic_events_size(over_limit["diagnostics"]["events"]) == 50_001
     assert "diagnostics.events exceeds its total serialized size limit" in validate_row_schema(over_limit)
+
+
+def test_scorer_accepts_49_998_event_envelope_and_rejects_50_002():
+    event = {"event_type": "boundary", "data": {"message": ""}}
+    overhead = serialized_diagnostic_events_size([event])
+
+    below_limit = _raw_row()
+    below_event = {"event_type": "boundary", "data": {"message": "x" * (49_998 - overhead)}}
+    below_limit["diagnostics"]["events"] = [below_event]
+    assert serialized_diagnostic_events_size(below_limit["diagnostics"]["events"]) == 49_998
+    assert validate_row_schema(below_limit) == []
+
+    above_limit = _raw_row()
+    above_event = {"event_type": "boundary", "data": {"message": "x" * (50_002 - overhead)}}
+    above_limit["diagnostics"]["events"] = [above_event]
+    assert serialized_diagnostic_events_size(above_limit["diagnostics"]["events"]) == 50_002
+    assert "diagnostics.events exceeds its total serialized size limit" in validate_row_schema(above_limit)
 
 
 def test_nested_stdout_truncation_flag_is_schema_valid():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -845,6 +845,21 @@ def test_scorer_clears_response_for_every_non_success_status(status):
     aggregates = aggregate_scores([scored])
     assert aggregates["operational_metrics"]["foundry-docs"]["pass_rate"] == 0.0
     assert aggregates["operational_metrics"]["foundry-docs"]["status_counts"] == {"invalid": 1}
+
+
+def test_invalid_source_config_is_sanitized_in_scored_output():
+    row = _raw_row()
+    row["selected_source_config"]["command"] = r"token=CONFIGSECRET C:\Users\Victim\private"
+
+    scored = score_result(row)
+    persisted = json.dumps(scored)
+
+    assert scored["row_valid"] is False
+    assert "CONFIGSECRET" not in persisted
+    assert "Victim" not in persisted
+    assert "private" not in persisted
+    assert "token=[REDACTED]" in persisted
+    assert "<PATH>" in persisted
     assert scored["response"] == ""
     assert scored["response_present"] is False
 
@@ -881,7 +896,11 @@ def test_mcp_failure_server_name_is_sanitized_and_bounded(monkeypatch):
 
 def test_size_based_event_truncation_is_schema_valid():
     row = _raw_row()
-    row["diagnostics"]["events"] = [{"event_type": "status", "data": {"message": "x" * 40_000}}]
+    source_events = _session_error_events_at_serialized_size(40_000)
+    row["diagnostics"]["events"] = [
+        {"event_type": "session.error", "data": event["data"]}
+        for event in source_events
+    ]
     row["diagnostics"]["events_truncated"] = True
 
     assert validate_row_schema(row) == []
@@ -983,37 +1002,37 @@ def test_runner_truncates_event_envelope_at_50_002():
 
 
 def test_scorer_accepts_exact_event_envelope_limit_and_rejects_one_byte_over():
-    event = {"event_type": "boundary", "data": {"message": ""}}
-    overhead = serialized_diagnostic_events_size([event])
-    event["data"]["message"] = "x" * (50_000 - overhead)
-    assert serialized_diagnostic_events_size([event]) == 50_000
-
     at_limit = _raw_row()
-    at_limit["diagnostics"]["events"] = [event]
+    at_limit["diagnostics"]["events"] = [
+        {"event_type": "session.error", "data": event["data"]}
+        for event in _session_error_events_at_serialized_size(50_000)
+    ]
+    assert serialized_diagnostic_events_size(at_limit["diagnostics"]["events"]) == 50_000
     assert validate_row_schema(at_limit) == []
 
     over_limit = _raw_row()
-    over_limit["diagnostics"]["events"] = [{
-        "event_type": "boundary",
-        "data": {"message": event["data"]["message"] + "x"},
-    }]
+    over_limit["diagnostics"]["events"] = [
+        {"event_type": "session.error", "data": event["data"]}
+        for event in _session_error_events_at_serialized_size(50_001)
+    ]
     assert serialized_diagnostic_events_size(over_limit["diagnostics"]["events"]) == 50_001
     assert "diagnostics.events exceeds its total serialized size limit" in validate_row_schema(over_limit)
 
 
 def test_scorer_accepts_49_998_event_envelope_and_rejects_50_002():
-    event = {"event_type": "boundary", "data": {"message": ""}}
-    overhead = serialized_diagnostic_events_size([event])
-
     below_limit = _raw_row()
-    below_event = {"event_type": "boundary", "data": {"message": "x" * (49_998 - overhead)}}
-    below_limit["diagnostics"]["events"] = [below_event]
+    below_limit["diagnostics"]["events"] = [
+        {"event_type": "session.error", "data": event["data"]}
+        for event in _session_error_events_at_serialized_size(49_998)
+    ]
     assert serialized_diagnostic_events_size(below_limit["diagnostics"]["events"]) == 49_998
     assert validate_row_schema(below_limit) == []
 
     above_limit = _raw_row()
-    above_event = {"event_type": "boundary", "data": {"message": "x" * (50_002 - overhead)}}
-    above_limit["diagnostics"]["events"] = [above_event]
+    above_limit["diagnostics"]["events"] = [
+        {"event_type": "session.error", "data": event["data"]}
+        for event in _session_error_events_at_serialized_size(50_002)
+    ]
     assert serialized_diagnostic_events_size(above_limit["diagnostics"]["events"]) == 50_002
     assert "diagnostics.events exceeds its total serialized size limit" in validate_row_schema(above_limit)
 
@@ -1394,6 +1413,79 @@ def test_scorer_rejects_success_row_missing_required_evidence_fields():
     assert scored["scores"]["has_response"] is False
 
 
+def test_scorer_rejects_and_sanitizes_malicious_persisted_identifiers():
+    row = _raw_row()
+    malicious = r"foundry_docs-search_docs token=LEAKME C:\Users\Alice\private " + ("x" * 500)
+    row["observed_tools"] = [malicious]
+    row["successful_tools"] = [malicious]
+    row["event_parse_error"] = r"duplicate call token=PARSESECRET C:\Users\Bob\private"
+    row["diagnostics"]["events"] = [{
+        "event_type": "tool.execution_complete",
+        "data": {
+            "toolName": malicious,
+            "toolCallId": r"call token=CALLSECRET C:\Users\Carol\private",
+        },
+    }]
+
+    scored = score_result(row)
+    persisted = json.dumps(scored)
+
+    assert scored["row_valid"] is False
+    assert scored["status"] == "invalid"
+    for leaked in ("LEAKME", "Alice", "PARSESECRET", "Bob", "CALLSECRET", "Carol", "private"):
+        assert leaked not in persisted
+    assert all(len(identifier) <= 270 for identifier in scored["observed_tools"])
+    assert "token=[REDACTED]" in persisted
+    assert "<PATH>" in persisted
+
+
+def test_scorer_projects_known_fields_and_rejects_unsanitized_diagnostics():
+    row = _raw_row()
+    row["extra_secret"] = r"token=TOPSECRET C:\Users\Victim\private"
+    row["diagnostics"]["stdout_excerpt"] = r"token=DIAGSECRET C:\Users\Victim\private"
+
+    scored = score_result(row)
+    persisted = json.dumps(scored)
+
+    assert scored["row_valid"] is False
+    assert "extra_secret" not in scored
+    for leaked in ("TOPSECRET", "DIAGSECRET", "Victim", "private"):
+        assert leaked not in persisted
+    assert "token=[REDACTED]" in persisted
+    assert "<PATH>" in persisted
+
+
+def test_scorer_sanitizes_malformed_nested_retained_fields():
+    row = _raw_row()
+    row["question"] = {"nested": r"token=LEAKME C:\Users\Alice\private"}
+    row["event_parse_error"] = {"nested": r"token=PARSELEAK C:\Users\Bob\private"}
+    row["observed_tools"] = {"nested": r"token=TOOLLEAK C:\Users\Carol\private"}
+
+    scored = score_result(row)
+    persisted = json.dumps(scored)
+
+    assert scored["row_valid"] is False
+    for leaked in ("LEAKME", "Alice", "PARSELEAK", "Bob", "TOOLLEAK", "Carol", "private"):
+        assert leaked not in persisted
+    assert "token=[REDACTED]" in persisted
+    assert "<PATH>" in persisted
+    assert scored["observed_tools"] == []
+
+
+def test_scorer_rejects_non_string_diagnostic_identifier():
+    row = _raw_row()
+    row["diagnostics"]["events"] = [{
+        "event_type": "tool.execution_complete",
+        "data": {"toolCallId": 123, "toolName": "foundry_docs-search_docs"},
+    }]
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert scored["status"] == "invalid"
+    assert "diagnostics.events[0].data.toolCallId must be a string identifier" in scored["failure_reason"]
+
+
 @pytest.mark.parametrize(
     "malformed",
     [
@@ -1518,6 +1610,76 @@ def test_unexpected_rows_are_invalidated_before_aggregation():
     assert unexpected["scores"]["has_response"] is False
     assert aggregates["server_model_matrix"] == {}
     assert aggregates["server_averages"] == {}
+
+
+def test_unknown_server_row_and_required_matrix_fail_closed():
+    unknown = _raw_row()
+    unknown["server"] = "unknown-server"
+    unknown["selected_source"] = "unknown-server"
+    unknown["selected_source_config"] = {
+        "name": "unknown",
+        "type": "local",
+        "endpoint": None,
+        "command": "unknown",
+        "tool_prefix": None,
+        "azure_required": False,
+    }
+    unknown["observed_tools"] = ["unknown-search"]
+    unknown["successful_tools"] = ["unknown-search"]
+
+    scored = score_result(unknown)
+    publication = validate_required_matrix(
+        [scored],
+        scenario_ids=["scenario-1"],
+        servers=["unknown-server"],
+        models=["model-1"],
+    )
+    aggregates = aggregate_scores([scored])
+
+    assert scored["row_valid"] is False
+    assert scored["status"] == "invalid"
+    assert scored["response"] == ""
+    assert publication["allowed"] is False
+    assert publication["unknown_required_servers"] == ["unknown-server"]
+    assert "unknown required server(s): unknown-server" in publication["failure_reasons"]
+    assert aggregates["server_model_matrix"] == {}
+    assert aggregates["server_averages"] == {}
+
+
+def test_unknown_azure_required_server_blocks_otherwise_valid_matrix():
+    valid = score_result(_raw_row())
+
+    publication = validate_required_matrix(
+        [valid],
+        scenario_ids=["scenario-1"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+        azure_required_servers={"typo-server"},
+    )
+
+    assert publication["allowed"] is False
+    assert publication["unknown_required_servers"] == ["typo-server"]
+    assert "unknown required server(s): typo-server" in publication["failure_reasons"]
+
+
+def test_required_matrix_sanitizes_unknown_selector_row_labels():
+    selector = r"token=SERVERLEAK C:\Users\Alice\private"
+
+    publication = validate_required_matrix(
+        [],
+        scenario_ids=["scenario-1"],
+        servers=[selector],
+        models=["model-1"],
+        azure_required_servers={selector},
+    )
+    persisted = json.dumps(publication)
+
+    assert publication["allowed"] is False
+    assert "SERVERLEAK" not in persisted
+    assert "Alice" not in persisted
+    assert "private" not in persisted
+    assert "token=[REDACTED]" in persisted
+    assert "<PATH>" in persisted
 
 
 def test_scorer_rejects_contradictory_source_descriptor_and_tool_evidence():
@@ -1648,9 +1810,10 @@ def test_scorer_cli_writes_blocked_diagnostics_before_failing(tmp_path):
     raw_path.write_text(
         json.dumps({
             "metadata": {
-                "run_id": "run-1",
-                "servers": ["foundry-docs"],
-                "models": ["model-1"],
+                "run_id": r"run-1 token=RUNSECRET C:\Users\Alice\private",
+                "servers": [r"foundry-docs token=SERVERSECRET C:\Users\Bob\private"],
+                "models": [r"model-1 token=MODELSECRET C:\Users\Carol\private"],
+                "extra_secret": r"token=EXTRASECRET C:\Users\Dana\private",
             },
             "results": [_raw_row()],
         }),
@@ -1686,3 +1849,19 @@ def test_scorer_cli_writes_blocked_diagnostics_before_failing(tmp_path):
     scored = json.loads(output_path.read_text(encoding="utf-8"))
     assert scored["publication"]["allowed"] is False
     assert scored["aggregates"]["denominators"]["status_counts"]["missing"] == 1
+    persisted = json.dumps(scored["metadata"])
+    for leaked in (
+        "RUNSECRET",
+        "Alice",
+        "SERVERSECRET",
+        "Bob",
+        "MODELSECRET",
+        "Carol",
+        "EXTRASECRET",
+        "Dana",
+        "private",
+    ):
+        assert leaked not in persisted
+    assert "extra_secret" not in scored["metadata"]
+    assert "token=[REDACTED]" in persisted
+    assert "<PATH>" in persisted

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -321,6 +321,39 @@ def test_timeout_is_preserved_as_invalid_row_diagnostics(monkeypatch):
     assert publication["allowed"] is False
 
 
+def test_process_launch_error_sanitizes_every_persisted_field(monkeypatch):
+    leaked = (
+        "failed to launch with GITHUB_TOKEN=github_pat_launchsecret "
+        "Authorization: Basic dXNlcjpwYXNz\n"
+        "failed at C:/Users/Jane Doe/private/copilot.exe"
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: (_ for _ in ()).throw(OSError(leaked)),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    persisted = json.dumps({
+        "stderr": result["stderr"],
+        "failure_reason": result["failure_reason"],
+        "diagnostics": result["diagnostics"],
+    })
+    for secret in ("github_pat_launchsecret", "dXNlcjpwYXNz", "Jane Doe", "copilot.exe"):
+        assert secret not in persisted
+    assert "GITHUB_TOKEN=[REDACTED]" in result["stderr"]
+    assert "Authorization: [REDACTED]" in result["stderr"]
+    assert "<PATH>" in result["stderr"]
+    assert result["failure_reason"] == f"process_launch_error: {result['stderr']}"
+    assert result["diagnostics"]["stderr_excerpt"] == result["stderr"]
+
+
 def test_mcp_initialization_failure_preserves_sanitized_lifecycle_diagnostics(monkeypatch):
     stdout = "\n".join([
         json.dumps({
@@ -874,6 +907,34 @@ def test_runner_accepts_event_envelope_at_49_998():
     assert parsed["diagnostic_events_truncated"] is False
     assert len(parsed["diagnostic_events"]) == 5
     assert serialized_diagnostic_events_size(parsed["diagnostic_events"]) == 49_998
+
+
+def test_runner_accepts_event_envelope_at_50_000():
+    source_events = _session_error_events_at_serialized_size(50_000)
+    stdout = "\n".join([
+        *(json.dumps(event, separators=(",", ":")) for event in source_events),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["diagnostic_events_truncated"] is False
+    assert len(parsed["diagnostic_events"]) == 5
+    assert serialized_diagnostic_events_size(parsed["diagnostic_events"]) == 50_000
+
+
+def test_runner_truncates_event_envelope_at_50_001():
+    source_events = _session_error_events_at_serialized_size(50_001)
+    stdout = "\n".join([
+        *(json.dumps(event, separators=(",", ":")) for event in source_events),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["diagnostic_events_truncated"] is True
+    assert len(parsed["diagnostic_events"]) == 4
+    assert serialized_diagnostic_events_size(parsed["diagnostic_events"]) < 50_000
 
 
 def test_runner_truncates_event_envelope_at_50_002():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import time
+import urllib.parse
 from pathlib import Path
 
 import pytest
@@ -625,6 +626,49 @@ def test_percent_encoded_credentials_and_local_paths_are_detected_recursively():
         assert leaked not in sanitized
     assert "<PATH>" in sanitized
     assert "https://host/a%2Fb+c." in sanitized
+
+
+def test_four_plus_layer_encoded_authorization_redacts_and_budget_exhaustion_fails_closed(monkeypatch):
+    encoded = "Authorization=CustomScheme opaque-value"
+    for _ in range(5):
+        encoded = urllib.parse.quote_plus(encoded)
+    response = f"upstream={encoded}"
+
+    sanitized = _sanitize_response_text(response)
+    assert "opaque-value" not in sanitized
+    assert "[REDACTED]" in sanitized
+
+    monkeypatch.setattr(run_docs_eval, "MAX_ENCODED_DECODE_ITERATIONS", 1)
+    exhausted = _sanitize_response_text(response)
+    assert encoded not in exhausted
+    assert exhausted == "[REDACTED]"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "Authorization%3A CustomScheme opaque-value",
+        "%41uthorization=CustomScheme opaque-value",
+    ],
+)
+def test_partially_encoded_authorization_redacts_complete_line(response):
+    assert _sanitize_response_text(response) == "[REDACTED]"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "Authorization%3A\n opaque-value",
+        "Authorization%253A\r\n \r\n nonce=LEAKME",
+        'upstream={%22Authorization%22%3A\n opaque-value}',
+    ],
+)
+def test_folded_encoded_authorization_redacts_logical_header_block(response):
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == "[REDACTED]\n" or sanitized == "[REDACTED]\r\n"
+    assert "opaque-value" not in sanitized
+    assert "LEAKME" not in sanitized
 
 
 def test_encoded_credentials_and_paths_are_redacted_in_diagnostic_channels(monkeypatch):
@@ -2283,6 +2327,35 @@ def test_scorer_rejects_non_string_diagnostic_identifier():
     assert "diagnostics.events[0].data.toolCallId must be a string identifier" in scored["failure_reason"]
 
 
+def test_deep_diagnostic_identifier_nesting_fails_closed_without_recursion_error():
+    nested: object = {"toolCallId": "safe-call"}
+    for _ in range(995):
+        nested = {"child": nested}
+    row = _raw_row()
+    row["diagnostics"]["events"] = [{"event_type": "status", "data": nested}]
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert "exceeds maximum diagnostic nesting depth" in scored["failure_reason"]
+
+
+def test_wide_diagnostic_identifier_mapping_is_bounded_lazily():
+    row = _raw_row()
+    row["diagnostics"]["events"] = [{
+        "event_type": "status",
+        "data": {f"field-{index}": "value" for index in range(100_000)},
+    }]
+
+    started = time.perf_counter()
+    scored = score_result(row)
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 1.0
+    assert scored["row_valid"] is False
+    assert "contains more than 20 fields" in scored["failure_reason"]
+
+
 @pytest.mark.parametrize(
     "malformed",
     [
@@ -2837,6 +2910,38 @@ def test_baseline_comparison_blocks_invalid_current_required_row(tmp_path, capsy
     captured = capsys.readouterr()
     assert "Baseline comparison blocked" in captured.err
     assert "No regressions detected" not in captured.out
+
+
+def test_baseline_comparison_rejects_invalid_baseline_matrix(tmp_path, capsys):
+    invalid_baseline = _raw_row()
+    invalid_baseline["status"] = "invalid"
+    invalid_baseline["passed"] = False
+    invalid_baseline["response"] = ""
+    invalid_baseline["response_present"] = False
+    invalid_baseline["failure_reason"] = "invalid baseline evidence"
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({"results": [invalid_baseline]}),
+        encoding="utf-8",
+    )
+
+    exit_code = compare_results({"results": [_raw_row()]}, str(baseline_path))
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "invalid baseline matrix" in captured.err
+    assert "No regressions detected" not in captured.out
+
+
+@pytest.mark.parametrize("baseline", [[], {"results": None}, {"results": 123}])
+def test_baseline_comparison_rejects_malformed_baseline_shape(tmp_path, capsys, baseline):
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+
+    exit_code = compare_results({"results": [_raw_row()]}, str(baseline_path))
+
+    assert exit_code == 2
+    assert "must be an object with a results array" in capsys.readouterr().err
 
 
 def test_cli_main_baseline_comparison_fails_for_missing_required_current_row(

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -20,10 +20,12 @@ from eval_scorer import aggregate_scores, score_result, validate_required_matrix
 from foundry_docs_mcp._server_factory import DOCS_CONFIG, build_server  # noqa: E402
 from run_docs_eval import (  # noqa: E402
     MCP_SERVERS,
+    _sanitize_response_text,
     _sanitize_text,
     build_mcp_config,
     parse_event_stream,
     run_single_eval,
+    select_servers,
     serialized_diagnostic_events_size,
 )
 
@@ -207,6 +209,494 @@ def test_run_single_eval_passes_only_selected_config_across_process_boundary(mon
     assert result["response_present"] is True
     assert result["status"] == "success"
     assert result["failure_reason"] is None
+
+
+def test_success_response_is_sanitized_in_raw_and_scored_rows(monkeypatch):
+    response = r"Useful answer. token=LEAKME See C:\Users\Alice\private for details."
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=_event_stream(response=response),
+            stderr="",
+        ),
+    )
+
+    raw_row = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+    scored_row = score_result(raw_row)
+
+    assert raw_row["status"] == "success"
+    assert scored_row["row_valid"] is True
+    assert raw_row["response"].startswith("Useful answer.")
+    for row in (raw_row, scored_row):
+        persisted = json.dumps(row)
+        assert "LEAKME" not in persisted
+        assert "Alice" not in persisted
+        assert "private" not in persisted
+        assert "token=[REDACTED]" in persisted
+        assert "<PATH>" in persisted
+
+
+def test_success_response_preserves_root_relative_documentation_link(monkeypatch):
+    response = (
+        "Use agents. See [agent docs](/concepts/agents) for prerequisites. "
+        "Then configure managed identity."
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=_event_stream(response=response),
+            stderr="",
+        ),
+    )
+
+    raw_row = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+    scored_row = score_result(raw_row)
+
+    assert raw_row["status"] == "success"
+    assert raw_row["response"] == response
+    assert scored_row["row_valid"] is True
+    assert scored_row["response"] == response
+
+
+def test_success_response_preserves_bare_route_and_https_url_but_redacts_sensitive_query():
+    response = (
+        "See /concepts/agents and https://learn.microsoft.com/en-us/azure/ai. "
+        "Do not expose [private](/concepts/agents?token=LEAKME&view=foundry). "
+        "Signed: https://host/path?sig=SUPERSECRET&se=2099-01-01. "
+        "Bare: /concepts/agents?sig=BARESECRET&view=foundry. "
+        "OAuth: https://host/path?access_token=OAUTHSECRET&view=foundry."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    assert "/concepts/agents" in sanitized
+    assert "https://learn.microsoft.com/en-us/azure/ai" in sanitized
+    assert "LEAKME" not in sanitized
+    assert "token=[REDACTED]" in sanitized
+    assert "view=foundry" in sanitized
+    assert "SUPERSECRET" not in sanitized
+    assert "sig=[REDACTED]&se=2099-01-01" in sanitized
+    assert "BARESECRET" not in sanitized
+    assert "/concepts/agents?sig=[REDACTED]&view=foundry." in sanitized
+    assert "OAUTHSECRET" not in sanitized
+    assert "access_token=[REDACTED]&view=foundry." in sanitized
+    assert _sanitize_response_text(sanitized) == sanitized
+
+
+def test_success_response_redacts_confirmed_unix_local_paths_and_bounds_long_routes():
+    response = "Read /etc/private.conf and /home/alice/private before [docs](/" + ("x" * 200_000) + ")."
+
+    sanitized = _sanitize_response_text(response)
+
+    assert "/etc/private.conf" not in sanitized
+    assert "/home/alice/private" not in sanitized
+    assert sanitized.count("<PATH>") == 2
+    assert len(sanitized) <= 50_000 + len("...[truncated]")
+
+
+def test_success_response_preserves_sentence_and_os_named_root_link():
+    response = (
+        r"Read C:\Users\Alice\private. This sentence must remain intact. "
+        r"Also read C:\Users\Alice\other! Keep this too. "
+        "See [home docs](/home/overview)."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == (
+        "Read <PATH>. This sentence must remain intact. "
+        "Also read <PATH>! Keep this too. "
+        "See [home docs](<PATH>)."
+    )
+
+
+def test_success_response_path_match_stops_before_unrecognized_prose():
+    response = r"The file C:\Users\Alice\private should remain secret while this prose survives."
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == "The file <PATH> should remain secret while this prose survives."
+
+
+def test_success_response_stops_unquoted_path_after_filename_component():
+    response = (
+        r"The file is at C:\Users\Alice\secret.txt locally. "
+        "The export is /home/alice/Customer SSN.csv now."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == "The file is at <PATH> locally. The export is <PATH> now."
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (
+            r"Open C:\Users\Alice\Customer SSN.csv and continue.",
+            "Open <PATH> and continue.",
+        ),
+        (
+            r"Open C:\Users\O'Connor\Customer SSN.csv and continue.",
+            "Open <PATH> and continue.",
+        ),
+        (
+            "Open $HOME/private.txt and ${HOME}/fourth.txt and ~/other.txt and %USERPROFILE%\\third.txt.",
+            "Open <PATH> and <PATH> and <PATH> and <PATH>.",
+        ),
+        (
+            r"Open C:\Program Files and \\server\share\Customer Data and $HOME/Customer Data.",
+            "Open <PATH> and <PATH> and <PATH>.",
+        ),
+        (
+            r"Open C:\Users\Alice\Customer Data using Explorer.",
+            "Open <PATH> using Explorer.",
+        ),
+        (
+            r"Open C:\Users\Alice\Customer SSN exists nearby.",
+            "Open <PATH> exists nearby.",
+        ),
+        (
+            r"Open C:\Users\Alice\Customer Sensitive Data.csv and /home/alice/Customer Sensitive Data.csv.",
+            "Open <PATH> and <PATH>.",
+        ),
+        (
+            "Open ~alice/private.txt and /app/Customer Data/config.json and /data/private.bin.",
+            "Open <PATH> and <PATH> and <PATH>.",
+        ),
+    ],
+)
+def test_success_response_redacts_unquoted_paths_with_spaces_apostrophes_and_home_aliases(response, expected):
+    assert _sanitize_response_text(response) == expected
+
+
+def test_success_response_redacts_entire_quoted_local_path_with_spaces():
+    response = r'Open "C:\Users\Alice\Customer SSN.csv" and continue.'
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == 'Open "<PATH>" and continue.'
+
+
+def test_success_response_redacts_single_quoted_path_with_apostrophe():
+    response = r"Open 'C:\Users\O'Connor\Customer SSN.csv' and continue."
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == "Open '<PATH>' and continue."
+
+
+def test_success_response_redacts_complete_path_under_home_prefix():
+    response = "Open \"C:\\Users\\nbrady\\O'Connor Customer SSN.csv\" and continue."
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == 'Open "<PATH>" and continue.'
+
+
+def test_success_response_unclosed_quoted_path_does_not_consume_later_prose():
+    response = "Open \"C:\\Users\\Alice\\secret.txt\nKeep this paragraph and say \"done\"."
+
+    sanitized = _sanitize_response_text(response)
+
+    assert "secret.txt" not in sanitized
+    assert "Keep this paragraph" in sanitized
+    assert '"done"' in sanitized
+
+
+def test_success_response_quoted_path_stops_before_arbitrary_following_word():
+    response = r'Open "C:\Users\Alice\secret.txt" using the command "Open". Then continue.'
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == 'Open "<PATH>" using the command "Open". Then continue.'
+
+
+def test_success_response_redacts_complete_dotted_token_and_preserves_period():
+    response = "Use token=header.payload.signature. Then continue."
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == "Use token=[REDACTED]. Then continue."
+
+
+def test_success_response_redacts_common_unix_roots_and_bare_oauth_sas_assignments():
+    response = (
+        "Read /opt/acme/private.conf and /usr/local/private and /workspace/private. "
+        "Also read /boot/grub/grub.cfg and /private/etc/hosts. "
+        "Use ?sv=2024-01-01&sig=SUPERSECRET and code=AUTHCODE123."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == (
+        "Read <PATH> and <PATH> and <PATH>. "
+        "Also read <PATH> and <PATH>. "
+        "Use ?sv=2024-01-01&sig=[REDACTED] and code=[REDACTED]."
+    )
+
+
+def test_signed_url_response_remains_valid_after_runner_and_scorer(monkeypatch):
+    response = "Use https://host/path?sig=SECRET&view=foundry."
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=_event_stream(response=response),
+            stderr="",
+        ),
+    )
+
+    raw_row = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+    scored_row = score_result(raw_row)
+
+    assert raw_row["response"] == "Use https://host/path?sig=[REDACTED]&view=foundry."
+    assert scored_row["row_valid"] is True
+    assert scored_row["response"] == raw_row["response"]
+
+
+def test_oauth_query_and_fragment_credentials_are_redacted():
+    response = (
+        "Open https://host/callback?code=AUTHCODE123&client_secret=CLIENTSECRET123"
+        "#access_token=header.payload.signature&view=foundry."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    for secret in ("AUTHCODE123", "CLIENTSECRET123", "header.payload.signature"):
+        assert secret not in sanitized
+    assert "code=[REDACTED]" in sanitized
+    assert "client_secret=[REDACTED]" in sanitized
+    assert "access_token=[REDACTED]&view=foundry." in sanitized
+
+
+def test_url_userinfo_aliases_and_nested_fragment_credentials_are_redacted():
+    response = (
+        "Open https://user:password@host/path?x-api-key=APISECRET&subscription-key=AZURESECRET"
+        "#/callback?code=AUTHCODE&client_secret=CLIENTSECRET."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    for secret in ("user:password", "APISECRET", "AZURESECRET", "AUTHCODE", "CLIENTSECRET"):
+        assert secret not in sanitized
+    assert "https://[REDACTED]@host/path" in sanitized
+    assert "x-api-key=[REDACTED]" in sanitized
+    assert "subscription-key=[REDACTED]" in sanitized
+    assert "#/callback?code=[REDACTED]&client_secret=[REDACTED]." in sanitized
+
+
+def test_quoted_url_values_assertions_and_encoded_tokens_are_redacted():
+    response = (
+        'Open https://host/path?token="URLSECRET"&client_assertion=header.payload.signature'
+        '&code_verifier=VERIFIER&ref=ghp%5FENCODEDSECRET.'
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    for secret in ("URLSECRET", "header.payload.signature", "VERIFIER", "ghp%5FENCODEDSECRET"):
+        assert secret not in sanitized
+    assert "token=[REDACTED]" in sanitized
+    assert "client_assertion=[REDACTED]" in sanitized
+    assert "code_verifier=[REDACTED]" in sanitized
+    assert "ref=[REDACTED]" in sanitized
+
+
+def test_malformed_url_userinfo_is_redacted_before_url_parsing():
+    response = "See https://user:URLSECRET@[broken/path"
+
+    sanitized = _sanitize_response_text(response)
+
+    assert "URLSECRET" not in sanitized
+    assert "https://[REDACTED]@" in sanitized
+
+
+def test_url_benign_parameter_values_and_fragments_still_redact_embedded_tokens():
+    response = (
+        "Open https://host/path?ref=ghp_QUERYSECRET123"
+        "#section=ghp_FRAGMENTSECRET123."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    assert "ghp_QUERYSECRET123" not in sanitized
+    assert "ghp_FRAGMENTSECRET123" not in sanitized
+    assert "ref=[REDACTED]" in sanitized
+    assert "#section=[REDACTED]." in sanitized
+
+
+def test_strict_and_alias_credentials_are_redacted_without_corrupting_redaction_marker():
+    response = (
+        "jwt=headerheader.payloadpayload.signaturesig "
+        "pat=PATSECRET sas=SASSECRET SharedAccessKey=SHAREDSECRET AccountKey=ACCOUNTSECRET "
+        "token=[REDACTED] token=[REDACTED]LEAK"
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    for secret in (
+        "headerheader.payloadpayload.signaturesig",
+        "PATSECRET",
+        "SASSECRET",
+        "SHAREDSECRET",
+        "ACCOUNTSECRET",
+        "[REDACTED]LEAK",
+    ):
+        assert secret not in sanitized
+    assert "token=[REDACTED]" in sanitized
+
+
+def test_malformed_https_url_fails_closed_without_crashing():
+    response = "See https://[broken/path?token=LEAKME"
+
+    sanitized = _sanitize_response_text(response)
+
+    assert "LEAKME" not in sanitized
+    assert "token=[REDACTED]" in sanitized
+
+
+def test_noncredential_code_assignments_remain_usable():
+    response = "status_code=404 errorCode=InvalidRequest language_code=en-US"
+
+    assert _sanitize_response_text(response) == response
+
+
+def test_secrets_in_https_path_components_are_redacted():
+    response = "See https://host/token=LEAKME and https://host/github_pat_ABCDEF123456."
+
+    sanitized = _sanitize_response_text(response)
+
+    assert "LEAKME" not in sanitized
+    assert "github_pat_ABCDEF123456" not in sanitized
+    assert "https://host/token=[REDACTED]" in sanitized
+    assert "https://host/[REDACTED]." in sanitized
+
+
+def test_https_path_encoding_is_preserved_when_no_secret_is_present():
+    response = "See https://host/a%2Fb+c."
+
+    assert _sanitize_response_text(response) == response
+
+
+def test_percent_encoded_credentials_and_local_paths_are_detected_recursively():
+    response = (
+        "Account %41ccountKey=ACCOUNTSECRET123 "
+        "JWT jwt=headerheader%252Epayloadpayload%252Esignaturesig "
+        "Path %252Fhome%252Falice%252Fsecret.txt "
+        "Safe https://host/a%2Fb+c."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    for leaked in ("ACCOUNTSECRET123", "headerheader", "payloadpayload", "signaturesig", "secret.txt"):
+        assert leaked not in sanitized
+    assert "<PATH>" in sanitized
+    assert "https://host/a%2Fb+c." in sanitized
+
+
+def test_encoded_credentials_and_paths_are_redacted_in_diagnostic_channels(monkeypatch):
+    leaked = "token%3DSECRETVALUE %252Fhome%252Falice%252Fsecret.txt"
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            1,
+            stdout="not-json",
+            stderr=leaked,
+        ),
+    )
+
+    raw_row = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+    scored_row = score_result(raw_row)
+
+    for row in (raw_row, scored_row):
+        persisted = json.dumps(row)
+        assert "SECRETVALUE" not in persisted
+        assert "secret.txt" not in persisted
+        assert "[REDACTED]" in persisted
+        assert "<PATH>" in persisted
+
+
+def test_markdown_os_paths_are_redacted_while_documentation_routes_survive():
+    response = (
+        "Read [passwd](/etc/passwd) and [env](/home/runner/work/repo/.env). "
+        "Keep [agents](/concepts/agents)."
+    )
+
+    sanitized = _sanitize_response_text(response)
+
+    assert sanitized == "Read [passwd](<PATH>) and [env](<PATH>). Keep [agents](/concepts/agents)."
+
+
+def test_select_servers_rejects_unknown_mixed_and_empty_plural_selection():
+    with pytest.raises(ValueError, match="unknown server"):
+        select_servers(None, ["unknown"])
+    with pytest.raises(ValueError, match="unknown server"):
+        select_servers(None, ["foundry-docs", "unknown"])
+    with pytest.raises(ValueError, match="requires at least one"):
+        select_servers(None, [])
+    with pytest.raises(ValueError, match="cannot be used together"):
+        select_servers("foundry-docs", ["foundry-docs-vnext"])
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["--servers", "unknown", "--dry-run"],
+        ["--servers", "foundry-docs", "unknown", "--dry-run"],
+        ["--servers", "--dry-run"],
+        ["--servers", "unknown"],
+        ["--models", "--dry-run"],
+    ],
+)
+def test_cli_plural_server_selection_fails_nonzero_before_execution(tmp_path, extra_args):
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(Path(__file__).parents[1] / "scripts" / "run_docs_eval.py"),
+            "--scenarios",
+            str(Path(__file__).parents[1] / "tests" / "docs_eval_scenarios.json"),
+            "--output-dir",
+            str(tmp_path),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 1
+    assert "Error:" in proc.stderr
+    assert list(tmp_path.glob("run-*.json")) == []
 
 
 @pytest.mark.parametrize(
@@ -1660,6 +2150,99 @@ def test_unknown_azure_required_server_blocks_otherwise_valid_matrix():
     assert publication["allowed"] is False
     assert publication["unknown_required_servers"] == ["typo-server"]
     assert "unknown required server(s): typo-server" in publication["failure_reasons"]
+
+
+def test_non_azure_server_cannot_spoof_azure_evidence():
+    spoofed = _raw_row(server="microsoft-learn")
+    spoofed["azure_required"] = True
+    spoofed["azure_live_query_proven"] = True
+    spoofed["selected_source_config"]["azure_required"] = True
+
+    scored = score_result(spoofed)
+    publication = validate_required_matrix(
+        [scored],
+        scenario_ids=["scenario-1"],
+        servers=["microsoft-learn"],
+        models=["model-1"],
+        azure_required_servers={"microsoft-learn"},
+    )
+
+    assert scored["row_valid"] is False
+    assert scored["status"] == "invalid"
+    assert scored["response"] == ""
+    assert publication["allowed"] is False
+    assert publication["unsupported_azure_required_servers"] == ["microsoft-learn"]
+    assert (
+        "Azure-required server(s) do not support Azure evidence: microsoft-learn"
+        in publication["failure_reasons"]
+    )
+
+
+def test_azure_required_server_must_be_in_required_matrix():
+    valid = score_result(_raw_row())
+
+    publication = validate_required_matrix(
+        [valid],
+        scenario_ids=["scenario-1"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+        azure_required_servers={"foundry-docs-vnext"},
+    )
+
+    assert publication["allowed"] is False
+    assert publication["azure_required_outside_matrix"] == ["foundry-docs-vnext"]
+    assert (
+        "Azure-required server(s) are outside the required server matrix: foundry-docs-vnext"
+        in publication["failure_reasons"]
+    )
+
+
+def test_azure_required_server_must_be_in_implicit_effective_matrix():
+    valid = score_result(_raw_row())
+
+    publication = validate_required_matrix(
+        [valid],
+        azure_required_servers={"foundry-docs-vnext"},
+    )
+
+    assert publication["allowed"] is False
+    assert publication["azure_required_outside_matrix"] == ["foundry-docs-vnext"]
+
+
+@pytest.mark.parametrize(
+    "selectors",
+    [
+        {"scenario_ids": ["scenario-1"]},
+        {"servers": ["foundry-docs"]},
+        {"models": ["model-1"]},
+        {"scenario_ids": ["scenario-1"], "servers": ["foundry-docs"]},
+        {"servers": ["foundry-docs"], "models": ["model-1"]},
+    ],
+)
+def test_required_matrix_rejects_partial_selector_combinations(selectors):
+    valid = score_result(_raw_row())
+
+    publication = validate_required_matrix([valid], **selectors)
+
+    assert publication["allowed"] is False
+    assert publication["partial_required_selectors"] is True
+    assert (
+        "required scenario, server, and model selectors must be supplied together"
+        in publication["failure_reasons"]
+    )
+
+
+def test_required_matrix_rejects_omitted_selector_triple():
+    valid = score_result(_raw_row())
+
+    publication = validate_required_matrix([valid])
+
+    assert publication["allowed"] is False
+    assert publication["partial_required_selectors"] is True
+    assert (
+        "required scenario, server, and model selectors must be supplied together"
+        in publication["failure_reasons"]
+    )
 
 
 def test_required_matrix_sanitizes_unknown_selector_row_labels():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -572,6 +572,32 @@ def test_escaped_authorization_does_not_leak_in_stdout_or_stderr(monkeypatch):
     assert "[REDACTED]" in result["diagnostics"]["stderr_excerpt"]
 
 
+def test_exact_custom_scheme_escaped_authorization_does_not_leak_in_excerpts(monkeypatch):
+    leaked = r'upstream={\"Authorization\":\"CustomScheme opaque-value\"}'
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=f"{leaked}\nnot-json",
+            stderr=leaked,
+        ),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert "opaque-value" not in result["diagnostics"]["stdout_excerpt"]
+    assert "opaque-value" not in result["diagnostics"]["stderr_excerpt"]
+    assert "[REDACTED]" in result["diagnostics"]["stdout_excerpt"]
+    assert "[REDACTED]" in result["diagnostics"]["stderr_excerpt"]
+
+
 def test_truncated_escaped_authorization_value_fails_closed(monkeypatch):
     leaked = (
         r'upstream={\"Authorization\":\"Digest nonce=LEAKME, username=\\\"alice\\\", '
@@ -898,6 +924,55 @@ def test_scorer_accepts_49_998_event_envelope_and_rejects_50_002():
     above_limit["diagnostics"]["events"] = [above_event]
     assert serialized_diagnostic_events_size(above_limit["diagnostics"]["events"]) == 50_002
     assert "diagnostics.events exceeds its total serialized size limit" in validate_row_schema(above_limit)
+
+
+def _session_error_event_with_individual_size(target_size: int) -> tuple[dict, dict]:
+    source = {"type": "session.error", "data": {"errorType": "q", "message": "m"}}
+    source["data"].update({f"field{field_index}": "" for field_index in range(18)})
+    diagnostic = {"event_type": "session.error", "data": dict(source["data"])}
+
+    remaining = target_size - len(json.dumps(diagnostic, ensure_ascii=True, separators=(",", ":")))
+    assert remaining >= 0
+    for field_index in range(18):
+        if remaining == 0:
+            break
+        addition = min(2_000, remaining)
+        value = "x" * addition
+        source["data"][f"field{field_index}"] = value
+        diagnostic["data"][f"field{field_index}"] = value
+        remaining -= addition
+
+    assert remaining == 0
+    assert len(json.dumps(diagnostic, ensure_ascii=True, separators=(",", ":"))) == target_size
+    return source, diagnostic
+
+
+def test_list_envelope_overhead_truncates_runner_and_is_rejected_by_scorer():
+    source_events = []
+    diagnostic_events = []
+    for _ in range(3):
+        source, diagnostic = _session_error_event_with_individual_size(16_666)
+        source_events.append(source)
+        diagnostic_events.append(diagnostic)
+
+    per_event_sum = sum(
+        len(json.dumps(event, ensure_ascii=True, separators=(",", ":")))
+        for event in diagnostic_events
+    )
+    assert per_event_sum == 49_998
+    assert serialized_diagnostic_events_size(diagnostic_events) == 50_002
+
+    parsed = parse_event_stream("\n".join([
+        *(json.dumps(event, separators=(",", ":")) for event in source_events),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ]))
+    assert parsed["diagnostic_events_truncated"] is True
+    assert len(parsed["diagnostic_events"]) == 2
+    assert serialized_diagnostic_events_size(parsed["diagnostic_events"]) < 50_000
+
+    row = _raw_row()
+    row["diagnostics"]["events"] = diagnostic_events
+    assert "diagnostics.events exceeds its total serialized size limit" in validate_row_schema(row)
 
 
 def test_nested_stdout_truncation_flag_is_schema_valid():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -29,6 +29,7 @@ from run_docs_eval import (  # noqa: E402
     _sanitize_response_text,
     _sanitize_text,
     build_mcp_config,
+    compare_results,
     parse_event_stream,
     run_evaluation,
     run_single_eval,
@@ -1159,6 +1160,42 @@ def test_escaped_authorization_does_not_leak_in_stdout_or_stderr(monkeypatch):
     assert "digest-secret" not in result["diagnostics"]["stderr_excerpt"]
     assert "[REDACTED]" in result["diagnostics"]["stdout_excerpt"]
     assert "[REDACTED]" in result["diagnostics"]["stderr_excerpt"]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        r'upstream={\\"Authorization\\":CustomScheme opaque-value}',
+        r'upstream={\\\\\"Authorization\\\\\":Digest username=alice, nonce=LEAKME}',
+    ],
+)
+def test_deeply_escaped_authorization_is_clean_in_valid_raw_and_scored_rows(monkeypatch, response):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=_event_stream(response=response),
+            stderr=response,
+        ),
+    )
+
+    raw_row = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+    scored_row = score_result(raw_row)
+
+    assert raw_row["status"] == "success"
+    assert scored_row["row_valid"] is True
+    for row in (raw_row, scored_row):
+        persisted = json.dumps(row)
+        assert "opaque-value" not in persisted
+        assert "LEAKME" not in persisted
+        assert "[REDACTED]" in persisted
 
 
 def test_exact_custom_scheme_escaped_authorization_does_not_leak_in_excerpts(monkeypatch):
@@ -2512,6 +2549,33 @@ def test_required_matrix_rejects_omitted_selector_triple():
     )
 
 
+@pytest.mark.parametrize(
+    ("scenario_ids", "servers", "models", "empty_name"),
+    [
+        ([], [], [], "scenarios"),
+        ([], ["foundry-docs"], ["model-1"], "scenarios"),
+        (["scenario-1"], [], ["model-1"], "servers"),
+        (["scenario-1"], ["foundry-docs"], [], "models"),
+    ],
+)
+def test_required_matrix_rejects_explicit_empty_selector_collections(
+    scenario_ids,
+    servers,
+    models,
+    empty_name,
+):
+    publication = validate_required_matrix(
+        [],
+        scenario_ids=scenario_ids,
+        servers=servers,
+        models=models,
+    )
+
+    assert publication["allowed"] is False
+    assert empty_name in publication["empty_required_selectors"]
+    assert "required selector collection(s) must not be empty" in publication["failure_reasons"][-1]
+
+
 def test_required_matrix_sanitizes_unknown_selector_row_labels():
     selector = r"token=SERVERLEAK C:\Users\Alice\private"
 
@@ -2728,3 +2792,45 @@ def test_scorer_cli_writes_blocked_diagnostics_before_failing(tmp_path):
     assert "extra_secret" not in scored["metadata"]
     assert "token=[REDACTED]" in persisted
     assert "<PATH>" in persisted
+
+
+def test_baseline_comparison_blocks_missing_current_required_rows(tmp_path, capsys):
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({
+            "results": [
+                _raw_row(scenario_id="scenario-1", server="foundry-docs", model="model-1"),
+                _raw_row(scenario_id="scenario-2", server="foundry-docs", model="model-1"),
+            ]
+        }),
+        encoding="utf-8",
+    )
+    current = {"results": [_raw_row(scenario_id="scenario-1", server="foundry-docs", model="model-1")]}
+
+    exit_code = compare_results(current, str(baseline_path))
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Baseline comparison blocked" in captured.err
+    assert "No regressions detected" not in captured.out
+
+
+def test_baseline_comparison_blocks_invalid_current_required_row(tmp_path, capsys):
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({"results": [_raw_row()]}),
+        encoding="utf-8",
+    )
+    invalid = _raw_row()
+    invalid["status"] = "invalid"
+    invalid["passed"] = False
+    invalid["response"] = ""
+    invalid["response_present"] = False
+    invalid["failure_reason"] = "invalid evidence"
+
+    exit_code = compare_results({"results": [invalid]}, str(baseline_path))
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Baseline comparison blocked" in captured.err
+    assert "No regressions detected" not in captured.out

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -839,6 +839,12 @@ def test_scorer_clears_response_for_every_non_success_status(status):
     scored = score_result(row)
 
     assert scored["row_valid"] is False
+    assert scored["status"] == "invalid"
+    assert scored["passed"] is False
+    assert scored["operational"]["passed"] is False
+    aggregates = aggregate_scores([scored])
+    assert aggregates["operational_metrics"]["foundry-docs"]["pass_rate"] == 0.0
+    assert aggregates["operational_metrics"]["foundry-docs"]["status_counts"] == {"invalid": 1}
     assert scored["response"] == ""
     assert scored["response_present"] is False
 
@@ -1083,6 +1089,48 @@ def test_large_event_is_stopped_before_json_parse_and_remains_bounded():
     assert parsed["response"] == ""
 
 
+def test_real_size_57kb_tool_result_parses_and_validates_selected_source(monkeypatch):
+    completion = {
+        "type": "tool.execution_complete",
+        "data": {
+            "toolCallId": "call-1",
+            "success": True,
+            "result": {"content": [{"type": "text", "text": ""}]},
+        },
+    }
+    base_size = len(json.dumps(completion, separators=(",", ":")).encode())
+    completion["data"]["result"]["content"][0]["text"] = "x" * (57_000 - base_size)
+    completion_line = json.dumps(completion, separators=(",", ":"))
+    assert len(completion_line.encode()) == 57_000
+
+    stdout = "\n".join([
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+        }),
+        completion_line,
+        json.dumps({"type": "assistant.message", "data": {"content": "trusted answer"}}),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "success"
+    assert result["source_validated"] is True
+    assert result["response"] == "trusted answer"
+    assert result["event_parse_error"] is None
+
+
 def test_deeply_nested_bounded_json_fails_closed_without_recursion_crash():
     nested = "[" * 5_000 + "null" + "]" * 5_000
     stdout = f'{{"type":"session.error","data":{{"message":{nested}}}}}'
@@ -1126,6 +1174,81 @@ def test_diagnostic_path_keys_are_sanitized(monkeypatch):
     serialized = json.dumps(result["diagnostics"])
     assert "private.txt" not in serialized
     assert "<PATH>" in serialized
+
+
+def test_tool_name_is_validated_raw_but_persisted_sanitized(monkeypatch):
+    tool_name = r"foundry_docs-search_docs token=LEAKME C:\Users\Alice\private"
+    stdout = _event_stream(tool_name=tool_name, response="trusted answer")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    raw_row = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+    scored_row = score_result(raw_row)
+
+    assert raw_row["source_validated"] is True
+    assert scored_row["row_valid"] is True
+    assert raw_row["observed_tools"] == ["foundry_docs-search_docs token=[REDACTED] <PATH>"]
+    for row in (raw_row, scored_row):
+        persisted = json.dumps(row)
+        assert "LEAKME" not in persisted
+        assert "Alice" not in persisted
+        assert "private" not in persisted
+
+
+def test_cross_source_failure_reason_sanitizes_tool_identifier(monkeypatch):
+    tool_name = r"evil-search token=LEAKME C:\Users\Alice\private"
+    stdout = _event_stream(tool_name=tool_name, response="untrusted answer")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "invalid"
+    assert result["failure_reason"].startswith("cross_source_tool_call:")
+    assert "LEAKME" not in result["failure_reason"]
+    assert "Alice" not in result["failure_reason"]
+    assert "private" not in result["failure_reason"]
+    assert "token=[REDACTED]" in result["failure_reason"]
+    assert "<PATH>" in result["failure_reason"]
+
+
+def test_parse_error_sanitizes_tool_call_identifier():
+    tool_call_id = r"call token=CALLSECRET C:\Users\Alice\private"
+    stdout = "\n".join([
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": tool_call_id, "toolName": "foundry_docs-search_docs"},
+        }),
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": tool_call_id, "toolName": "foundry_docs-search_docs"},
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert "CALLSECRET" not in parsed["parse_error"]
+    assert "Alice" not in parsed["parse_error"]
+    assert "private" not in parsed["parse_error"]
+    assert "token=[REDACTED]" in parsed["parse_error"]
+    assert "<PATH>" in parsed["parse_error"]
 
 
 @pytest.mark.parametrize(
@@ -1268,7 +1391,7 @@ def test_scorer_rejects_success_row_missing_required_evidence_fields():
     scored = score_result(fabricated)
 
     assert scored["row_valid"] is False
-    assert scored["scores"]["has_response"] is True
+    assert scored["scores"]["has_response"] is False
 
 
 @pytest.mark.parametrize(
@@ -1313,6 +1436,88 @@ def test_required_matrix_enforces_azure_server_policy():
 
     assert publication["allowed"] is False
     assert publication["invalid_rows"][0]["failure_reason"] == "azure_required_evidence_missing"
+    assert row["status"] == "invalid"
+    assert row["passed"] is False
+    assert row["response"] == ""
+    assert row["response_present"] is False
+    assert row["row_valid"] is False
+    assert row["scores"] == {
+        "completeness": 0.0,
+        "quality": 0.0,
+        "doc_retrieval": 0.0,
+        "response_length": 0,
+        "has_response": False,
+    }
+    aggregates = aggregate_scores([row])
+    assert aggregates["server_model_matrix"] == {}
+    assert aggregates["server_averages"] == {}
+
+
+def test_malformed_azure_tool_evidence_fails_closed_without_crashing():
+    malformed = _raw_row(model="unexpected-model")
+    malformed["successful_tools"] = [None]
+    scored = score_result(malformed)
+
+    publication = validate_required_matrix(
+        [scored],
+        scenario_ids=["scenario-1"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+        azure_required_servers={"foundry-docs"},
+    )
+
+    assert scored["row_valid"] is False
+    assert scored["status"] == "invalid"
+    assert scored["response"] == ""
+    assert publication["allowed"] is False
+
+
+def test_duplicate_azure_rows_are_all_excluded_from_aggregates():
+    missing_azure = score_result(_raw_row())
+    valid_azure_raw = _raw_row()
+    valid_azure_raw["azure_required"] = True
+    valid_azure_raw["azure_live_query_proven"] = True
+    valid_azure_raw["selected_source_config"]["azure_required"] = True
+    valid_azure = score_result(valid_azure_raw)
+    assert valid_azure["row_valid"] is True
+
+    publication = validate_required_matrix(
+        [missing_azure, valid_azure],
+        scenario_ids=["scenario-1"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+        azure_required_servers={"foundry-docs"},
+    )
+    aggregates = aggregate_scores([missing_azure, valid_azure])
+
+    assert publication["allowed"] is False
+    assert publication["duplicate_rows"] == ["scenario-1 / foundry-docs / model-1"]
+    assert all(row["row_valid"] is False for row in (missing_azure, valid_azure))
+    assert all(row["response"] == "" for row in (missing_azure, valid_azure))
+    assert aggregates["server_model_matrix"] == {}
+    assert aggregates["server_averages"] == {}
+
+
+def test_unexpected_rows_are_invalidated_before_aggregation():
+    unexpected = score_result(_raw_row(model="unexpected-model"))
+    assert unexpected["row_valid"] is True
+
+    publication = validate_required_matrix(
+        [unexpected],
+        scenario_ids=["scenario-1"],
+        servers=["foundry-docs"],
+        models=["model-1"],
+        azure_required_servers={"foundry-docs"},
+    )
+    aggregates = aggregate_scores([unexpected])
+
+    assert publication["allowed"] is False
+    assert publication["unexpected_rows"] == ["scenario-1 / foundry-docs / unexpected-model"]
+    assert unexpected["row_valid"] is False
+    assert unexpected["response"] == ""
+    assert unexpected["scores"]["has_response"] is False
+    assert aggregates["server_model_matrix"] == {}
+    assert aggregates["server_averages"] == {}
 
 
 def test_scorer_rejects_contradictory_source_descriptor_and_tool_evidence():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -24,6 +24,7 @@ from run_docs_eval import (  # noqa: E402
     build_mcp_config,
     parse_event_stream,
     run_single_eval,
+    serialized_diagnostic_events_size,
 )
 
 
@@ -524,6 +525,86 @@ def test_authorization_header_redacts_entire_value_for_every_scheme(raw, secret)
 
 
 @pytest.mark.parametrize(
+    "raw",
+    [
+        r'upstream={\"Authorization\":\"CustomScheme opaque-value\"}',
+        r'upstream={\"authorization\":\"Basic dXNlcjpwYXNz\"}',
+        r'upstream={\"AUTHORIZATION\":\"Digest username=alice response=digest-secret\"}',
+    ],
+)
+def test_escaped_serialized_authorization_is_redacted_from_text(raw):
+    sanitized, _truncated = _sanitize_text(raw)
+
+    assert "opaque-value" not in sanitized
+    assert "dXNlcjpwYXNz" not in sanitized
+    assert "digest-secret" not in sanitized
+    assert "[REDACTED]" in sanitized
+
+
+def test_escaped_authorization_does_not_leak_in_stdout_or_stderr(monkeypatch):
+    leaked = (
+        r'upstream={\"Authorization\":\"Digest username=\\\"alice\\\", '
+        r'response=\\\"digest-secret\\\"\"}'
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=f"{leaked}\nnot-json",
+            stderr=leaked,
+        ),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert "alice" not in result["diagnostics"]["stdout_excerpt"]
+    assert "alice" not in result["diagnostics"]["stderr_excerpt"]
+    assert "digest-secret" not in result["diagnostics"]["stdout_excerpt"]
+    assert "digest-secret" not in result["diagnostics"]["stderr_excerpt"]
+    assert "[REDACTED]" in result["diagnostics"]["stdout_excerpt"]
+    assert "[REDACTED]" in result["diagnostics"]["stderr_excerpt"]
+
+
+def test_truncated_escaped_authorization_value_fails_closed(monkeypatch):
+    leaked = (
+        r'upstream={\"Authorization\":\"Digest nonce=LEAKME, username=\\\"alice\\\", '
+        r'response=\\\"digest-secret\\\"' + ("x" * 20_000)
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=f"{leaked}\nnot-json",
+            stderr=leaked,
+        ),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    for excerpt in (
+        result["diagnostics"]["stdout_excerpt"],
+        result["diagnostics"]["stderr_excerpt"],
+    ):
+        assert "LEAKME" not in excerpt
+        assert "digest-secret" not in excerpt
+        assert "[REDACTED]" in excerpt
+
+
+@pytest.mark.parametrize(
     "raw_path",
     [
         "C:/Users/Jane Doe/private/file.txt",
@@ -714,6 +795,92 @@ def test_size_based_event_truncation_is_schema_valid():
     row["diagnostics"]["events_truncated"] = True
 
     assert validate_row_schema(row) == []
+
+
+def test_serialized_event_size_helper_matches_persisted_json_envelope():
+    events = [
+        {"event_type": "session.error", "data": {"message": "first"}},
+        {"event_type": "session.mcp_servers_loaded", "data": {"servers": []}},
+    ]
+
+    assert serialized_diagnostic_events_size(events) == len(
+        json.dumps(events, ensure_ascii=True, separators=(",", ":"))
+    )
+
+
+def _session_error_events_at_serialized_size(target_size: int) -> list[dict]:
+    source_events = []
+    diagnostic_events = []
+    for _ in range(5):
+        data = {"errorType": "q", "message": "m"}
+        data.update({f"field{field_index}": "" for field_index in range(18)})
+        source_events.append({"type": "session.error", "data": data})
+        diagnostic_events.append({"event_type": "session.error", "data": dict(data)})
+
+    remaining = target_size - serialized_diagnostic_events_size(diagnostic_events)
+    assert remaining >= 0
+    for field_index in range(18):
+        for event_index in range(5):
+            if remaining == 0:
+                break
+            addition = min(2_000, remaining)
+            value = "x" * addition
+            source_events[event_index]["data"][f"field{field_index}"] = value
+            diagnostic_events[event_index]["data"][f"field{field_index}"] = value
+            remaining -= addition
+        if remaining == 0:
+            break
+
+    assert remaining == 0
+    assert serialized_diagnostic_events_size(diagnostic_events) == target_size
+    return source_events
+
+
+def test_runner_accepts_exact_event_envelope_limit():
+    source_events = _session_error_events_at_serialized_size(50_000)
+    stdout = "\n".join([
+        *(json.dumps(event, separators=(",", ":")) for event in source_events),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["diagnostic_events_truncated"] is False
+    assert len(parsed["diagnostic_events"]) == 5
+    assert serialized_diagnostic_events_size(parsed["diagnostic_events"]) == 50_000
+
+
+def test_runner_truncates_event_envelope_one_byte_over_limit():
+    source_events = _session_error_events_at_serialized_size(50_001)
+    stdout = "\n".join([
+        *(json.dumps(event, separators=(",", ":")) for event in source_events),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["diagnostic_events_truncated"] is True
+    assert len(parsed["diagnostic_events"]) == 4
+    assert serialized_diagnostic_events_size(parsed["diagnostic_events"]) < 50_000
+
+
+def test_scorer_accepts_exact_event_envelope_limit_and_rejects_one_byte_over():
+    event = {"event_type": "boundary", "data": {"message": ""}}
+    overhead = serialized_diagnostic_events_size([event])
+    event["data"]["message"] = "x" * (50_000 - overhead)
+    assert serialized_diagnostic_events_size([event]) == 50_000
+
+    at_limit = _raw_row()
+    at_limit["diagnostics"]["events"] = [event]
+    assert validate_row_schema(at_limit) == []
+
+    over_limit = _raw_row()
+    over_limit["diagnostics"]["events"] = [{
+        "event_type": "boundary",
+        "data": {"message": event["data"]["message"] + "x"},
+    }]
+    assert serialized_diagnostic_events_size(over_limit["diagnostics"]["events"]) == 50_001
+    assert "diagnostics.events exceeds its total serialized size limit" in validate_row_schema(over_limit)
 
 
 def test_nested_stdout_truncation_flag_is_schema_valid():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -16,7 +16,13 @@ from fastmcp import Client
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from eval_report import generate_report  # noqa: E402
-from eval_scorer import aggregate_scores, score_result, validate_required_matrix, validate_row_schema  # noqa: E402
+from eval_scorer import (  # noqa: E402
+    _sanitize_metadata,
+    aggregate_scores,
+    score_result,
+    validate_required_matrix,
+    validate_row_schema,
+)
 from foundry_docs_mcp._server_factory import DOCS_CONFIG, build_server  # noqa: E402
 from run_docs_eval import (  # noqa: E402
     MCP_SERVERS,
@@ -24,6 +30,7 @@ from run_docs_eval import (  # noqa: E402
     _sanitize_text,
     build_mcp_config,
     parse_event_stream,
+    run_evaluation,
     run_single_eval,
     select_servers,
     serialized_diagnostic_events_size,
@@ -1075,6 +1082,40 @@ def test_authorization_header_redacts_entire_value_for_every_scheme(raw, secret)
 @pytest.mark.parametrize(
     "raw",
     [
+        "Authorization: Digest username=alice,\r\n nonce=LEAKME",
+        "Authorization=Digest username=alice,\n\tnonce=LEAKME",
+        "Authorization: Digest username=alice,\r\n \r\n nonce=LEAKME",
+    ],
+)
+def test_folded_authorization_values_redact_indented_continuations(raw):
+    sanitized, _truncated = _sanitize_text(raw)
+
+    assert sanitized in {"Authorization: [REDACTED]", "Authorization=[REDACTED]"}
+    assert "LEAKME" not in sanitized
+    assert "nonce" not in sanitized
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "Authorization=Basic credential",
+        "Authorization=CustomScheme opaque credential",
+        "Authorization=Digest username=alice, realm=private, nonce=SECRET",
+        '"Authorization"=Digest username=alice, realm=private, nonce=SECRET',
+        '"Authorization": Digest username=alice, realm=private, nonce=SECRET',
+        r'{\"Authorization\":Digest username=alice, realm=private, nonce=SECRET}',
+        'Authorization=Digest username="alice}", nonce="LEAKME"',
+    ],
+)
+def test_unquoted_authorization_assignment_redacts_complete_value(raw):
+    sanitized, _truncated = _sanitize_text(raw)
+
+    assert sanitized == "Authorization=[REDACTED]"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
         r'upstream={\"Authorization\":\"CustomScheme opaque-value\"}',
         r'upstream={\"authorization\":\"Basic dXNlcjpwYXNz\"}',
         r'upstream={\"AUTHORIZATION\":\"Digest username=alice response=digest-secret\"}',
@@ -1849,6 +1890,232 @@ def test_parse_event_stream_rejects_non_object_events_and_unknown_tool_outcomes(
 
 
 @pytest.mark.parametrize(
+    "invalid_value",
+    [
+        r"token=LEAKME C:\Users\Alice\private",
+        float("nan"),
+        float("inf"),
+        -1,
+    ],
+)
+def test_usage_metrics_discard_invalid_values_and_remain_strict_json(invalid_value):
+    stdout = json.dumps({
+        "type": "result",
+        "exitCode": 0,
+        "usage": {
+            "premiumRequests": invalid_value,
+            "totalApiDurationMs": invalid_value,
+            "sessionDurationMs": invalid_value,
+        },
+    })
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["premium_requests"] is None
+    assert parsed["api_duration_ms"] is None
+    assert parsed["session_duration_ms"] is None
+    assert "must be a finite non-negative number" in parsed["parse_error"]
+    assert "LEAKME" not in parsed["parse_error"]
+    assert "Alice" not in parsed["parse_error"]
+    json.dumps(parsed, allow_nan=False)
+
+
+@pytest.mark.parametrize("usage", [None, False, [], "", 0])
+def test_usage_rejects_every_falsy_non_object_value(usage):
+    parsed = parse_event_stream(json.dumps({
+        "type": "result",
+        "exitCode": 0,
+        "usage": usage,
+    }))
+
+    assert "result usage must be a JSON object" in parsed["parse_error"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("premium_requests", float("nan")),
+        ("api_duration_ms", float("inf")),
+        ("session_duration_ms", -1),
+    ],
+)
+def test_scorer_rejects_nonfinite_usage_metrics(field, value):
+    row = _raw_row()
+    row[field] = value
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert scored[field] is None
+    json.dumps(scored, allow_nan=False)
+
+
+def test_cumulative_output_tokens_cannot_exceed_metric_bound():
+    stdout = "\n".join([
+        json.dumps({
+            "type": "assistant.message",
+            "data": {"content": "first", "outputTokens": 10**15},
+        }),
+        json.dumps({
+            "type": "assistant.message",
+            "data": {"content": "second", "outputTokens": 10**15},
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["output_tokens"] == 10**15
+    assert "cumulative output token count exceeds" in parsed["parse_error"]
+
+
+@pytest.mark.parametrize("output_tokens", [None, False, "", 0.0])
+def test_output_token_count_rejects_explicit_non_integer_values(output_tokens):
+    parsed = parse_event_stream("\n".join([
+        json.dumps({
+            "type": "assistant.message",
+            "data": {"content": "answer", "outputTokens": output_tokens},
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ]))
+
+    assert parsed["output_tokens"] == 0
+    assert "output token count must be a non-negative integer" in parsed["parse_error"]
+
+
+def test_usage_metrics_reject_integer_beyond_aggregation_bound():
+    parsed = parse_event_stream(json.dumps({
+        "type": "result",
+        "exitCode": 0,
+        "usage": {"premiumRequests": 10**1_000},
+    }))
+
+    assert parsed["premium_requests"] is None
+    assert "must be a finite non-negative number" in parsed["parse_error"]
+
+
+def test_nonfinite_nested_diagnostic_value_is_normalized_for_strict_json():
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.error",
+            "data": {"errorType": "query", "message": "failed", "extra": float("nan")},
+        }),
+        json.dumps({"type": "result", "exitCode": 1}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["diagnostic_events"][0]["data"]["extra"] is None
+    json.dumps(parsed, allow_nan=False)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), -1, 10**1_000])
+def test_scorer_rejects_nonfinite_response_time(value):
+    row = _raw_row()
+    row["response_time_seconds"] = value
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert scored["operational"]["response_time_seconds"] is None
+    assert scored["response_time_seconds"] is None
+    json.dumps(scored, allow_nan=False)
+
+
+@pytest.mark.parametrize("field", ["turns", "tool_calls", "tool_errors", "output_tokens"])
+def test_invalid_count_metrics_are_removed_from_strict_scored_output(field):
+    row = _raw_row()
+    row[field] = float("nan")
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert scored[field] is None
+    json.dumps(scored, allow_nan=False)
+
+
+@pytest.mark.parametrize("field", ["turns", "tool_calls", "tool_errors", "output_tokens"])
+def test_oversized_count_metrics_are_removed_from_operational_output(field):
+    row = _raw_row()
+    row[field] = 10**10_000
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert scored[field] is None
+    assert scored["operational"][field] is None
+    json.dumps(scored, allow_nan=False)
+
+
+def test_oversized_source_config_and_metadata_counts_are_bounded():
+    row = _raw_row()
+    row["source_config_count"] = 10**10_000
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert scored["source_config_count"] == 0
+    json.dumps(scored, allow_nan=False)
+
+    metadata = {
+        "run_id": "run-1",
+        "servers": ["foundry-docs"],
+        "models": ["model-1"],
+        "total_evaluations": 10**10_000,
+    }
+    # The scorer's metadata projection drops the oversized count before strict output.
+    projected = _sanitize_metadata(metadata)
+    assert "total_evaluations" not in projected
+    json.dumps(projected, allow_nan=False)
+
+
+def test_derived_tool_error_total_is_bounded():
+    first = score_result(_raw_row())
+    second = score_result(_raw_row(scenario_id="scenario-2"))
+    first["operational"]["tool_errors"] = 10**15
+    second["operational"]["tool_errors"] = 10**15
+
+    aggregates = aggregate_scores([first, second])
+    operational = aggregates["operational_metrics"]["foundry-docs"]
+
+    assert operational["total_tool_errors"] is None
+    assert operational["tool_errors_overflow"] is True
+    json.dumps(aggregates, allow_nan=False)
+
+
+@pytest.mark.parametrize("field", ["premium_requests", "api_duration_ms", "session_duration_ms"])
+def test_scorer_rejects_usage_metric_above_bound(field):
+    row = _raw_row()
+    row[field] = 10**15 + 1
+
+    scored = score_result(row)
+
+    assert scored["row_valid"] is False
+    assert scored[field] is None
+    json.dumps(scored, allow_nan=False)
+
+
+def test_usage_metrics_accept_large_non_negative_integer_without_float_overflow():
+    large_integer = 10**15
+    stdout = json.dumps({
+        "type": "result",
+        "exitCode": 0,
+        "usage": {"premiumRequests": large_integer},
+    })
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["premium_requests"] == large_integer
+    assert parsed["parse_error"] is None
+    json.dumps(parsed, allow_nan=False)
+
+    invalid_row = {"premium_requests": large_integer}
+    scored = score_result(invalid_row)
+    assert scored["row_valid"] is False
+    assert scored["premium_requests"] == large_integer
+    json.dumps(scored, allow_nan=False)
+
+
+@pytest.mark.parametrize(
     "events",
     [
         [
@@ -2351,6 +2618,19 @@ def test_required_matrix_denominators_include_every_outcome():
         "missing": 1,
     }
     assert publication["response_counts"] == {"present": 1, "missing": 3}
+
+
+@pytest.mark.parametrize(
+    ("scenarios", "servers", "models", "message"),
+    [
+        ([], None, None, "scenarios must not be empty"),
+        ([SCENARIO], {}, None, "servers must not be empty"),
+        ([SCENARIO], None, [], "models must not be empty"),
+    ],
+)
+def test_run_evaluation_rejects_explicit_empty_collections(scenarios, servers, models, message):
+    with pytest.raises(ValueError, match=message):
+        run_evaluation(scenarios, servers=servers, models=models)
 
 
 def test_invalid_matrix_generates_diagnostics_without_comparative_scores():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -2421,6 +2421,26 @@ def test_trusted_scenario_ids_reject_sanitization_collisions():
         validate_trusted_scenarios(scenarios)
 
 
+def test_trusted_scenario_validation_errors_do_not_leak_raw_id():
+    scenario_id = r"token=LEAKME C:\Users\Alice\private"
+    scenarios = [{
+        "id": scenario_id,
+        "question": "question",
+        "category": "category",
+        "rubric": SCENARIO["rubric"],
+    }]
+
+    with pytest.raises(ValueError) as exc_info:
+        validate_trusted_scenarios(scenarios)
+
+    error = str(exc_info.value)
+    assert "LEAKME" not in error
+    assert "Alice" not in error
+    assert "private" not in error
+    assert "token=[REDACTED]" in error
+    assert "<PATH>" in error
+
+
 def test_scorer_rejects_and_sanitizes_malicious_persisted_identifiers():
     row = _raw_row()
     malicious = r"foundry_docs-search_docs token=LEAKME C:\Users\Alice\private " + ("x" * 500)

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -22,7 +22,8 @@ from eval_report import generate_report  # noqa: E402
 from eval_scorer import (  # noqa: E402
     _sanitize_metadata,
     aggregate_scores,
-    score_result,
+    score_result as _score_result,
+    validate_trusted_scenarios,
     validate_required_matrix,
     validate_row_schema,
 )
@@ -47,8 +48,8 @@ SCENARIO = {
     "question": "How do I create an agent?",
     "rubric": {
         "must_mention": ["agent"],
-        "quality_criteria": [],
-        "expected_docs": [],
+        "quality_criteria": ["step-by-step"],
+        "expected_docs": ["agent"],
     },
 }
 
@@ -95,6 +96,7 @@ def _raw_row(
         "server": server,
         "model": model,
         "category": "getting-started",
+        "question": SCENARIO["question"],
         "response": response,
         "response_present": bool(response),
         "status": status,
@@ -132,6 +134,32 @@ def _raw_row(
         "output_tokens": 12,
         "response_time_seconds": 0.1,
     }
+
+
+def score_result(result, trusted_scenarios=None):
+    if trusted_scenarios is None:
+        scenario_id = result.get("scenario_id") if isinstance(result, dict) else SCENARIO["id"]
+        trusted_scenarios = {
+            scenario_id: {
+                "id": scenario_id,
+                "question": SCENARIO["question"],
+                "category": SCENARIO["category"],
+                "rubric": SCENARIO["rubric"],
+            }
+        }
+    return _score_result(result, trusted_scenarios)
+
+
+def _trusted_definitions(*scenario_ids):
+    return [
+        {
+            "id": scenario_id,
+            "question": SCENARIO["question"],
+            "category": SCENARIO["category"],
+            "rubric": SCENARIO["rubric"],
+        }
+        for scenario_id in scenario_ids
+    ]
 
 
 def test_build_mcp_config_contains_exactly_one_selected_source(monkeypatch):
@@ -2301,6 +2329,52 @@ def test_scorer_rejects_success_row_missing_required_evidence_fields():
     assert scored["scores"]["has_response"] is False
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda row: row.pop("rubric"),
+        lambda row: row.update({"rubric": {"must_mention": [], "quality_criteria": [], "expected_docs": []}}),
+        lambda row: row.update({"rubric": {**row["rubric"], "must_mention": ["different"]}}),
+        lambda row: row.update({"question": "different question"}),
+        lambda row: row.update({"category": "different-category"}),
+    ],
+)
+def test_scorer_rejects_missing_empty_or_mismatched_trusted_scenario_fields(mutation):
+    row = _raw_row()
+    mutation(row)
+    trusted = validate_trusted_scenarios([{
+        "id": SCENARIO["id"],
+        "question": SCENARIO["question"],
+        "category": SCENARIO["category"],
+        "rubric": SCENARIO["rubric"],
+    }])
+
+    scored = score_result(row, trusted)
+
+    assert scored["row_valid"] is False
+    assert scored["status"] == "invalid"
+    assert scored["response"] == ""
+    assert scored["scores"]["completeness"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "scenarios",
+    [
+        [{"id": "x", "question": "q", "category": "c", "rubric": {
+            "must_mention": [], "quality_criteria": ["q"], "expected_docs": ["d"]
+        }}],
+        [{"id": "x", "question": "", "category": "c", "rubric": SCENARIO["rubric"]}],
+        [{"id": "x", "question": "q", "category": "c", "rubric": {"must_mention": ["x"]}}],
+        [{"id": " ", "question": " ", "category": " ", "rubric": {
+            "must_mention": [" "], "quality_criteria": [" "], "expected_docs": [" "]
+        }}],
+    ],
+)
+def test_required_scenario_definitions_require_complete_trusted_fields(scenarios):
+    with pytest.raises(ValueError):
+        validate_trusted_scenarios(scenarios)
+
+
 def test_scorer_rejects_and_sanitizes_malicious_persisted_identifiers():
     row = _raw_row()
     malicious = r"foundry_docs-search_docs token=LEAKME C:\Users\Alice\private " + ("x" * 500)
@@ -2870,7 +2944,20 @@ def test_scorer_cli_writes_blocked_diagnostics_before_failing(tmp_path):
         encoding="utf-8",
     )
     scenarios_path.write_text(
-        json.dumps([{"id": "scenario-1"}, {"id": "scenario-2"}]),
+        json.dumps([
+            {
+                "id": "scenario-1",
+                "question": SCENARIO["question"],
+                "category": SCENARIO["category"],
+                "rubric": SCENARIO["rubric"],
+            },
+            {
+                "id": "scenario-2",
+                "question": SCENARIO["question"],
+                "category": SCENARIO["category"],
+                "rubric": SCENARIO["rubric"],
+            },
+        ]),
         encoding="utf-8",
     )
 
@@ -2930,7 +3017,11 @@ def test_baseline_comparison_blocks_missing_current_required_rows(tmp_path, caps
     )
     current = {"results": [_raw_row(scenario_id="scenario-1", server="foundry-docs", model="model-1")]}
 
-    exit_code = compare_results(current, str(baseline_path))
+    exit_code = compare_results(
+        current,
+        str(baseline_path),
+        _trusted_definitions("scenario-1", "scenario-2"),
+    )
 
     assert exit_code == 1
     captured = capsys.readouterr()
@@ -2951,7 +3042,11 @@ def test_baseline_comparison_blocks_invalid_current_required_row(tmp_path, capsy
     invalid["response_present"] = False
     invalid["failure_reason"] = "invalid evidence"
 
-    exit_code = compare_results({"results": [invalid]}, str(baseline_path))
+    exit_code = compare_results(
+        {"results": [invalid]},
+        str(baseline_path),
+        _trusted_definitions("scenario-1"),
+    )
 
     assert exit_code == 1
     captured = capsys.readouterr()
@@ -2972,7 +3067,11 @@ def test_baseline_comparison_rejects_invalid_baseline_matrix(tmp_path, capsys):
         encoding="utf-8",
     )
 
-    exit_code = compare_results({"results": [_raw_row()]}, str(baseline_path))
+    exit_code = compare_results(
+        {"results": [_raw_row()]},
+        str(baseline_path),
+        _trusted_definitions("scenario-1"),
+    )
 
     assert exit_code == 2
     captured = capsys.readouterr()
@@ -2985,7 +3084,11 @@ def test_baseline_comparison_rejects_malformed_baseline_shape(tmp_path, capsys, 
     baseline_path = tmp_path / "baseline.json"
     baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
 
-    exit_code = compare_results({"results": [_raw_row()]}, str(baseline_path))
+    exit_code = compare_results(
+        {"results": [_raw_row()]},
+        str(baseline_path),
+        _trusted_definitions("scenario-1"),
+    )
 
     assert exit_code == 2
     assert "must be an object with a results array" in capsys.readouterr().err
@@ -3022,7 +3125,10 @@ def test_cli_main_baseline_comparison_fails_for_missing_required_current_row(
     monkeypatch.setattr(
         run_docs_eval,
         "load_scenarios",
-        lambda path: [SCENARIO],
+        lambda path: [
+            SCENARIO,
+            {**SCENARIO, "id": "scenario-2"},
+        ],
     )
     monkeypatch.setattr(
         run_docs_eval,

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import os
@@ -15,6 +16,7 @@ from fastmcp import Client
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
+import run_docs_eval  # noqa: E402
 from eval_report import generate_report  # noqa: E402
 from eval_scorer import (  # noqa: E402
     _sanitize_metadata,
@@ -1167,6 +1169,7 @@ def test_escaped_authorization_does_not_leak_in_stdout_or_stderr(monkeypatch):
     [
         r'upstream={\\"Authorization\\":CustomScheme opaque-value}',
         r'upstream={\\\\\"Authorization\\\\\":Digest username=alice, nonce=LEAKME}',
+        r'upstream={\\\\\\\\\"Authorization\\\\\\\\\":Digest username=alice, nonce=LEAKME}',
     ],
 )
 def test_deeply_escaped_authorization_is_clean_in_valid_raw_and_scored_rows(monkeypatch, response):
@@ -2831,6 +2834,65 @@ def test_baseline_comparison_blocks_invalid_current_required_row(tmp_path, capsy
     exit_code = compare_results({"results": [invalid]}, str(baseline_path))
 
     assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Baseline comparison blocked" in captured.err
+    assert "No regressions detected" not in captured.out
+
+
+def test_cli_main_baseline_comparison_fails_for_missing_required_current_row(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({
+            "results": [
+                _raw_row(scenario_id="scenario-1"),
+                _raw_row(scenario_id="scenario-2"),
+            ]
+        }),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "results"
+    args = argparse.Namespace(
+        scenarios=str(Path(__file__).parents[1] / "tests" / "docs_eval_scenarios.json"),
+        output_dir=str(output_dir),
+        server="foundry-docs",
+        servers=None,
+        models=["model-1"],
+        timeout=3,
+        require_azure=False,
+        dry_run=False,
+        baseline=str(baseline_path),
+    )
+    monkeypatch.setattr(run_docs_eval, "_parse_args", lambda: args)
+    monkeypatch.setattr(
+        run_docs_eval,
+        "load_scenarios",
+        lambda path: [SCENARIO],
+    )
+    monkeypatch.setattr(
+        run_docs_eval,
+        "run_evaluation",
+        lambda scenarios, servers, models, timeout, require_azure: {
+            "metadata": {
+                "run_id": "current-run",
+                "timestamp": "2026-07-29T00:00:00Z",
+                "scenarios_count": 1,
+                "servers": ["foundry-docs"],
+                "models": ["model-1"],
+                "total_evaluations": 1,
+                "completed": 1,
+            },
+            "results": [_raw_row(scenario_id="scenario-1")],
+        },
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_docs_eval.main()
+
+    assert exc_info.value.code == 1
     captured = capsys.readouterr()
     assert "Baseline comparison blocked" in captured.err
     assert "No regressions detected" not in captured.out

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -283,6 +283,32 @@ def test_success_response_is_sanitized_in_raw_and_scored_rows(monkeypatch):
         assert "<PATH>" in persisted
 
 
+def test_scorer_cli_requires_trusted_scenario_file_before_scoring(tmp_path):
+        raw_path = tmp_path / "raw.json"
+        output_path = tmp_path / "scored.json"
+        raw_path.write_text(
+            json.dumps({"metadata": {}, "results": [_raw_row()]}),
+            encoding="utf-8",
+        )
+
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).parents[1] / "scripts" / "eval_scorer.py"),
+                str(raw_path),
+                "--output",
+                str(output_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert proc.returncode == 2
+        assert "--required-scenarios" in proc.stderr
+        assert not output_path.exists()
+
+
 def test_success_response_preserves_root_relative_documentation_link(monkeypatch):
     response = (
         "Use agents. See [agent docs](/concepts/agents) for prerequisites. "
@@ -2375,6 +2401,26 @@ def test_required_scenario_definitions_require_complete_trusted_fields(scenarios
         validate_trusted_scenarios(scenarios)
 
 
+def test_trusted_scenario_ids_reject_sanitization_collisions():
+    scenarios = [
+        {
+            "id": "token=abc",
+            "question": "question one",
+            "category": "category",
+            "rubric": SCENARIO["rubric"],
+        },
+        {
+            "id": "token=[REDACTED]",
+            "question": "question two",
+            "category": "category",
+            "rubric": SCENARIO["rubric"],
+        },
+    ]
+
+    with pytest.raises(ValueError, match="canonical form"):
+        validate_trusted_scenarios(scenarios)
+
+
 def test_scorer_rejects_and_sanitizes_malicious_persisted_identifiers():
     row = _raw_row()
     malicious = r"foundry_docs-search_docs token=LEAKME C:\Users\Alice\private " + ("x" * 500)
@@ -3071,6 +3117,25 @@ def test_baseline_comparison_rejects_invalid_baseline_matrix(tmp_path, capsys):
         {"results": [_raw_row()]},
         str(baseline_path),
         _trusted_definitions("scenario-1"),
+    )
+
+    assert exit_code == 2
+    captured = capsys.readouterr()
+    assert "invalid baseline matrix" in captured.err
+    assert "No regressions detected" not in captured.out
+
+
+def test_baseline_comparison_requires_every_trusted_scenario_in_baseline(tmp_path, capsys):
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        json.dumps({"results": [_raw_row(scenario_id="scenario-1")]}),
+        encoding="utf-8",
+    )
+
+    exit_code = compare_results(
+        {"results": [_raw_row(scenario_id="scenario-1")]},
+        str(baseline_path),
+        _trusted_definitions("scenario-1", "scenario-2"),
     )
 
     assert exit_code == 2

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -1010,6 +1010,53 @@ def test_real_mcp_servers_loaded_schema_preserves_statuses_and_selected_failure(
     assert "[REDACTED]" in diagnostic["data"]["servers"][0]["error"]
 
 
+def test_canonical_mcp_servers_loaded_diagnostic_scores_as_valid(monkeypatch):
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_servers_loaded",
+            "ephemeral": True,
+            "data": {
+                "servers": [
+                    {
+                        "name": "foundry_docs",
+                        "status": "connected",
+                        "source": "user",
+                        "transport": "stdio",
+                    }
+                ]
+            },
+        }),
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+        }),
+        json.dumps({
+            "type": "tool.execution_complete",
+            "data": {"toolCallId": "call-1", "success": True},
+        }),
+        json.dumps({"type": "assistant.message", "data": {"content": "trusted answer"}}),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    raw_row = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+    scored_row = score_result(raw_row)
+
+    assert raw_row["status"] == "success"
+    assert raw_row["diagnostics"]["events"][0]["event_type"] == "session.mcp_servers_loaded"
+    assert scored_row["row_valid"] is True
+    assert scored_row["status"] == "success"
+
+
 def test_real_session_error_schema_preserves_diagnostics_and_invalidates_answer(monkeypatch):
     stdout = "\n".join([
         json.dumps({

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -354,6 +354,31 @@ def test_process_launch_error_sanitizes_every_persisted_field(monkeypatch):
     assert result["diagnostics"]["stderr_excerpt"] == result["stderr"]
 
 
+def test_exact_process_launch_error_leaks_neither_token_nor_path_in_raw_or_scored_row(monkeypatch):
+    leaked = r"token=LEAKME at C:\Users\Alice\private"
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: (_ for _ in ()).throw(OSError(leaked)),
+    )
+
+    raw_row = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+    scored_row = score_result(raw_row)
+
+    for row in (raw_row, scored_row):
+        persisted = json.dumps(row)
+        assert "LEAKME" not in persisted
+        assert "Alice" not in persisted
+        assert "private" not in persisted
+        assert "token=[REDACTED]" in persisted
+        assert "<PATH>" in persisted
+
+
 def test_mcp_initialization_failure_preserves_sanitized_lifecycle_diagnostics(monkeypatch):
     stdout = "\n".join([
         json.dumps({


### PR DESCRIPTION
## Summary
- retain bounded, sanitized MCP lifecycle/status/error events and failed tool diagnostics in each evaluation row
- preserve parsed partial MCP/tool evidence plus sanitized stdout/stderr excerpts on timeout while keeping timeout responses invalid
- enforce the exact bounded diagnostic envelope in scoring so malformed, missing, or oversized diagnostics block comparative publication

## Validation
- `python -m pytest tests\test_docs_eval_evidence.py tests\test_mcp_server_inspection.py -q` (73 passed)
- `python -m ruff check scripts\run_docs_eval.py scripts\eval_scorer.py scripts\eval_report.py foundry_docs_mcp\_server_factory.py tests\test_docs_eval_evidence.py`
- `git diff --check origin/main...HEAD`
- 60,000-character sanitizer probe: bounded to 2,014 characters with truncation asserted (~0.096s)

This corrective diff contains only `scripts/run_docs_eval.py`, `scripts/eval_scorer.py`, and `tests/test_docs_eval_evidence.py`; the implementation already merged in #644 is excluded.

Follow-up to #631 and #644.