### PR TITLE
Prove trusted navigation no-op

### DIFF
--- a/.github/issue-629-postmerge-noop-proof.txt
+++ b/.github/issue-629-postmerge-noop-proof.txt
@@ -1,0 +1,1 @@
+Temporary irrelevant-path change used to verify the trusted required-check sentinel.


### PR DESCRIPTION
Disposable post-merge evidence PR for #629. Changes one irrelevant path to prove both the implementation no-op and trusted Validate source navigation sentinel succeed. Must not merge; close after evidence capture.