### PR TITLE
Prove trusted navigation skip handling

### DIFF
--- a/.github/issue-629-skip-ci-proof.txt
+++ b/.github/issue-629-skip-ci-proof.txt
@@ -1,0 +1,1 @@
+Temporary change used to verify that the trusted sentinel fails closed when pull-request CI is skipped.


### PR DESCRIPTION
Disposable post-merge evidence PR for #629. HEAD contains [skip ci], so pull_request workflows should be suppressed while the trusted pull_request_target Validate source navigation sentinel must still run and fail closed. Must not merge; close after evidence capture.