### PR TITLE
Fix docs-vnext sync batch durability gaps

### DIFF
--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -1095,16 +1095,11 @@ class GitHubGitBackend:
         overflow_streams: set[str] = set()
         overflow_event = threading.Event()
         termination_lock = threading.Lock()
-        terminated = False
         process_group_id = process.pid
         deadline = time.monotonic() + timeout_seconds
 
         def terminate_process_group() -> None:
-            nonlocal terminated
             with termination_lock:
-                if terminated:
-                    return
-                terminated = True
                 try:
                     if os.name == "posix":
                         os.killpg(process_group_id, signal.SIGKILL)
@@ -1142,47 +1137,36 @@ class GitHubGitBackend:
         )
         stdout_thread.start()
         stderr_thread.start()
-        timed_out = False
         leader_exited_at: float | None = None
         while True:
-            readers_alive = stdout_thread.is_alive() or stderr_thread.is_alive()
-            leader_exited = process.poll() is not None
-            if overflow_event.is_set() or (leader_exited and not readers_alive):
-                break
+            if overflow_event.is_set():
+                terminate_process_group()
+                raise BatchSyncError(
+                    f"{args[0]} {args[1] if len(args) > 1 else ''} "
+                    f"{'/'.join(sorted(overflow_streams))} exceeds the "
+                    f"{max_bytes}-byte discovery limit"
+                )
 
             now = time.monotonic()
             remaining = deadline - now
-            if remaining <= DISCOVERY_TERMINATION_GRACE_SECONDS:
-                timed_out = True
+            if remaining <= 0:
                 terminate_process_group()
+                raise BatchSyncError(
+                    f"{args[0]} {args[1] if len(args) > 1 else ''} exceeded the "
+                    f"{timeout_seconds}-second discovery timeout"
+                )
+
+            readers_alive = stdout_thread.is_alive() or stderr_thread.is_alive()
+            leader_exited = process.poll() is not None
+            if leader_exited and not readers_alive:
                 break
             if leader_exited:
                 leader_exited_at = leader_exited_at or now
                 if now - leader_exited_at >= DISCOVERY_TERMINATION_GRACE_SECONDS:
                     terminate_process_group()
-                    break
             time.sleep(min(0.01, remaining))
-
-        for thread in (stdout_thread, stderr_thread):
-            remaining = max(0.0, deadline - time.monotonic())
-            thread.join(timeout=remaining)
-        if stdout_thread.is_alive() or stderr_thread.is_alive():
+        if overflow_event.is_set() or overflow_streams:
             terminate_process_group()
-            timed_out = True
-        if process.poll() is None:
-            remaining = max(0.0, deadline - time.monotonic())
-            try:
-                process.wait(timeout=remaining)
-            except subprocess.TimeoutExpired:
-                terminate_process_group()
-                timed_out = True
-
-        if timed_out:
-            raise BatchSyncError(
-                f"{args[0]} {args[1] if len(args) > 1 else ''} exceeded the "
-                f"{timeout_seconds}-second discovery timeout"
-            )
-        if overflow_streams:
             raise BatchSyncError(
                 f"{args[0]} {args[1] if len(args) > 1 else ''} "
                 f"{'/'.join(sorted(overflow_streams))} exceeds the "

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -25,6 +25,7 @@ CHECKPOINT_SCHEMA_VERSION = 1
 DEFAULT_MAX_FILES = 50
 DEFAULT_MAX_PAYLOAD_BYTES = 40 * 1024 * 1024
 MAX_AUTOMATION_BRANCHES = 100
+MAX_COMPLETED_BRANCH_DELETIONS = 500
 MAX_COMMIT_MESSAGE_BYTES = 4096
 MAX_REMOTE_DISCOVERY_BYTES = 32 * 1024
 DISCOVERY_COMMAND_TIMEOUT_SECONDS = 30
@@ -46,6 +47,11 @@ SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 OPERATION_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 GIT_COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
 POSITIVE_DECIMAL_PATTERN = re.compile(r"^[1-9][0-9]*$")
+AUTOMATION_BRANCH_PATTERN = re.compile(
+    rf"^{re.escape(BRANCH_PREFIX)}/"
+    r"(?P<manifest>[0-9a-f]{16})/"
+    r"batch-(?P<number>[0-9]{3})-(?P<batch>[0-9a-f]{12})$"
+)
 DECISIONS = {"add", "modify", "remove", "preserve"}
 MUTATING_DECISIONS = {"add", "modify", "remove"}
 
@@ -645,6 +651,40 @@ def exclude_completed_remote_heads(
         for head_ref, commit_sha in remote_head_commits.items()
         if head_ref not in completed_heads
     }
+
+
+def completed_branch_deletions(
+    pull_requests: Sequence[PullRequest],
+) -> tuple[str, ...]:
+    active_heads = {
+        pull_request.head_ref
+        for pull_request in pull_requests
+        if pull_request.incomplete
+    }
+    deletions: set[str] = set()
+    for pull_request in pull_requests:
+        marker = pull_request.marker
+        match = AUTOMATION_BRANCH_PATTERN.fullmatch(pull_request.head_ref)
+        if (
+            not pull_request.merged
+            or pull_request.head_ref in active_heads
+            or marker is None
+            or match is None
+        ):
+            continue
+        if (
+            marker["manifestSha256"][:16] != match.group("manifest")
+            or marker["batchNumber"] != int(match.group("number"))
+            or marker["batchId"].removeprefix("sha256:")[:12] != match.group("batch")
+        ):
+            continue
+        deletions.add(pull_request.head_ref)
+    if len(deletions) > MAX_COMPLETED_BRANCH_DELETIONS:
+        raise BatchSyncError(
+            f"Found {len(deletions)} verified completed automation branches, above the "
+            f"{MAX_COMPLETED_BRANCH_DELETIONS}-branch cleanup limit"
+        )
+    return tuple(sorted(deletions))
 
 
 def validate_marker_claim(
@@ -1516,9 +1556,35 @@ class GitHubGitBackend:
             commit_sha=commit_sha,
         )
 
+    def _delete_completed_branches(
+        self,
+        pull_requests: Sequence[PullRequest],
+    ) -> None:
+        deletions = completed_branch_deletions(pull_requests)
+        for head_ref in deletions:
+            try:
+                self._run_bounded_stdout(
+                    ["git", "push", "origin", "--delete", head_ref],
+                    max_bytes=MAX_REMOTE_DISCOVERY_BYTES,
+                )
+            except BatchSyncError:
+                output = self._run_bounded_stdout(
+                    [
+                        "git",
+                        "ls-remote",
+                        "--heads",
+                        "origin",
+                        f"refs/heads/{head_ref}",
+                    ],
+                    max_bytes=MAX_REMOTE_DISCOVERY_BYTES,
+                )
+                if parse_remote_branch_refs(output):
+                    raise
+
     def discover_campaign_branches(
         self, pull_requests: Sequence[PullRequest]
     ) -> list[OrphanBranch]:
+        self._delete_completed_branches(pull_requests)
         output = self._run_bounded_stdout(
             [
                 "git",

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -27,6 +27,11 @@ PR_MARKER_PATTERN = re.compile(
     rf"<!-- {re.escape(PR_MARKER_NAME)}\s*\n(?P<payload>\{{.*?\}})\s*\n-->",
     re.DOTALL,
 )
+COMMIT_IDENTITY_FIELDS = {
+    "Manifest-SHA256": "manifest_digest",
+    "Manifest-Run-ID": "manifest_run_id",
+    "Batch-ID": "batch_id",
+}
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 OPERATION_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 DECISIONS = {"add", "modify", "remove", "preserve"}
@@ -97,8 +102,20 @@ class PullRequest:
         return self.state in {"OPEN", "CLOSED"}
 
 
+@dataclass(frozen=True, slots=True)
+class OrphanBranch:
+    head_ref: str
+    manifest_digest: str
+    manifest_run_id: int
+    batch_id: str
+
+
 class AutomationBackend(Protocol):
     def list_pull_requests(self) -> list[PullRequest]: ...
+
+    def list_orphan_branches(
+        self, pull_requests: Sequence[PullRequest]
+    ) -> list[OrphanBranch]: ...
 
     def download_manifest(self, run_id: int) -> Path: ...
 
@@ -265,6 +282,66 @@ def _batch_id(manifest_digest: str, number: int, operations: Sequence[Operation]
     return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"
 
 
+def _strict_path_prefix(parent: str, child: str) -> bool:
+    return child.startswith(f"{parent}/")
+
+
+def _minimal_pathspecs(paths: set[str]) -> tuple[str, ...]:
+    selected: list[str] = []
+    for path in sorted(paths, key=lambda item: (len(PurePosixPath(item).parts), item)):
+        if not any(path == parent or _strict_path_prefix(parent, path) for parent in selected):
+            selected.append(path)
+    return tuple(selected)
+
+
+def _atomic_operation_groups(operations: Sequence[Operation]) -> tuple[tuple[Operation, ...], ...]:
+    parent = list(range(len(operations)))
+
+    def find(index: int) -> int:
+        while parent[index] != index:
+            parent[index] = parent[parent[index]]
+            index = parent[index]
+        return index
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parent[right_root] = left_root
+
+    for left_index, left in enumerate(operations):
+        for right_index in range(left_index + 1, len(operations)):
+            right = operations[right_index]
+            if _strict_path_prefix(left.path, right.path) or _strict_path_prefix(
+                right.path, left.path
+            ):
+                union(left_index, right_index)
+
+    grouped_indices: dict[int, list[int]] = {}
+    for index in range(len(operations)):
+        grouped_indices.setdefault(find(index), []).append(index)
+
+    groups: list[tuple[int, tuple[Operation, ...]]] = []
+    for indices in grouped_indices.values():
+        group = tuple(operations[index] for index in sorted(indices))
+        if len(group) > 1:
+            decisions = {operation.decision for operation in group}
+            paths = [operation.path for operation in group]
+            if "preserve" in decisions:
+                raise BatchSyncError(
+                    "Path dependency collides with a preserved operation and cannot be applied "
+                    f"safely: {paths}"
+                )
+            if not {"add", "remove"} <= decisions or not decisions <= {"add", "remove"}:
+                raise BatchSyncError(
+                    "Path dependency must be a file/directory remove-and-create replacement: "
+                    f"{paths}"
+                )
+        groups.append((min(indices), group))
+    groups.sort(key=lambda item: item[0])
+    return tuple(group for _, group in groups)
+
+
 def plan_batches(
     manifest: Manifest,
     max_files: int,
@@ -276,33 +353,44 @@ def plan_batches(
     if max_payload_bytes <= 0:
         raise BatchSyncError("max_payload_bytes must be greater than zero")
 
+    atomic_groups = _atomic_operation_groups(manifest.operations)
     partitions: list[tuple[Operation, ...]] = []
     current: list[Operation] = []
     current_files = 0
     current_payload = 0
-    for operation in manifest.operations:
-        if operation.file_count > max_files:
-            raise BatchSyncError(
-                f"Operation {operation.path!r} requires {operation.file_count} files, "
-                f"above the {max_files}-file ceiling"
-            )
-        if operation.payload_bytes > max_payload_bytes:
+    for group in atomic_groups:
+        group_files = sum(operation.file_count for operation in group)
+        group_payload = sum(operation.payload_bytes for operation in group)
+        if group_files > max_files or group_payload > max_payload_bytes:
+            paths = [operation.path for operation in group]
+            if len(group) > 1:
+                raise BatchSyncError(
+                    f"Atomic path dependency {paths} requires {group_files} files and "
+                    f"{group_payload} payload bytes, exceeding ceilings of {max_files} files "
+                    f"and {max_payload_bytes} bytes"
+                )
+            operation = group[0]
+            if operation.file_count > max_files:
+                raise BatchSyncError(
+                    f"Operation {operation.path!r} requires {operation.file_count} files, "
+                    f"above the {max_files}-file ceiling"
+                )
             raise BatchSyncError(
                 f"Operation {operation.path!r} requires {operation.payload_bytes} payload bytes, "
                 f"above the {max_payload_bytes}-byte ceiling"
             )
         exceeds_batch = current and (
-            current_files + operation.file_count > max_files
-            or current_payload + operation.payload_bytes > max_payload_bytes
+            current_files + group_files > max_files
+            or current_payload + group_payload > max_payload_bytes
         )
         if exceeds_batch:
             partitions.append(tuple(current))
             current = []
             current_files = 0
             current_payload = 0
-        current.append(operation)
-        current_files += operation.file_count
-        current_payload += operation.payload_bytes
+        current.extend(group)
+        current_files += group_files
+        current_payload += group_payload
     if current:
         partitions.append(tuple(current))
 
@@ -317,8 +405,9 @@ def plan_batches(
         for number, operations in enumerate(partitions, start=1)
     )
     planned_ids = [operation.id for batch in batches for operation in batch.operations]
-    if planned_ids != [operation.id for operation in manifest.operations]:
-        raise BatchSyncError("Batch planning did not preserve the complete manifest operation order")
+    manifest_ids = [operation.id for operation in manifest.operations]
+    if len(planned_ids) != len(set(planned_ids)) or set(planned_ids) != set(manifest_ids):
+        raise BatchSyncError("Batch planning did not assign every manifest operation exactly once")
     return batches
 
 
@@ -407,27 +496,67 @@ def parse_pull_request_marker(body: str | None) -> dict[str, Any] | None:
     return payload
 
 
+def parse_commit_identity(message: str, head_ref: str) -> OrphanBranch:
+    values: dict[str, str] = {}
+    for line in message.splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key in COMMIT_IDENTITY_FIELDS:
+            values[COMMIT_IDENTITY_FIELDS[key]] = value.strip()
+    if set(values) != set(COMMIT_IDENTITY_FIELDS.values()):
+        raise BatchSyncError(
+            f"Orphan automation branch {head_ref!r} is missing campaign identity trailers"
+        )
+    manifest_digest = values["manifest_digest"]
+    batch_id = values["batch_id"]
+    try:
+        manifest_run_id = int(values["manifest_run_id"])
+    except ValueError as exc:
+        raise BatchSyncError(
+            f"Orphan automation branch {head_ref!r} has an invalid manifest run ID"
+        ) from exc
+    if not SHA256_PATTERN.fullmatch(manifest_digest):
+        raise BatchSyncError(
+            f"Orphan automation branch {head_ref!r} has an invalid manifest digest"
+        )
+    if not OPERATION_ID_PATTERN.fullmatch(batch_id):
+        raise BatchSyncError(f"Orphan automation branch {head_ref!r} has an invalid batch ID")
+    if manifest_run_id <= 0:
+        raise BatchSyncError(
+            f"Orphan automation branch {head_ref!r} has a non-positive manifest run ID"
+        )
+    return OrphanBranch(
+        head_ref=head_ref,
+        manifest_digest=manifest_digest,
+        manifest_run_id=manifest_run_id,
+        batch_id=batch_id,
+    )
+
+
 def select_active_manifest(
     current_manifest: Manifest,
     backend: AutomationBackend,
     pull_requests: Sequence[PullRequest],
+    orphan_branches: Sequence[OrphanBranch] = (),
 ) -> Manifest:
     """Resume the single unfinished campaign, downloading its original retained artifact."""
-    active_markers = [
-        pull_request.marker
+    active_identities = [
+        (pull_request.marker["manifestSha256"], pull_request.marker["manifestRunId"])
         for pull_request in pull_requests
         if pull_request.incomplete and pull_request.marker is not None
     ]
-    if not active_markers:
+    active_identities.extend(
+        (branch.manifest_digest, branch.manifest_run_id) for branch in orphan_branches
+    )
+    if not active_identities:
         return current_manifest
 
-    digests = {marker["manifestSha256"] for marker in active_markers}
+    digests = {digest for digest, _ in active_identities}
     if len(digests) != 1:
         raise BatchSyncError(
             "Multiple unfinished docs-vnext sync campaigns exist; close or merge one campaign "
             f"before retrying: {sorted(digests)}"
         )
-    run_ids = {marker["manifestRunId"] for marker in active_markers}
+    run_ids = {run_id for _, run_id in active_identities}
     if len(run_ids) != 1:
         raise BatchSyncError(
             "Unfinished campaign pull requests disagree on the retained manifest workflow run"
@@ -482,6 +611,18 @@ def _verify_metadata(path: Path, expected: dict[str, int | str] | None, label: s
         raise BatchSyncError(f"{label} metadata changed since manifest generation: {path}")
 
 
+def _directory_files(root: Path, relative_to: Path) -> set[str]:
+    files: set[str] = set()
+    for candidate in root.rglob("*"):
+        if candidate.is_symlink():
+            raise BatchSyncError(
+                f"Replacement directory must not contain symbolic links: {candidate}"
+            )
+        if candidate.is_file():
+            files.add(candidate.relative_to(relative_to).as_posix())
+    return files
+
+
 def apply_batch(repository_root: Path, manifest: Manifest, batch: Batch) -> tuple[str, ...]:
     """Verify all preconditions, then apply only the mutating operations in one batch."""
     source_root = _path_under(repository_root, manifest.source_root)
@@ -489,29 +630,77 @@ def apply_batch(repository_root: Path, manifest: Manifest, batch: Batch) -> tupl
     if not source_root.is_dir() or not target_root.is_dir():
         raise BatchSyncError("Manifest source and target roots must exist in the batch worktree")
 
+    removal_paths = {
+        operation.path for operation in batch.operations if operation.decision == "remove"
+    }
+    addition_paths = {
+        operation.path for operation in batch.operations if operation.decision == "add"
+    }
+    replacement_directories: set[Path] = set()
     resolved: list[tuple[Operation, Path, Path]] = []
     for operation in batch.operations:
         source_path = _path_under(source_root, operation.path)
         target_path = _path_under(target_root, operation.path)
-        _verify_metadata(source_path, operation.source, f"Source for {operation.id}")
-        _verify_metadata(target_path, operation.target, f"Target for {operation.id}")
+        if operation.decision == "remove" and source_path.is_dir():
+            expected_additions = {
+                path for path in addition_paths if _strict_path_prefix(operation.path, path)
+            }
+            actual_files = _directory_files(source_path, source_root)
+            if not expected_additions or actual_files != expected_additions:
+                raise BatchSyncError(
+                    f"File replaced by directory {operation.path!r} contains source files outside "
+                    f"its atomic creation dependency: actual={sorted(actual_files)}, "
+                    f"expected={sorted(expected_additions)}"
+                )
+        else:
+            _verify_metadata(source_path, operation.source, f"Source for {operation.id}")
+        if operation.decision == "add" and target_path.is_dir():
+            expected_removals = {
+                path for path in removal_paths if _strict_path_prefix(operation.path, path)
+            }
+            actual_files = _directory_files(target_path, target_root)
+            if not expected_removals or actual_files != expected_removals:
+                raise BatchSyncError(
+                    f"Directory replaced by file {operation.path!r} contains files outside its "
+                    f"atomic removal dependency: actual={sorted(actual_files)}, "
+                    f"expected={sorted(expected_removals)}"
+                )
+            replacement_directories.add(target_path)
+        else:
+            _verify_metadata(target_path, operation.target, f"Target for {operation.id}")
         resolved.append((operation, source_path, target_path))
 
     changed_paths: list[str] = []
+    removal_operations = sorted(
+        (item for item in resolved if item[0].decision == "remove"),
+        key=lambda item: len(PurePosixPath(item[0].path).parts),
+        reverse=True,
+    )
+    for operation, _, target_path in removal_operations:
+        target_path.unlink()
+        changed_paths.append(f"{manifest.target_root}/{operation.path}")
+    for directory in sorted(
+        replacement_directories,
+        key=lambda path: len(path.parts),
+        reverse=True,
+    ):
+        shutil.rmtree(directory)
+
     for operation, source_path, target_path in resolved:
         if operation.decision in {"add", "modify"}:
             target_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(source_path, target_path)
-            changed_paths.append(f"{manifest.target_root}/{operation.path}")
-        elif operation.decision == "remove":
-            target_path.unlink()
             changed_paths.append(f"{manifest.target_root}/{operation.path}")
 
     for operation, source_path, target_path in resolved:
         if operation.decision in {"add", "modify"}:
             _verify_metadata(target_path, _metadata(source_path), f"Applied target for {operation.id}")
         elif operation.decision == "remove":
-            _verify_metadata(target_path, None, f"Applied target for {operation.id}")
+            replacement_children = {
+                path for path in addition_paths if _strict_path_prefix(operation.path, path)
+            }
+            if not (replacement_children and target_path.is_dir()):
+                _verify_metadata(target_path, None, f"Applied target for {operation.id}")
     return tuple(changed_paths)
 
 
@@ -603,6 +792,7 @@ def execute_batches(
                         f"Pull request #{pull_request.number} uses {branch!r} with mismatched metadata"
                     )
                 if pull_request.state == "CLOSED":
+                    backend.publish_batch(manifest, batch, branch)
                     pull_request = backend.reopen_pull_request(pull_request)
                     result = "reopened-pull-request"
                 elif pull_request.merged:
@@ -746,6 +936,41 @@ class GitHubGitBackend:
                     pull_requests.append(self._pull_request_from_api(payload))
         return pull_requests
 
+    def list_orphan_branches(
+        self, pull_requests: Sequence[PullRequest]
+    ) -> list[OrphanBranch]:
+        result = self._run(
+            [
+                "git",
+                "ls-remote",
+                "--heads",
+                "origin",
+                f"refs/heads/{BRANCH_PREFIX}/*",
+            ]
+        )
+        pull_request_heads = {pull_request.head_ref for pull_request in pull_requests}
+        orphan_branches: list[OrphanBranch] = []
+        for line in result.stdout.splitlines():
+            _, separator, ref = line.partition("\t")
+            if not separator or not ref.startswith("refs/heads/"):
+                raise BatchSyncError(f"Cannot parse automation branch reference: {line!r}")
+            head_ref = ref.removeprefix("refs/heads/")
+            if head_ref in pull_request_heads:
+                continue
+            remote_ref = f"refs/remotes/origin/{head_ref}"
+            self._run(
+                [
+                    "git",
+                    "fetch",
+                    "--no-tags",
+                    "origin",
+                    f"+{ref}:{remote_ref}",
+                ]
+            )
+            commit = self._run(["git", "show", "--no-patch", "--format=%B", remote_ref])
+            orphan_branches.append(parse_commit_identity(commit.stdout, head_ref))
+        return orphan_branches
+
     def download_manifest(self, run_id: int) -> Path:
         destination = self.runner_temp / f"resume-manifest-{run_id}"
         destination.mkdir(parents=True, exist_ok=True)
@@ -813,7 +1038,8 @@ class GitHubGitBackend:
             expected_names = set(changed_paths)
             if not expected_names:
                 raise BatchSyncError(f"Batch {batch.number} has no mutating paths to publish")
-            self._run(["git", "add", "--", *sorted(expected_names)], cwd=worktree)
+            pathspecs = _minimal_pathspecs(expected_names)
+            self._run(["git", "add", "--all", "--", *pathspecs], cwd=worktree)
             staged_names = self._changed_names(worktree, "--cached")
             if staged_names != expected_names:
                 raise BatchSyncError(
@@ -835,7 +1061,7 @@ class GitHubGitBackend:
                         "--quiet",
                         remote_ref,
                         "--",
-                        *sorted(expected_names),
+                        *pathspecs,
                     ],
                     cwd=worktree,
                     check=False,
@@ -865,6 +1091,7 @@ class GitHubGitBackend:
                     (
                         f"Sync docs-vnext baseline batch {batch.number}/{batch.total}\n\n"
                         f"Manifest-SHA256: {manifest.digest}\n"
+                        f"Manifest-Run-ID: {manifest.run_id}\n"
                         f"Batch-ID: {batch.id}"
                     ),
                 ],
@@ -1006,7 +1233,13 @@ def main(
             runner_temp=args.runner_temp,
         )
         pull_requests = active_backend.list_pull_requests()
-        manifest = select_active_manifest(current_manifest, active_backend, pull_requests)
+        orphan_branches = active_backend.list_orphan_branches(pull_requests)
+        manifest = select_active_manifest(
+            current_manifest,
+            active_backend,
+            pull_requests,
+            orphan_branches,
+        )
         batches = plan_batches(manifest, args.max_files, args.max_payload_bytes)
         succeeded = execute_batches(
             manifest,

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, Sequence
@@ -21,6 +22,9 @@ BATCH_SCHEMA_VERSION = 1
 CHECKPOINT_SCHEMA_VERSION = 1
 DEFAULT_MAX_FILES = 50
 DEFAULT_MAX_PAYLOAD_BYTES = 40 * 1024 * 1024
+MAX_AUTOMATION_BRANCHES = 100
+MAX_COMMIT_MESSAGE_BYTES = 4096
+DISCOVERY_COMMAND_TIMEOUT_SECONDS = 30
 BRANCH_PREFIX = "automation/docs-vnext-sync"
 PR_MARKER_NAME = "docs-vnext-sync-state"
 PR_MARKER_PATTERN = re.compile(
@@ -32,6 +36,7 @@ COMMIT_IDENTITY_FIELDS = {
     "Manifest-Run-ID": "manifest_run_id",
     "Batch-ID": "batch_id",
 }
+TRAILER_PATTERN = re.compile(r"^(?P<key>[A-Za-z][A-Za-z0-9-]*): (?P<value>\S.*)$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 OPERATION_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 DECISIONS = {"add", "modify", "remove", "preserve"}
@@ -497,14 +502,47 @@ def parse_pull_request_marker(body: str | None) -> dict[str, Any] | None:
 
 
 def parse_commit_identity(message: str, head_ref: str) -> OrphanBranch:
+    message_bytes = len(message.encode("utf-8"))
+    if message_bytes > MAX_COMMIT_MESSAGE_BYTES:
+        raise BatchSyncError(
+            f"Automation branch {head_ref!r} commit message is {message_bytes} bytes, "
+            f"above the {MAX_COMMIT_MESSAGE_BYTES}-byte discovery limit"
+        )
+    lines = message.rstrip("\n").splitlines()
+    separator_indices = [index for index, line in enumerate(lines) if not line]
+    if not separator_indices:
+        raise BatchSyncError(
+            f"Automation branch {head_ref!r} is missing a final campaign trailer block"
+        )
+    trailer_lines = lines[separator_indices[-1] + 1 :]
+    if len(trailer_lines) != len(COMMIT_IDENTITY_FIELDS):
+        raise BatchSyncError(
+            f"Automation branch {head_ref!r} campaign trailer block must contain exactly "
+            f"{len(COMMIT_IDENTITY_FIELDS)} trailers"
+        )
+
     values: dict[str, str] = {}
-    for line in message.splitlines():
-        key, separator, value = line.partition(":")
-        if separator and key in COMMIT_IDENTITY_FIELDS:
-            values[COMMIT_IDENTITY_FIELDS[key]] = value.strip()
+    seen_keys: set[str] = set()
+    for line in trailer_lines:
+        match = TRAILER_PATTERN.fullmatch(line)
+        if match is None:
+            raise BatchSyncError(
+                f"Automation branch {head_ref!r} has a malformed campaign trailer: {line!r}"
+            )
+        key = match.group("key")
+        if key not in COMMIT_IDENTITY_FIELDS:
+            raise BatchSyncError(
+                f"Automation branch {head_ref!r} has an unknown campaign trailer {key!r}"
+            )
+        if key in seen_keys:
+            raise BatchSyncError(
+                f"Automation branch {head_ref!r} has duplicate campaign trailer {key!r}"
+            )
+        seen_keys.add(key)
+        values[COMMIT_IDENTITY_FIELDS[key]] = match.group("value")
     if set(values) != set(COMMIT_IDENTITY_FIELDS.values()):
         raise BatchSyncError(
-            f"Orphan automation branch {head_ref!r} is missing campaign identity trailers"
+            f"Automation branch {head_ref!r} is missing required campaign identity trailers"
         )
     manifest_digest = values["manifest_digest"]
     batch_id = values["batch_id"]
@@ -530,6 +568,25 @@ def parse_commit_identity(message: str, head_ref: str) -> OrphanBranch:
         manifest_run_id=manifest_run_id,
         batch_id=batch_id,
     )
+
+
+def parse_remote_branch_refs(output: str) -> tuple[str, ...]:
+    lines = [line for line in output.splitlines() if line]
+    if len(lines) > MAX_AUTOMATION_BRANCHES:
+        raise BatchSyncError(
+            f"Found {len(lines)} automation branches, above the "
+            f"{MAX_AUTOMATION_BRANCHES}-branch discovery limit"
+        )
+    head_refs: list[str] = []
+    for line in lines:
+        _, separator, ref = line.partition("\t")
+        expected_prefix = f"refs/heads/{BRANCH_PREFIX}/"
+        if not separator or not ref.startswith(expected_prefix):
+            raise BatchSyncError(f"Cannot parse automation branch reference: {line!r}")
+        head_refs.append(ref.removeprefix("refs/heads/"))
+    if len(head_refs) != len(set(head_refs)):
+        raise BatchSyncError("Remote automation branch discovery returned duplicate references")
+    return tuple(head_refs)
 
 
 def select_active_manifest(
@@ -573,6 +630,62 @@ def select_active_manifest(
             f"Retained manifest from run {run_id} has digest {resumed.digest}, expected {digest}"
         )
     return resumed
+
+
+def validate_campaign_identities(
+    manifest: Manifest,
+    batches: Sequence[Batch],
+    backend: AutomationBackend,
+    pull_requests: Sequence[PullRequest],
+    orphan_branches: Sequence[OrphanBranch],
+) -> frozenset[str]:
+    """Bind every unfinished identity to one exact planned batch and verified branch."""
+    batches_by_id = {batch.id: batch for batch in batches}
+    claimed_batches: dict[str, str] = {}
+
+    for pull_request in pull_requests:
+        if not pull_request.incomplete or pull_request.marker is None:
+            continue
+        marker = pull_request.marker
+        batch = batches_by_id.get(marker["batchId"])
+        if batch is None or marker != _marker_payload(manifest, batch):
+            raise BatchSyncError(
+                f"Pull request #{pull_request.number} does not match an exact planned batch "
+                f"for manifest {manifest.digest}"
+            )
+        expected_head = branch_name(manifest, batch)
+        if pull_request.head_ref != expected_head:
+            raise BatchSyncError(
+                f"Pull request #{pull_request.number} head {pull_request.head_ref!r} does not "
+                f"match deterministic branch {expected_head!r}"
+            )
+        prior = claimed_batches.setdefault(batch.id, f"pull request #{pull_request.number}")
+        if prior != f"pull request #{pull_request.number}":
+            raise BatchSyncError(f"Batch {batch.id} is claimed by both {prior} and a pull request")
+        backend.publish_batch(manifest, batch, expected_head)
+
+    for orphan in orphan_branches:
+        batch = batches_by_id.get(orphan.batch_id)
+        if (
+            batch is None
+            or orphan.manifest_digest != manifest.digest
+            or orphan.manifest_run_id != manifest.run_id
+        ):
+            raise BatchSyncError(
+                f"Orphan branch {orphan.head_ref!r} does not match an exact planned batch "
+                f"for manifest {manifest.digest}"
+            )
+        expected_head = branch_name(manifest, batch)
+        if orphan.head_ref != expected_head:
+            raise BatchSyncError(
+                f"Orphan branch {orphan.head_ref!r} does not match deterministic branch "
+                f"{expected_head!r}"
+            )
+        prior = claimed_batches.setdefault(batch.id, f"orphan branch {orphan.head_ref}")
+        if prior != f"orphan branch {orphan.head_ref}":
+            raise BatchSyncError(f"Batch {batch.id} is claimed by both {prior} and an orphan branch")
+        backend.publish_batch(manifest, batch, expected_head)
+    return frozenset(claimed_batches)
 
 
 def _metadata(path: Path) -> dict[str, int | str] | None:
@@ -763,6 +876,7 @@ def execute_batches(
     checkpoint_path: Path,
     max_files: int,
     max_payload_bytes: int,
+    preverified_batch_ids: frozenset[str] = frozenset(),
 ) -> bool:
     """Resume or publish batches sequentially and stop after the first partial failure."""
     checkpoint = _initial_checkpoint(manifest, batches, max_files, max_payload_bytes)
@@ -791,16 +905,18 @@ def execute_batches(
                     raise BatchSyncError(
                         f"Pull request #{pull_request.number} uses {branch!r} with mismatched metadata"
                     )
-                if pull_request.state == "CLOSED":
+                if pull_request.merged:
+                    result = "existing-merged-pull-request"
+                elif batch.id not in preverified_batch_ids:
                     backend.publish_batch(manifest, batch, branch)
+                if pull_request.state == "CLOSED":
                     pull_request = backend.reopen_pull_request(pull_request)
                     result = "reopened-pull-request"
-                elif pull_request.merged:
-                    result = "existing-merged-pull-request"
-                else:
+                elif not pull_request.merged:
                     result = "existing-open-pull-request"
             else:
-                backend.publish_batch(manifest, batch, branch)
+                if batch.id not in preverified_batch_ids:
+                    backend.publish_batch(manifest, batch, branch)
                 title = (
                     f"[docs-vnext-sync] Baseline {manifest.digest[:12]} "
                     f"batch {batch.number}/{batch.total}"
@@ -900,6 +1016,81 @@ class GitHubGitBackend:
             raise BatchSyncError(f"{args[0]} {args[1] if len(args) > 1 else ''} failed: {detail}")
         return result
 
+    def _run_bounded_stdout(
+        self,
+        args: Sequence[str],
+        *,
+        max_bytes: int,
+        cwd: Path | None = None,
+    ) -> str:
+        process = subprocess.Popen(
+            list(args),
+            cwd=cwd or self.repository_root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert process.stdout is not None
+        assert process.stderr is not None
+        stdout = bytearray()
+        stderr = bytearray()
+        overflow_streams: set[str] = set()
+
+        def drain(stream: Any, destination: bytearray, name: str) -> None:
+            while block := stream.read(1024):
+                destination.extend(block)
+                if len(destination) > max_bytes:
+                    overflow_streams.add(name)
+                    try:
+                        process.kill()
+                    except OSError:
+                        pass
+                    return
+
+        stdout_thread = threading.Thread(
+            target=drain,
+            args=(process.stdout, stdout, "stdout"),
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            target=drain,
+            args=(process.stderr, stderr, "stderr"),
+            daemon=True,
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+        try:
+            process.wait(timeout=DISCOVERY_COMMAND_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired as exc:
+            process.kill()
+            process.wait()
+            stdout_thread.join()
+            stderr_thread.join()
+            raise BatchSyncError(
+                f"{args[0]} {args[1] if len(args) > 1 else ''} exceeded the "
+                f"{DISCOVERY_COMMAND_TIMEOUT_SECONDS}-second discovery timeout"
+            ) from exc
+        stdout_thread.join()
+        stderr_thread.join()
+        if overflow_streams:
+            raise BatchSyncError(
+                f"{args[0]} {args[1] if len(args) > 1 else ''} "
+                f"{'/'.join(sorted(overflow_streams))} exceeds the "
+                f"{max_bytes}-byte discovery limit"
+            )
+        try:
+            stdout_text = bytes(stdout).decode("utf-8")
+            stderr_text = bytes(stderr).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise BatchSyncError(f"{args[0]} output is not valid UTF-8") from exc
+        if process.returncode != 0:
+            detail = (
+                stderr_text.strip()
+                or stdout_text.strip()
+                or f"exit code {process.returncode}"
+            )
+            raise BatchSyncError(f"{args[0]} {args[1] if len(args) > 1 else ''} failed: {detail}")
+        return stdout_text
+
     def _pull_request_from_api(self, payload: dict[str, Any]) -> PullRequest:
         merged = payload.get("merged_at") is not None
         state = "MERGED" if merged else str(payload["state"]).upper()
@@ -950,13 +1141,10 @@ class GitHubGitBackend:
         )
         pull_request_heads = {pull_request.head_ref for pull_request in pull_requests}
         orphan_branches: list[OrphanBranch] = []
-        for line in result.stdout.splitlines():
-            _, separator, ref = line.partition("\t")
-            if not separator or not ref.startswith("refs/heads/"):
-                raise BatchSyncError(f"Cannot parse automation branch reference: {line!r}")
-            head_ref = ref.removeprefix("refs/heads/")
+        for head_ref in parse_remote_branch_refs(result.stdout):
             if head_ref in pull_request_heads:
                 continue
+            ref = f"refs/heads/{head_ref}"
             remote_ref = f"refs/remotes/origin/{head_ref}"
             self._run(
                 [
@@ -967,8 +1155,11 @@ class GitHubGitBackend:
                     f"+{ref}:{remote_ref}",
                 ]
             )
-            commit = self._run(["git", "show", "--no-patch", "--format=%B", remote_ref])
-            orphan_branches.append(parse_commit_identity(commit.stdout, head_ref))
+            commit_message = self._run_bounded_stdout(
+                ["git", "show", "--no-patch", "--format=%B", remote_ref],
+                max_bytes=MAX_COMMIT_MESSAGE_BYTES,
+            )
+            orphan_branches.append(parse_commit_identity(commit_message, head_ref))
         return orphan_branches
 
     def download_manifest(self, run_id: int) -> Path:
@@ -1026,7 +1217,7 @@ class GitHubGitBackend:
                     "fetch",
                     "--no-tags",
                     "origin",
-                    f"refs/heads/{branch}:{remote_ref}",
+                    f"+refs/heads/{branch}:{remote_ref}",
                 ]
             )
 
@@ -1241,6 +1432,13 @@ def main(
             orphan_branches,
         )
         batches = plan_batches(manifest, args.max_files, args.max_payload_bytes)
+        preverified_batch_ids = validate_campaign_identities(
+            manifest,
+            batches,
+            active_backend,
+            pull_requests,
+            orphan_branches,
+        )
         succeeded = execute_batches(
             manifest,
             batches,
@@ -1249,6 +1447,7 @@ def main(
             args.checkpoint,
             args.max_files,
             args.max_payload_bytes,
+            preverified_batch_ids,
         )
         _write_summary(args.summary, args.checkpoint)
         if not succeeded:

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -341,7 +341,7 @@ def _atomic_operation_groups(operations: Sequence[Operation]) -> tuple[tuple[Ope
     for index in range(len(operations)):
         grouped_indices.setdefault(find(index), []).append(index)
 
-    groups: list[tuple[int, tuple[Operation, ...]]] = []
+    dependency_intervals: list[tuple[int, int]] = []
     for indices in grouped_indices.values():
         group = tuple(operations[index] for index in sorted(indices))
         if len(group) > 1:
@@ -357,9 +357,28 @@ def _atomic_operation_groups(operations: Sequence[Operation]) -> tuple[tuple[Ope
                     "Path dependency must be a file/directory remove-and-create replacement: "
                     f"{paths}"
                 )
-        groups.append((min(indices), group))
-    groups.sort(key=lambda item: item[0])
-    return tuple(group for _, group in groups)
+            dependency_intervals.append((min(indices), max(indices)))
+
+    merged_intervals: list[tuple[int, int]] = []
+    for start, end in sorted(dependency_intervals):
+        if merged_intervals and start <= merged_intervals[-1][1]:
+            prior_start, prior_end = merged_intervals[-1]
+            merged_intervals[-1] = (prior_start, max(prior_end, end))
+        else:
+            merged_intervals.append((start, end))
+
+    groups: list[tuple[Operation, ...]] = []
+    interval_by_start = {start: end for start, end in merged_intervals}
+    index = 0
+    while index < len(operations):
+        end = interval_by_start.get(index)
+        if end is None:
+            groups.append((operations[index],))
+            index += 1
+        else:
+            groups.append(tuple(operations[index : end + 1]))
+            index = end + 1
+    return tuple(groups)
 
 
 def plan_batches(
@@ -583,11 +602,6 @@ def parse_commit_identity(message: str, head_ref: str) -> OrphanBranch:
 
 def parse_remote_branch_refs(output: str) -> dict[str, str]:
     lines = [line for line in output.splitlines() if line]
-    if len(lines) > MAX_AUTOMATION_BRANCHES:
-        raise BatchSyncError(
-            f"Found {len(lines)} automation branches, above the "
-            f"{MAX_AUTOMATION_BRANCHES}-branch discovery limit"
-        )
     head_refs: dict[str, str] = {}
     for line in lines:
         commit_sha, separator, ref = line.partition("\t")
@@ -615,6 +629,22 @@ def enforce_campaign_candidate_limit(
             f"Found {candidate_count} active automation identity candidates, above the "
             f"{MAX_AUTOMATION_BRANCHES}-branch discovery limit"
         )
+
+
+def exclude_completed_remote_heads(
+    remote_head_commits: dict[str, str],
+    pull_requests: Sequence[PullRequest],
+) -> dict[str, str]:
+    completed_heads = {
+        pull_request.head_ref
+        for pull_request in pull_requests
+        if pull_request.merged
+    }
+    return {
+        head_ref: commit_sha
+        for head_ref, commit_sha in remote_head_commits.items()
+        if head_ref not in completed_heads
+    }
 
 
 def validate_marker_claim(
@@ -681,10 +711,11 @@ def validate_campaign_identities(
     backend: AutomationBackend,
     pull_requests: Sequence[PullRequest],
     campaign_branches: Sequence[OrphanBranch],
-) -> frozenset[str]:
+) -> dict[str, str]:
     """Bind every unfinished identity to one exact planned batch and verified branch."""
     batches_by_id = {batch.id: batch for batch in batches}
     claimed_batches: dict[str, str] = {}
+    authenticated_commits: dict[str, str] = {}
 
     for pull_request in pull_requests:
         if not pull_request.incomplete or not pull_request.head_ref.startswith(
@@ -729,6 +760,7 @@ def validate_campaign_identities(
             expected_head,
             expected_commit_sha=identity.commit_sha,
         )
+        authenticated_commits[batch.id] = identity.commit_sha
 
     for orphan in campaign_branches:
         if orphan.pull_request_number is not None:
@@ -758,7 +790,8 @@ def validate_campaign_identities(
             expected_head,
             expected_commit_sha=orphan.commit_sha,
         )
-    return frozenset(claimed_batches)
+        authenticated_commits[batch.id] = orphan.commit_sha
+    return authenticated_commits
 
 
 def _metadata(path: Path) -> dict[str, int | str] | None:
@@ -949,11 +982,12 @@ def execute_batches(
     checkpoint_path: Path,
     max_files: int,
     max_payload_bytes: int,
-    preverified_batch_ids: frozenset[str] = frozenset(),
+    authenticated_batch_commits: dict[str, str] | None = None,
 ) -> bool:
     """Resume or publish batches sequentially and stop after the first partial failure."""
     checkpoint = _initial_checkpoint(manifest, batches, max_files, max_payload_bytes)
     _write_checkpoint(checkpoint_path, checkpoint)
+    authenticated_batch_commits = authenticated_batch_commits or {}
 
     failed = False
     for batch, batch_state in zip(batches, checkpoint["batches"], strict=True):
@@ -975,7 +1009,7 @@ def execute_batches(
             if branch_pull_requests:
                 pull_request = branch_pull_requests[0]
                 if (
-                    batch.id not in preverified_batch_ids
+                    batch.id not in authenticated_batch_commits
                     and not _matching_marker(manifest, batch, pull_request.marker)
                 ):
                     raise BatchSyncError(
@@ -983,16 +1017,25 @@ def execute_batches(
                     )
                 if pull_request.merged:
                     result = "existing-merged-pull-request"
-                elif batch.id not in preverified_batch_ids:
-                    backend.publish_batch(manifest, batch, branch)
+                else:
+                    backend.publish_batch(
+                        manifest,
+                        batch,
+                        branch,
+                        expected_commit_sha=authenticated_batch_commits.get(batch.id),
+                    )
                 if pull_request.state == "CLOSED":
                     pull_request = backend.reopen_pull_request(pull_request)
                     result = "reopened-pull-request"
                 elif not pull_request.merged:
                     result = "existing-open-pull-request"
             else:
-                if batch.id not in preverified_batch_ids:
-                    backend.publish_batch(manifest, batch, branch)
+                backend.publish_batch(
+                    manifest,
+                    batch,
+                    branch,
+                    expected_commit_sha=authenticated_batch_commits.get(batch.id),
+                )
                 title = (
                     f"[docs-vnext-sync] Baseline {manifest.digest[:12]} "
                     f"batch {batch.number}/{batch.total}"
@@ -1165,8 +1208,21 @@ class GitHubGitBackend:
                     ("TotalTerminatedProcesses", ctypes.c_uint32),
                 ]
 
+            class ThreadEntry32(ctypes.Structure):
+                _fields_ = [
+                    ("dwSize", ctypes.c_uint32),
+                    ("cntUsage", ctypes.c_uint32),
+                    ("th32ThreadID", ctypes.c_uint32),
+                    ("th32OwnerProcessID", ctypes.c_uint32),
+                    ("tpBasePri", ctypes.c_long),
+                    ("tpDeltaPri", ctypes.c_long),
+                    ("dwFlags", ctypes.c_uint32),
+                ]
+
             windows_kernel32 = ctypes.windll.kernel32
             windows_kernel32.CreateJobObjectW.restype = ctypes.c_void_p
+            windows_kernel32.CreateToolhelp32Snapshot.restype = ctypes.c_void_p
+            windows_kernel32.OpenThread.restype = ctypes.c_void_p
             windows_job = windows_kernel32.CreateJobObjectW(None, None)
             limits = ExtendedLimitInformation()
             limits.BasicLimitInformation.LimitFlags = 0x00002000
@@ -1191,12 +1247,36 @@ class GitHubGitBackend:
                     windows_kernel32.CloseHandle(windows_job)
                 process.kill()
                 raise BatchSyncError("Cannot assign discovery command to a Windows Job Object")
-            windows_ntdll = ctypes.windll.ntdll
-            if windows_ntdll.NtResumeProcess(int(process._handle)) != 0:  # type: ignore[attr-defined]
+            snapshot = windows_kernel32.CreateToolhelp32Snapshot(0x00000004, 0)
+            invalid_handle = ctypes.c_void_p(-1).value
+            resumed = False
+            if snapshot != invalid_handle:
+                entry = ThreadEntry32()
+                entry.dwSize = ctypes.sizeof(entry)
+                has_thread = windows_kernel32.Thread32First(snapshot, ctypes.byref(entry))
+                while has_thread:
+                    if entry.th32OwnerProcessID == process.pid:
+                        thread_handle = windows_kernel32.OpenThread(
+                            0x0002,
+                            False,
+                            entry.th32ThreadID,
+                        )
+                        if thread_handle:
+                            resumed = windows_kernel32.ResumeThread(thread_handle) != 0xFFFFFFFF
+                            windows_kernel32.CloseHandle(thread_handle)
+                        break
+                    has_thread = windows_kernel32.Thread32Next(
+                        snapshot,
+                        ctypes.byref(entry),
+                    )
+                windows_kernel32.CloseHandle(snapshot)
+            if not resumed:
                 windows_kernel32.TerminateJobObject(windows_job, 1)
                 windows_kernel32.CloseHandle(windows_job)
                 process.kill()
-                raise BatchSyncError("Cannot resume discovery command after Job Object assignment")
+                raise BatchSyncError(
+                    "Cannot resume discovery command primary thread after Job Object assignment"
+                )
         assert process.stdout is not None
         assert process.stderr is not None
         stdout = bytearray()
@@ -1449,7 +1529,10 @@ class GitHubGitBackend:
             ],
             max_bytes=MAX_REMOTE_DISCOVERY_BYTES,
         )
-        remote_head_commits = parse_remote_branch_refs(output)
+        remote_head_commits = exclude_completed_remote_heads(
+            parse_remote_branch_refs(output),
+            pull_requests,
+        )
         remote_heads = set(remote_head_commits)
         all_pull_request_heads = {pull_request.head_ref for pull_request in pull_requests}
         incomplete_by_head: dict[str, PullRequest] = {}
@@ -1795,7 +1878,7 @@ def main(
             campaign_branches,
         )
         batches = plan_batches(manifest, args.max_files, args.max_payload_bytes)
-        preverified_batch_ids = validate_campaign_identities(
+        authenticated_batch_commits = validate_campaign_identities(
             manifest,
             batches,
             active_backend,
@@ -1810,7 +1893,7 @@ def main(
             args.checkpoint,
             args.max_files,
             args.max_payload_bytes,
-            preverified_batch_ids,
+            authenticated_batch_commits,
         )
         _write_summary(args.summary, args.checkpoint)
         if not succeeded:

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -1515,6 +1515,19 @@ class GitHubGitBackend:
                     f"Automation branch {branch!r} moved from authenticated commit "
                     f"{expected_commit_sha} to {final_commit_sha} before final verification"
                 )
+            final_message = self._run(
+                ["git", "show", "--no-patch", "--format=%B", final_commit_sha]
+            ).stdout
+            final_identity = parse_commit_identity(final_message, branch)
+            if (
+                final_identity.manifest_digest != manifest.digest
+                or final_identity.manifest_run_id != manifest.run_id
+                or final_identity.batch_id != batch.id
+            ):
+                raise BatchSyncError(
+                    f"Automation branch {branch!r} final commit identity does not match "
+                    "the planned manifest batch"
+                )
 
         worktree = Path(tempfile.mkdtemp(prefix="docs-vnext-sync-", dir=self.runner_temp))
         worktree.rmdir()

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -29,6 +29,7 @@ MAX_COMMIT_MESSAGE_BYTES = 4096
 MAX_REMOTE_DISCOVERY_BYTES = 32 * 1024
 DISCOVERY_COMMAND_TIMEOUT_SECONDS = 30
 DISCOVERY_TERMINATION_GRACE_SECONDS = 0.1
+WINDOWS_CREATE_SUSPENDED = 0x00000004
 BRANCH_PREFIX = "automation/docs-vnext-sync"
 PR_MARKER_NAME = "docs-vnext-sync-state"
 PR_MARKER_PATTERN = re.compile(
@@ -1099,17 +1100,20 @@ class GitHubGitBackend:
         cwd: Path | None = None,
         timeout_seconds: int = DISCOVERY_COMMAND_TIMEOUT_SECONDS,
     ) -> str:
+        deadline = time.monotonic() + timeout_seconds
+        windows_creation_flags = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            | WINDOWS_CREATE_SUSPENDED
+            if os.name == "nt"
+            else 0
+        )
         process = subprocess.Popen(
             list(args),
             cwd=cwd or self.repository_root,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             start_new_session=os.name == "posix",
-            creationflags=(
-                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-                if os.name == "nt"
-                else 0
-            ),
+            creationflags=windows_creation_flags,
         )
         windows_job: int | None = None
         windows_kernel32: Any | None = None
@@ -1149,6 +1153,18 @@ class GitHubGitBackend:
                     ("PeakJobMemoryUsed", ctypes.c_size_t),
                 ]
 
+            class BasicAccountingInformation(ctypes.Structure):
+                _fields_ = [
+                    ("TotalUserTime", ctypes.c_longlong),
+                    ("TotalKernelTime", ctypes.c_longlong),
+                    ("ThisPeriodTotalUserTime", ctypes.c_longlong),
+                    ("ThisPeriodTotalKernelTime", ctypes.c_longlong),
+                    ("TotalPageFaultCount", ctypes.c_uint32),
+                    ("TotalProcesses", ctypes.c_uint32),
+                    ("ActiveProcesses", ctypes.c_uint32),
+                    ("TotalTerminatedProcesses", ctypes.c_uint32),
+                ]
+
             windows_kernel32 = ctypes.windll.kernel32
             windows_kernel32.CreateJobObjectW.restype = ctypes.c_void_p
             windows_job = windows_kernel32.CreateJobObjectW(None, None)
@@ -1175,6 +1191,12 @@ class GitHubGitBackend:
                     windows_kernel32.CloseHandle(windows_job)
                 process.kill()
                 raise BatchSyncError("Cannot assign discovery command to a Windows Job Object")
+            windows_ntdll = ctypes.windll.ntdll
+            if windows_ntdll.NtResumeProcess(int(process._handle)) != 0:  # type: ignore[attr-defined]
+                windows_kernel32.TerminateJobObject(windows_job, 1)
+                windows_kernel32.CloseHandle(windows_job)
+                process.kill()
+                raise BatchSyncError("Cannot resume discovery command after Job Object assignment")
         assert process.stdout is not None
         assert process.stderr is not None
         stdout = bytearray()
@@ -1183,7 +1205,6 @@ class GitHubGitBackend:
         overflow_event = threading.Event()
         termination_lock = threading.Lock()
         process_group_id = process.pid
-        deadline = time.monotonic() + timeout_seconds
 
         def close_windows_job() -> None:
             nonlocal windows_job
@@ -1195,16 +1216,25 @@ class GitHubGitBackend:
             with termination_lock:
                 remaining = max(0.0, deadline - time.monotonic())
                 if os.name == "posix":
+                    signaled_group = False
                     try:
                         os.killpg(process_group_id, signal.SIGTERM)
+                        signaled_group = True
                     except (OSError, ProcessLookupError):
                         pass
-                    if remaining > 0:
+                    if signaled_group and remaining > 0:
                         time.sleep(min(0.02, remaining))
-                    try:
-                        os.killpg(process_group_id, signal.SIGKILL)
-                    except (OSError, ProcessLookupError):
-                        pass
+                    if signaled_group:
+                        try:
+                            os.killpg(process_group_id, signal.SIGKILL)
+                        except (OSError, ProcessLookupError):
+                            pass
+                    while time.monotonic() < deadline:
+                        try:
+                            os.killpg(process_group_id, 0)
+                        except (OSError, ProcessLookupError):
+                            break
+                        time.sleep(0.005)
                 elif os.name == "nt":
                     terminated_job = bool(
                         windows_job
@@ -1213,6 +1243,19 @@ class GitHubGitBackend:
                     )
                     if not terminated_job:
                         close_windows_job()
+                    elif windows_job and windows_kernel32 is not None:
+                        accounting = BasicAccountingInformation()
+                        while time.monotonic() < deadline:
+                            queried = windows_kernel32.QueryInformationJobObject(
+                                windows_job,
+                                1,
+                                ctypes.byref(accounting),
+                                ctypes.sizeof(accounting),
+                                None,
+                            )
+                            if not queried or accounting.ActiveProcesses == 0:
+                                break
+                            time.sleep(0.005)
                 else:
                     try:
                         process.kill()
@@ -1224,6 +1267,11 @@ class GitHubGitBackend:
                     except OSError:
                         pass
 
+        def join_readers() -> bool:
+            for thread in (stdout_thread, stderr_thread):
+                thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            return not stdout_thread.is_alive() and not stderr_thread.is_alive()
+
         def drain(stream: Any, destination: bytearray, name: str) -> None:
             try:
                 while block := stream.read(1024):
@@ -1231,7 +1279,6 @@ class GitHubGitBackend:
                     if len(destination) > max_bytes:
                         overflow_streams.add(name)
                         overflow_event.set()
-                        terminate_process_group()
                         return
             except (OSError, ValueError):
                 return
@@ -1252,6 +1299,7 @@ class GitHubGitBackend:
         while True:
             if overflow_event.is_set():
                 terminate_process_group()
+                join_readers()
                 close_windows_job()
                 raise BatchSyncError(
                     f"{args[0]} {args[1] if len(args) > 1 else ''} "
@@ -1263,6 +1311,7 @@ class GitHubGitBackend:
             remaining = deadline - now
             if remaining <= DISCOVERY_TERMINATION_GRACE_SECONDS:
                 terminate_process_group()
+                join_readers()
                 close_windows_job()
                 raise BatchSyncError(
                     f"{args[0]} {args[1] if len(args) > 1 else ''} exceeded the "
@@ -1280,11 +1329,18 @@ class GitHubGitBackend:
             time.sleep(min(0.01, remaining))
         if overflow_event.is_set() or overflow_streams:
             terminate_process_group()
+            join_readers()
             close_windows_job()
             raise BatchSyncError(
                 f"{args[0]} {args[1] if len(args) > 1 else ''} "
                 f"{'/'.join(sorted(overflow_streams))} exceeds the "
                 f"{max_bytes}-byte discovery limit"
+            )
+        terminate_process_group()
+        if not join_readers():
+            close_windows_job()
+            raise BatchSyncError(
+                f"{args[0]} discovery process tree did not stop before its deadline"
             )
         try:
             stdout_text = bytes(stdout).decode("utf-8")

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import re
+import signal
 import shutil
 import subprocess
 import sys
@@ -26,6 +27,7 @@ MAX_AUTOMATION_BRANCHES = 100
 MAX_COMMIT_MESSAGE_BYTES = 4096
 MAX_REMOTE_DISCOVERY_BYTES = 32 * 1024
 DISCOVERY_COMMAND_TIMEOUT_SECONDS = 30
+DISCOVERY_DRAIN_JOIN_SECONDS = 2
 BRANCH_PREFIX = "automation/docs-vnext-sync"
 PR_MARKER_NAME = "docs-vnext-sync-state"
 PR_MARKER_PATTERN = re.compile(
@@ -650,9 +652,6 @@ def select_active_manifest(
 
     digest = next(iter(digests))
     run_id = next(iter(run_ids))
-    if digest == current_manifest.digest:
-        return replace(current_manifest, run_id=run_id)
-
     resumed = load_manifest(backend.download_manifest(run_id), run_id)
     if resumed.digest != digest:
         raise BatchSyncError(
@@ -1081,23 +1080,50 @@ class GitHubGitBackend:
             cwd=cwd or self.repository_root,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            start_new_session=os.name == "posix",
+            creationflags=(
+                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                if os.name == "nt"
+                else 0
+            ),
         )
         assert process.stdout is not None
         assert process.stderr is not None
         stdout = bytearray()
         stderr = bytearray()
         overflow_streams: set[str] = set()
+        termination_lock = threading.Lock()
+        terminated = False
 
-        def drain(stream: Any, destination: bytearray, name: str) -> None:
-            while block := stream.read(1024):
-                destination.extend(block)
-                if len(destination) > max_bytes:
-                    overflow_streams.add(name)
+        def terminate_process_group() -> None:
+            nonlocal terminated
+            with termination_lock:
+                if terminated:
+                    return
+                terminated = True
+                try:
+                    if os.name == "posix":
+                        os.killpg(process.pid, signal.SIGKILL)
+                    elif os.name == "nt":
+                        os.kill(process.pid, signal.CTRL_BREAK_EVENT)
+                    else:
+                        process.kill()
+                except (OSError, ProcessLookupError):
                     try:
                         process.kill()
                     except OSError:
                         pass
-                    return
+
+        def drain(stream: Any, destination: bytearray, name: str) -> None:
+            try:
+                while block := stream.read(1024):
+                    destination.extend(block)
+                    if len(destination) > max_bytes:
+                        overflow_streams.add(name)
+                        terminate_process_group()
+                        return
+            except (OSError, ValueError):
+                return
 
         stdout_thread = threading.Thread(
             target=drain,
@@ -1114,16 +1140,33 @@ class GitHubGitBackend:
         try:
             process.wait(timeout=timeout_seconds)
         except subprocess.TimeoutExpired as exc:
-            process.kill()
-            process.wait()
-            stdout_thread.join()
-            stderr_thread.join()
+            terminate_process_group()
+            try:
+                process.wait(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+            process.stdout.close()
+            process.stderr.close()
+            stdout_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+            stderr_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
             raise BatchSyncError(
                 f"{args[0]} {args[1] if len(args) > 1 else ''} exceeded the "
                 f"{timeout_seconds}-second discovery timeout"
             ) from exc
-        stdout_thread.join()
-        stderr_thread.join()
+        stdout_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+        stderr_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+        if stdout_thread.is_alive() or stderr_thread.is_alive():
+            terminate_process_group()
+            process.stdout.close()
+            process.stderr.close()
+            stdout_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+            stderr_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+            if stdout_thread.is_alive() or stderr_thread.is_alive():
+                raise BatchSyncError(
+                    f"{args[0]} discovery stream drains did not stop within "
+                    f"{DISCOVERY_DRAIN_JOIN_SECONDS} seconds"
+                )
         if overflow_streams:
             raise BatchSyncError(
                 f"{args[0]} {args[1] if len(args) > 1 else ''} "

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -43,6 +43,7 @@ COMMIT_IDENTITY_FIELDS = {
 TRAILER_PATTERN = re.compile(r"^(?P<key>[A-Za-z][A-Za-z0-9-]*): (?P<value>\S.*)$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 OPERATION_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+GIT_COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40,64}$")
 POSITIVE_DECIMAL_PATTERN = re.compile(r"^[1-9][0-9]*$")
 DECISIONS = {"add", "modify", "remove", "preserve"}
 MUTATING_DECISIONS = {"add", "modify", "remove"}
@@ -119,6 +120,7 @@ class OrphanBranch:
     manifest_run_id: int
     batch_id: str
     pull_request_number: int | None = None
+    commit_sha: str = "0000000000000000000000000000000000000000"
 
 
 class AutomationBackend(Protocol):
@@ -130,7 +132,13 @@ class AutomationBackend(Protocol):
 
     def download_manifest(self, run_id: int) -> Path: ...
 
-    def publish_batch(self, manifest: Manifest, batch: Batch, branch: str) -> None: ...
+    def publish_batch(
+        self,
+        manifest: Manifest,
+        batch: Batch,
+        branch: str,
+        expected_commit_sha: str | None = None,
+    ) -> None: ...
 
     def create_pull_request(
         self,
@@ -572,23 +580,28 @@ def parse_commit_identity(message: str, head_ref: str) -> OrphanBranch:
     )
 
 
-def parse_remote_branch_refs(output: str) -> tuple[str, ...]:
+def parse_remote_branch_refs(output: str) -> dict[str, str]:
     lines = [line for line in output.splitlines() if line]
     if len(lines) > MAX_AUTOMATION_BRANCHES:
         raise BatchSyncError(
             f"Found {len(lines)} automation branches, above the "
             f"{MAX_AUTOMATION_BRANCHES}-branch discovery limit"
         )
-    head_refs: list[str] = []
+    head_refs: dict[str, str] = {}
     for line in lines:
-        _, separator, ref = line.partition("\t")
+        commit_sha, separator, ref = line.partition("\t")
         expected_prefix = f"refs/heads/{BRANCH_PREFIX}/"
-        if not separator or not ref.startswith(expected_prefix):
+        if (
+            not separator
+            or not GIT_COMMIT_PATTERN.fullmatch(commit_sha)
+            or not ref.startswith(expected_prefix)
+        ):
             raise BatchSyncError(f"Cannot parse automation branch reference: {line!r}")
-        head_refs.append(ref.removeprefix("refs/heads/"))
-    if len(head_refs) != len(set(head_refs)):
-        raise BatchSyncError("Remote automation branch discovery returned duplicate references")
-    return tuple(head_refs)
+        head_ref = ref.removeprefix("refs/heads/")
+        if head_ref in head_refs:
+            raise BatchSyncError("Remote automation branch discovery returned duplicate references")
+        head_refs[head_ref] = commit_sha
+    return head_refs
 
 
 def enforce_campaign_candidate_limit(
@@ -709,7 +722,12 @@ def validate_campaign_identities(
         prior = claimed_batches.setdefault(batch.id, f"pull request #{pull_request.number}")
         if prior != f"pull request #{pull_request.number}":
             raise BatchSyncError(f"Batch {batch.id} is claimed by both {prior} and a pull request")
-        backend.publish_batch(manifest, batch, expected_head)
+        backend.publish_batch(
+            manifest,
+            batch,
+            expected_head,
+            expected_commit_sha=identity.commit_sha,
+        )
 
     for orphan in campaign_branches:
         if orphan.pull_request_number is not None:
@@ -733,7 +751,12 @@ def validate_campaign_identities(
         prior = claimed_batches.setdefault(batch.id, f"orphan branch {orphan.head_ref}")
         if prior != f"orphan branch {orphan.head_ref}":
             raise BatchSyncError(f"Batch {batch.id} is claimed by both {prior} and an orphan branch")
-        backend.publish_batch(manifest, batch, expected_head)
+        backend.publish_batch(
+            manifest,
+            batch,
+            expected_head,
+            expected_commit_sha=orphan.commit_sha,
+        )
     return frozenset(claimed_batches)
 
 
@@ -1088,6 +1111,70 @@ class GitHubGitBackend:
                 else 0
             ),
         )
+        windows_job: int | None = None
+        windows_kernel32: Any | None = None
+        if os.name == "nt":
+            import ctypes
+
+            class IoCounters(ctypes.Structure):
+                _fields_ = [
+                    ("ReadOperationCount", ctypes.c_ulonglong),
+                    ("WriteOperationCount", ctypes.c_ulonglong),
+                    ("OtherOperationCount", ctypes.c_ulonglong),
+                    ("ReadTransferCount", ctypes.c_ulonglong),
+                    ("WriteTransferCount", ctypes.c_ulonglong),
+                    ("OtherTransferCount", ctypes.c_ulonglong),
+                ]
+
+            class BasicLimitInformation(ctypes.Structure):
+                _fields_ = [
+                    ("PerProcessUserTimeLimit", ctypes.c_longlong),
+                    ("PerJobUserTimeLimit", ctypes.c_longlong),
+                    ("LimitFlags", ctypes.c_uint32),
+                    ("MinimumWorkingSetSize", ctypes.c_size_t),
+                    ("MaximumWorkingSetSize", ctypes.c_size_t),
+                    ("ActiveProcessLimit", ctypes.c_uint32),
+                    ("Affinity", ctypes.c_size_t),
+                    ("PriorityClass", ctypes.c_uint32),
+                    ("SchedulingClass", ctypes.c_uint32),
+                ]
+
+            class ExtendedLimitInformation(ctypes.Structure):
+                _fields_ = [
+                    ("BasicLimitInformation", BasicLimitInformation),
+                    ("IoInfo", IoCounters),
+                    ("ProcessMemoryLimit", ctypes.c_size_t),
+                    ("JobMemoryLimit", ctypes.c_size_t),
+                    ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                    ("PeakJobMemoryUsed", ctypes.c_size_t),
+                ]
+
+            windows_kernel32 = ctypes.windll.kernel32
+            windows_kernel32.CreateJobObjectW.restype = ctypes.c_void_p
+            windows_job = windows_kernel32.CreateJobObjectW(None, None)
+            limits = ExtendedLimitInformation()
+            limits.BasicLimitInformation.LimitFlags = 0x00002000
+            configured = bool(
+                windows_job
+                and windows_kernel32.SetInformationJobObject(
+                    windows_job,
+                    9,
+                    ctypes.byref(limits),
+                    ctypes.sizeof(limits),
+                )
+            )
+            assigned = bool(
+                configured
+                and windows_kernel32.AssignProcessToJobObject(
+                    windows_job,
+                    int(process._handle),  # type: ignore[attr-defined]
+                )
+            )
+            if not assigned:
+                if windows_job:
+                    windows_kernel32.CloseHandle(windows_job)
+                process.kill()
+                raise BatchSyncError("Cannot assign discovery command to a Windows Job Object")
         assert process.stdout is not None
         assert process.stderr is not None
         stdout = bytearray()
@@ -1098,16 +1185,40 @@ class GitHubGitBackend:
         process_group_id = process.pid
         deadline = time.monotonic() + timeout_seconds
 
+        def close_windows_job() -> None:
+            nonlocal windows_job
+            if windows_job and windows_kernel32 is not None:
+                windows_kernel32.CloseHandle(windows_job)
+                windows_job = None
+
         def terminate_process_group() -> None:
             with termination_lock:
-                try:
-                    if os.name == "posix":
+                remaining = max(0.0, deadline - time.monotonic())
+                if os.name == "posix":
+                    try:
+                        os.killpg(process_group_id, signal.SIGTERM)
+                    except (OSError, ProcessLookupError):
+                        pass
+                    if remaining > 0:
+                        time.sleep(min(0.02, remaining))
+                    try:
                         os.killpg(process_group_id, signal.SIGKILL)
-                    elif os.name == "nt":
-                        os.kill(process_group_id, signal.CTRL_BREAK_EVENT)
-                    else:
+                    except (OSError, ProcessLookupError):
+                        pass
+                elif os.name == "nt":
+                    terminated_job = bool(
+                        windows_job
+                        and windows_kernel32 is not None
+                        and windows_kernel32.TerminateJobObject(windows_job, 1)
+                    )
+                    if not terminated_job:
+                        close_windows_job()
+                else:
+                    try:
                         process.kill()
-                except (OSError, ProcessLookupError):
+                    except OSError:
+                        pass
+                if process.poll() is None:
                     try:
                         process.kill()
                     except OSError:
@@ -1141,6 +1252,7 @@ class GitHubGitBackend:
         while True:
             if overflow_event.is_set():
                 terminate_process_group()
+                close_windows_job()
                 raise BatchSyncError(
                     f"{args[0]} {args[1] if len(args) > 1 else ''} "
                     f"{'/'.join(sorted(overflow_streams))} exceeds the "
@@ -1149,8 +1261,9 @@ class GitHubGitBackend:
 
             now = time.monotonic()
             remaining = deadline - now
-            if remaining <= 0:
+            if remaining <= DISCOVERY_TERMINATION_GRACE_SECONDS:
                 terminate_process_group()
+                close_windows_job()
                 raise BatchSyncError(
                     f"{args[0]} {args[1] if len(args) > 1 else ''} exceeded the "
                     f"{timeout_seconds}-second discovery timeout"
@@ -1167,6 +1280,7 @@ class GitHubGitBackend:
             time.sleep(min(0.01, remaining))
         if overflow_event.is_set() or overflow_streams:
             terminate_process_group()
+            close_windows_job()
             raise BatchSyncError(
                 f"{args[0]} {args[1] if len(args) > 1 else ''} "
                 f"{'/'.join(sorted(overflow_streams))} exceeds the "
@@ -1176,6 +1290,7 @@ class GitHubGitBackend:
             stdout_text = bytes(stdout).decode("utf-8")
             stderr_text = bytes(stderr).decode("utf-8")
         except UnicodeDecodeError as exc:
+            close_windows_job()
             raise BatchSyncError(f"{args[0]} output is not valid UTF-8") from exc
         if process.returncode != 0:
             detail = (
@@ -1183,7 +1298,9 @@ class GitHubGitBackend:
                 or stdout_text.strip()
                 or f"exit code {process.returncode}"
             )
+            close_windows_job()
             raise BatchSyncError(f"{args[0]} {args[1] if len(args) > 1 else ''} failed: {detail}")
+        close_windows_job()
         return stdout_text
 
     def _pull_request_from_api(self, payload: dict[str, Any]) -> PullRequest:
@@ -1228,6 +1345,7 @@ class GitHubGitBackend:
         remote_ref: str,
         head_ref: str,
         pull_request_number: int | None = None,
+        expected_commit_sha: str | None = None,
     ) -> OrphanBranch:
         self._run_bounded_stdout(
             [
@@ -1239,13 +1357,27 @@ class GitHubGitBackend:
             ],
             max_bytes=MAX_COMMIT_MESSAGE_BYTES,
         )
+        commit_sha = self._run_bounded_stdout(
+            ["git", "rev-parse", remote_ref],
+            max_bytes=MAX_COMMIT_MESSAGE_BYTES,
+        ).strip()
+        if not GIT_COMMIT_PATTERN.fullmatch(commit_sha):
+            raise BatchSyncError(
+                f"Fetched automation branch {head_ref!r} has invalid commit ID {commit_sha!r}"
+            )
+        if expected_commit_sha is not None and commit_sha != expected_commit_sha:
+            raise BatchSyncError(
+                f"Automation branch {head_ref!r} moved from discovered commit "
+                f"{expected_commit_sha} to {commit_sha} before authentication"
+            )
         commit_message = self._run_bounded_stdout(
-            ["git", "show", "--no-patch", "--format=%B", remote_ref],
+            ["git", "show", "--no-patch", "--format=%B", commit_sha],
             max_bytes=MAX_COMMIT_MESSAGE_BYTES,
         )
         return replace(
             parse_commit_identity(commit_message, head_ref),
             pull_request_number=pull_request_number,
+            commit_sha=commit_sha,
         )
 
     def discover_campaign_branches(
@@ -1261,7 +1393,8 @@ class GitHubGitBackend:
             ],
             max_bytes=MAX_REMOTE_DISCOVERY_BYTES,
         )
-        remote_heads = set(parse_remote_branch_refs(output))
+        remote_head_commits = parse_remote_branch_refs(output)
+        remote_heads = set(remote_head_commits)
         all_pull_request_heads = {pull_request.head_ref for pull_request in pull_requests}
         incomplete_by_head: dict[str, PullRequest] = {}
         for pull_request in pull_requests:
@@ -1287,6 +1420,7 @@ class GitHubGitBackend:
                 f"refs/remotes/origin/{head_ref}",
                 head_ref,
                 pull_request.number if pull_request is not None else None,
+                expected_commit_sha=remote_head_commits[head_ref],
             )
             if pull_request is not None:
                 validate_marker_claim(pull_request, identity)
@@ -1349,7 +1483,13 @@ class GitHubGitBackend:
         )
         return {line for line in result.stdout.splitlines() if line}
 
-    def publish_batch(self, manifest: Manifest, batch: Batch, branch: str) -> None:
+    def publish_batch(
+        self,
+        manifest: Manifest,
+        batch: Batch,
+        branch: str,
+        expected_commit_sha: str | None = None,
+    ) -> None:
         self._run(["git", "fetch", "--no-tags", "origin", self.base_branch])
         base_ref = f"refs/remotes/origin/{self.base_branch}"
         remote_exists = self._remote_branch_exists(branch)
@@ -1364,6 +1504,17 @@ class GitHubGitBackend:
                     f"+refs/heads/{branch}:{remote_ref}",
                 ]
             )
+            final_commit_sha = self._run(
+                ["git", "rev-parse", remote_ref]
+            ).stdout.strip()
+            if (
+                expected_commit_sha is not None
+                and final_commit_sha != expected_commit_sha
+            ):
+                raise BatchSyncError(
+                    f"Automation branch {branch!r} moved from authenticated commit "
+                    f"{expected_commit_sha} to {final_commit_sha} before final verification"
+                )
 
         worktree = Path(tempfile.mkdtemp(prefix="docs-vnext-sync-", dir=self.runner_temp))
         worktree.rmdir()

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 from dataclasses import dataclass, replace
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol, Sequence
@@ -27,7 +28,7 @@ MAX_AUTOMATION_BRANCHES = 100
 MAX_COMMIT_MESSAGE_BYTES = 4096
 MAX_REMOTE_DISCOVERY_BYTES = 32 * 1024
 DISCOVERY_COMMAND_TIMEOUT_SECONDS = 30
-DISCOVERY_DRAIN_JOIN_SECONDS = 2
+DISCOVERY_TERMINATION_GRACE_SECONDS = 0.1
 BRANCH_PREFIX = "automation/docs-vnext-sync"
 PR_MARKER_NAME = "docs-vnext-sync-state"
 PR_MARKER_PATTERN = re.compile(
@@ -1092,8 +1093,11 @@ class GitHubGitBackend:
         stdout = bytearray()
         stderr = bytearray()
         overflow_streams: set[str] = set()
+        overflow_event = threading.Event()
         termination_lock = threading.Lock()
         terminated = False
+        process_group_id = process.pid
+        deadline = time.monotonic() + timeout_seconds
 
         def terminate_process_group() -> None:
             nonlocal terminated
@@ -1103,9 +1107,9 @@ class GitHubGitBackend:
                 terminated = True
                 try:
                     if os.name == "posix":
-                        os.killpg(process.pid, signal.SIGKILL)
+                        os.killpg(process_group_id, signal.SIGKILL)
                     elif os.name == "nt":
-                        os.kill(process.pid, signal.CTRL_BREAK_EVENT)
+                        os.kill(process_group_id, signal.CTRL_BREAK_EVENT)
                     else:
                         process.kill()
                 except (OSError, ProcessLookupError):
@@ -1120,6 +1124,7 @@ class GitHubGitBackend:
                     destination.extend(block)
                     if len(destination) > max_bytes:
                         overflow_streams.add(name)
+                        overflow_event.set()
                         terminate_process_group()
                         return
             except (OSError, ValueError):
@@ -1137,36 +1142,46 @@ class GitHubGitBackend:
         )
         stdout_thread.start()
         stderr_thread.start()
-        try:
-            process.wait(timeout=timeout_seconds)
-        except subprocess.TimeoutExpired as exc:
+        timed_out = False
+        leader_exited_at: float | None = None
+        while True:
+            readers_alive = stdout_thread.is_alive() or stderr_thread.is_alive()
+            leader_exited = process.poll() is not None
+            if overflow_event.is_set() or (leader_exited and not readers_alive):
+                break
+
+            now = time.monotonic()
+            remaining = deadline - now
+            if remaining <= DISCOVERY_TERMINATION_GRACE_SECONDS:
+                timed_out = True
+                terminate_process_group()
+                break
+            if leader_exited:
+                leader_exited_at = leader_exited_at or now
+                if now - leader_exited_at >= DISCOVERY_TERMINATION_GRACE_SECONDS:
+                    terminate_process_group()
+                    break
+            time.sleep(min(0.01, remaining))
+
+        for thread in (stdout_thread, stderr_thread):
+            remaining = max(0.0, deadline - time.monotonic())
+            thread.join(timeout=remaining)
+        if stdout_thread.is_alive() or stderr_thread.is_alive():
             terminate_process_group()
+            timed_out = True
+        if process.poll() is None:
+            remaining = max(0.0, deadline - time.monotonic())
             try:
-                process.wait(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+                process.wait(timeout=remaining)
             except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
-            process.stdout.close()
-            process.stderr.close()
-            stdout_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
-            stderr_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
+                terminate_process_group()
+                timed_out = True
+
+        if timed_out:
             raise BatchSyncError(
                 f"{args[0]} {args[1] if len(args) > 1 else ''} exceeded the "
                 f"{timeout_seconds}-second discovery timeout"
-            ) from exc
-        stdout_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
-        stderr_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
-        if stdout_thread.is_alive() or stderr_thread.is_alive():
-            terminate_process_group()
-            process.stdout.close()
-            process.stderr.close()
-            stdout_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
-            stderr_thread.join(timeout=DISCOVERY_DRAIN_JOIN_SECONDS)
-            if stdout_thread.is_alive() or stderr_thread.is_alive():
-                raise BatchSyncError(
-                    f"{args[0]} discovery stream drains did not stop within "
-                    f"{DISCOVERY_DRAIN_JOIN_SECONDS} seconds"
-                )
+            )
         if overflow_streams:
             raise BatchSyncError(
                 f"{args[0]} {args[1] if len(args) > 1 else ''} "

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -24,6 +24,7 @@ DEFAULT_MAX_FILES = 50
 DEFAULT_MAX_PAYLOAD_BYTES = 40 * 1024 * 1024
 MAX_AUTOMATION_BRANCHES = 100
 MAX_COMMIT_MESSAGE_BYTES = 4096
+MAX_REMOTE_DISCOVERY_BYTES = 32 * 1024
 DISCOVERY_COMMAND_TIMEOUT_SECONDS = 30
 BRANCH_PREFIX = "automation/docs-vnext-sync"
 PR_MARKER_NAME = "docs-vnext-sync-state"
@@ -39,6 +40,7 @@ COMMIT_IDENTITY_FIELDS = {
 TRAILER_PATTERN = re.compile(r"^(?P<key>[A-Za-z][A-Za-z0-9-]*): (?P<value>\S.*)$")
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 OPERATION_ID_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+POSITIVE_DECIMAL_PATTERN = re.compile(r"^[1-9][0-9]*$")
 DECISIONS = {"add", "modify", "remove", "preserve"}
 MUTATING_DECISIONS = {"add", "modify", "remove"}
 
@@ -113,12 +115,13 @@ class OrphanBranch:
     manifest_digest: str
     manifest_run_id: int
     batch_id: str
+    pull_request_number: int | None = None
 
 
 class AutomationBackend(Protocol):
     def list_pull_requests(self) -> list[PullRequest]: ...
 
-    def list_orphan_branches(
+    def discover_campaign_branches(
         self, pull_requests: Sequence[PullRequest]
     ) -> list[OrphanBranch]: ...
 
@@ -546,22 +549,18 @@ def parse_commit_identity(message: str, head_ref: str) -> OrphanBranch:
         )
     manifest_digest = values["manifest_digest"]
     batch_id = values["batch_id"]
-    try:
-        manifest_run_id = int(values["manifest_run_id"])
-    except ValueError as exc:
+    manifest_run_id_text = values["manifest_run_id"]
+    if not POSITIVE_DECIMAL_PATTERN.fullmatch(manifest_run_id_text):
         raise BatchSyncError(
-            f"Orphan automation branch {head_ref!r} has an invalid manifest run ID"
-        ) from exc
+            f"Automation branch {head_ref!r} manifest run ID must be a canonical positive decimal"
+        )
+    manifest_run_id = int(manifest_run_id_text)
     if not SHA256_PATTERN.fullmatch(manifest_digest):
         raise BatchSyncError(
             f"Orphan automation branch {head_ref!r} has an invalid manifest digest"
         )
     if not OPERATION_ID_PATTERN.fullmatch(batch_id):
         raise BatchSyncError(f"Orphan automation branch {head_ref!r} has an invalid batch ID")
-    if manifest_run_id <= 0:
-        raise BatchSyncError(
-            f"Orphan automation branch {head_ref!r} has a non-positive manifest run ID"
-        )
     return OrphanBranch(
         head_ref=head_ref,
         manifest_digest=manifest_digest,
@@ -589,21 +588,51 @@ def parse_remote_branch_refs(output: str) -> tuple[str, ...]:
     return tuple(head_refs)
 
 
+def enforce_campaign_candidate_limit(
+    remote_heads: set[str],
+    incomplete_pull_request_heads: set[str],
+) -> None:
+    candidate_count = len(remote_heads | incomplete_pull_request_heads)
+    if candidate_count > MAX_AUTOMATION_BRANCHES:
+        raise BatchSyncError(
+            f"Found {candidate_count} active automation identity candidates, above the "
+            f"{MAX_AUTOMATION_BRANCHES}-branch discovery limit"
+        )
+
+
+def validate_marker_claim(
+    pull_request: PullRequest,
+    identity: OrphanBranch,
+) -> None:
+    marker = pull_request.marker
+    if marker is None:
+        return
+    claimed = (
+        marker["manifestSha256"],
+        marker["manifestRunId"],
+        marker["batchId"],
+    )
+    verified = (
+        identity.manifest_digest,
+        identity.manifest_run_id,
+        identity.batch_id,
+    )
+    if claimed != verified:
+        raise BatchSyncError(
+            f"Pull request #{pull_request.number} body identity conflicts with its verified "
+            "head commit"
+        )
+
+
 def select_active_manifest(
     current_manifest: Manifest,
     backend: AutomationBackend,
-    pull_requests: Sequence[PullRequest],
-    orphan_branches: Sequence[OrphanBranch] = (),
+    campaign_branches: Sequence[OrphanBranch],
 ) -> Manifest:
     """Resume the single unfinished campaign, downloading its original retained artifact."""
     active_identities = [
-        (pull_request.marker["manifestSha256"], pull_request.marker["manifestRunId"])
-        for pull_request in pull_requests
-        if pull_request.incomplete and pull_request.marker is not None
+        (branch.manifest_digest, branch.manifest_run_id) for branch in campaign_branches
     ]
-    active_identities.extend(
-        (branch.manifest_digest, branch.manifest_run_id) for branch in orphan_branches
-    )
     if not active_identities:
         return current_manifest
 
@@ -637,24 +666,42 @@ def validate_campaign_identities(
     batches: Sequence[Batch],
     backend: AutomationBackend,
     pull_requests: Sequence[PullRequest],
-    orphan_branches: Sequence[OrphanBranch],
+    campaign_branches: Sequence[OrphanBranch],
 ) -> frozenset[str]:
     """Bind every unfinished identity to one exact planned batch and verified branch."""
     batches_by_id = {batch.id: batch for batch in batches}
     claimed_batches: dict[str, str] = {}
 
     for pull_request in pull_requests:
-        if not pull_request.incomplete or pull_request.marker is None:
+        if not pull_request.incomplete or not pull_request.head_ref.startswith(
+            f"{BRANCH_PREFIX}/"
+        ):
             continue
-        marker = pull_request.marker
-        batch = batches_by_id.get(marker["batchId"])
-        if batch is None or marker != _marker_payload(manifest, batch):
+        matching_identities = [
+            identity
+            for identity in campaign_branches
+            if identity.pull_request_number == pull_request.number
+        ]
+        if len(matching_identities) != 1:
+            raise BatchSyncError(
+                f"Pull request #{pull_request.number} has {len(matching_identities)} "
+                "verified head identities"
+            )
+        identity = matching_identities[0]
+        batch = batches_by_id.get(identity.batch_id)
+        if batch is None:
             raise BatchSyncError(
                 f"Pull request #{pull_request.number} does not match an exact planned batch "
                 f"for manifest {manifest.digest}"
             )
+        if pull_request.marker is not None and pull_request.marker != _marker_payload(
+            manifest, batch
+        ):
+            raise BatchSyncError(
+                f"Pull request #{pull_request.number} body conflicts with its verified head identity"
+            )
         expected_head = branch_name(manifest, batch)
-        if pull_request.head_ref != expected_head:
+        if identity.head_ref != pull_request.head_ref or pull_request.head_ref != expected_head:
             raise BatchSyncError(
                 f"Pull request #{pull_request.number} head {pull_request.head_ref!r} does not "
                 f"match deterministic branch {expected_head!r}"
@@ -664,7 +711,9 @@ def validate_campaign_identities(
             raise BatchSyncError(f"Batch {batch.id} is claimed by both {prior} and a pull request")
         backend.publish_batch(manifest, batch, expected_head)
 
-    for orphan in orphan_branches:
+    for orphan in campaign_branches:
+        if orphan.pull_request_number is not None:
+            continue
         batch = batches_by_id.get(orphan.batch_id)
         if (
             batch is None
@@ -901,7 +950,10 @@ def execute_batches(
                 raise BatchSyncError(f"Multiple pull requests use deterministic branch {branch!r}")
             if branch_pull_requests:
                 pull_request = branch_pull_requests[0]
-                if not _matching_marker(manifest, batch, pull_request.marker):
+                if (
+                    batch.id not in preverified_batch_ids
+                    and not _matching_marker(manifest, batch, pull_request.marker)
+                ):
                     raise BatchSyncError(
                         f"Pull request #{pull_request.number} uses {branch!r} with mismatched metadata"
                     )
@@ -1022,6 +1074,7 @@ class GitHubGitBackend:
         *,
         max_bytes: int,
         cwd: Path | None = None,
+        timeout_seconds: int = DISCOVERY_COMMAND_TIMEOUT_SECONDS,
     ) -> str:
         process = subprocess.Popen(
             list(args),
@@ -1059,7 +1112,7 @@ class GitHubGitBackend:
         stdout_thread.start()
         stderr_thread.start()
         try:
-            process.wait(timeout=DISCOVERY_COMMAND_TIMEOUT_SECONDS)
+            process.wait(timeout=timeout_seconds)
         except subprocess.TimeoutExpired as exc:
             process.kill()
             process.wait()
@@ -1067,7 +1120,7 @@ class GitHubGitBackend:
             stderr_thread.join()
             raise BatchSyncError(
                 f"{args[0]} {args[1] if len(args) > 1 else ''} exceeded the "
-                f"{DISCOVERY_COMMAND_TIMEOUT_SECONDS}-second discovery timeout"
+                f"{timeout_seconds}-second discovery timeout"
             ) from exc
         stdout_thread.join()
         stderr_thread.join()
@@ -1127,40 +1180,89 @@ class GitHubGitBackend:
                     pull_requests.append(self._pull_request_from_api(payload))
         return pull_requests
 
-    def list_orphan_branches(
+    def _fetch_campaign_identity(
+        self,
+        source_ref: str,
+        remote_ref: str,
+        head_ref: str,
+        pull_request_number: int | None = None,
+    ) -> OrphanBranch:
+        self._run_bounded_stdout(
+            [
+                "git",
+                "fetch",
+                "--no-tags",
+                "origin",
+                f"+{source_ref}:{remote_ref}",
+            ],
+            max_bytes=MAX_COMMIT_MESSAGE_BYTES,
+        )
+        commit_message = self._run_bounded_stdout(
+            ["git", "show", "--no-patch", "--format=%B", remote_ref],
+            max_bytes=MAX_COMMIT_MESSAGE_BYTES,
+        )
+        return replace(
+            parse_commit_identity(commit_message, head_ref),
+            pull_request_number=pull_request_number,
+        )
+
+    def discover_campaign_branches(
         self, pull_requests: Sequence[PullRequest]
     ) -> list[OrphanBranch]:
-        result = self._run(
+        output = self._run_bounded_stdout(
             [
                 "git",
                 "ls-remote",
                 "--heads",
                 "origin",
                 f"refs/heads/{BRANCH_PREFIX}/*",
-            ]
+            ],
+            max_bytes=MAX_REMOTE_DISCOVERY_BYTES,
         )
-        pull_request_heads = {pull_request.head_ref for pull_request in pull_requests}
-        orphan_branches: list[OrphanBranch] = []
-        for head_ref in parse_remote_branch_refs(result.stdout):
-            if head_ref in pull_request_heads:
+        remote_heads = set(parse_remote_branch_refs(output))
+        all_pull_request_heads = {pull_request.head_ref for pull_request in pull_requests}
+        incomplete_by_head: dict[str, PullRequest] = {}
+        for pull_request in pull_requests:
+            if not pull_request.incomplete or not pull_request.head_ref.startswith(
+                f"{BRANCH_PREFIX}/"
+            ):
                 continue
-            ref = f"refs/heads/{head_ref}"
-            remote_ref = f"refs/remotes/origin/{head_ref}"
-            self._run(
-                [
-                    "git",
-                    "fetch",
-                    "--no-tags",
-                    "origin",
-                    f"+{ref}:{remote_ref}",
-                ]
+            if pull_request.head_ref in incomplete_by_head:
+                raise BatchSyncError(
+                    f"Multiple unmerged pull requests use automation head "
+                    f"{pull_request.head_ref!r}"
+                )
+            incomplete_by_head[pull_request.head_ref] = pull_request
+
+        enforce_campaign_candidate_limit(remote_heads, set(incomplete_by_head))
+        campaign_branches: list[OrphanBranch] = []
+        for head_ref in sorted(remote_heads):
+            pull_request = incomplete_by_head.get(head_ref)
+            if head_ref in all_pull_request_heads and pull_request is None:
+                continue
+            identity = self._fetch_campaign_identity(
+                f"refs/heads/{head_ref}",
+                f"refs/remotes/origin/{head_ref}",
+                head_ref,
+                pull_request.number if pull_request is not None else None,
             )
-            commit_message = self._run_bounded_stdout(
-                ["git", "show", "--no-patch", "--format=%B", remote_ref],
-                max_bytes=MAX_COMMIT_MESSAGE_BYTES,
+            if pull_request is not None:
+                validate_marker_claim(pull_request, identity)
+            campaign_branches.append(identity)
+
+        for head_ref, pull_request in incomplete_by_head.items():
+            if head_ref in remote_heads:
+                continue
+            identity = self._fetch_campaign_identity(
+                f"refs/pull/{pull_request.number}/head",
+                f"refs/remotes/origin/pull-{pull_request.number}-head",
+                head_ref,
+                pull_request.number,
             )
-            orphan_branches.append(parse_commit_identity(commit_message, head_ref))
-        return orphan_branches
+            validate_marker_claim(pull_request, identity)
+            campaign_branches.append(identity)
+
+        return campaign_branches
 
     def download_manifest(self, run_id: int) -> Path:
         destination = self.runner_temp / f"resume-manifest-{run_id}"
@@ -1424,12 +1526,11 @@ def main(
             runner_temp=args.runner_temp,
         )
         pull_requests = active_backend.list_pull_requests()
-        orphan_branches = active_backend.list_orphan_branches(pull_requests)
+        campaign_branches = active_backend.discover_campaign_branches(pull_requests)
         manifest = select_active_manifest(
             current_manifest,
             active_backend,
-            pull_requests,
-            orphan_branches,
+            campaign_branches,
         )
         batches = plan_batches(manifest, args.max_files, args.max_payload_bytes)
         preverified_batch_ids = validate_campaign_identities(
@@ -1437,7 +1538,7 @@ def main(
             batches,
             active_backend,
             pull_requests,
-            orphan_branches,
+            campaign_branches,
         )
         succeeded = execute_batches(
             manifest,

--- a/scripts/apply_docs_vnext_sync_batches.py
+++ b/scripts/apply_docs_vnext_sync_batches.py
@@ -145,7 +145,7 @@ class AutomationBackend(Protocol):
         batch: Batch,
         branch: str,
         expected_commit_sha: str | None = None,
-    ) -> None: ...
+    ) -> str: ...
 
     def create_pull_request(
         self,
@@ -794,13 +794,12 @@ def validate_campaign_identities(
         prior = claimed_batches.setdefault(batch.id, f"pull request #{pull_request.number}")
         if prior != f"pull request #{pull_request.number}":
             raise BatchSyncError(f"Batch {batch.id} is claimed by both {prior} and a pull request")
-        backend.publish_batch(
+        authenticated_commits[batch.id] = backend.publish_batch(
             manifest,
             batch,
             expected_head,
             expected_commit_sha=identity.commit_sha,
         )
-        authenticated_commits[batch.id] = identity.commit_sha
 
     for orphan in campaign_branches:
         if orphan.pull_request_number is not None:
@@ -824,13 +823,12 @@ def validate_campaign_identities(
         prior = claimed_batches.setdefault(batch.id, f"orphan branch {orphan.head_ref}")
         if prior != f"orphan branch {orphan.head_ref}":
             raise BatchSyncError(f"Batch {batch.id} is claimed by both {prior} and an orphan branch")
-        backend.publish_batch(
+        authenticated_commits[batch.id] = backend.publish_batch(
             manifest,
             batch,
             expected_head,
             expected_commit_sha=orphan.commit_sha,
         )
-        authenticated_commits[batch.id] = orphan.commit_sha
     return authenticated_commits
 
 
@@ -1694,7 +1692,7 @@ class GitHubGitBackend:
         batch: Batch,
         branch: str,
         expected_commit_sha: str | None = None,
-    ) -> None:
+    ) -> str:
         self._run(["git", "fetch", "--no-tags", "origin", self.base_branch])
         base_ref = f"refs/remotes/origin/{self.base_branch}"
         remote_exists = self._remote_branch_exists(branch)
@@ -1774,7 +1772,7 @@ class GitHubGitBackend:
                     raise BatchSyncError(
                         f"Existing branch {branch!r} does not match the reconstructed batch"
                     )
-                return
+                return final_commit_sha
 
             self._run(["git", "switch", "--create", branch], cwd=worktree)
             self._run(["git", "config", "user.name", "github-actions[bot]"], cwd=worktree)
@@ -1801,10 +1799,15 @@ class GitHubGitBackend:
                 ],
                 cwd=worktree,
             )
+            published_commit_sha = self._run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=worktree,
+            ).stdout.strip()
             self._run(
                 ["git", "push", "origin", f"HEAD:refs/heads/{branch}"],
                 cwd=worktree,
             )
+            return published_commit_sha
         finally:
             self._run(
                 ["git", "worktree", "remove", "--force", str(worktree)],

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -944,12 +944,7 @@ def test_exited_parent_still_terminates_grandchild_holding_discovery_pipes(tmp_p
         base_branch="main",
         runner_temp=tmp_path / "runner",
     )
-    child_code = (
-        "import time\n"
-        "while True:\n"
-        " print('holding-pipe', flush=True)\n"
-        " time.sleep(0.1)\n"
-    )
+    child_code = "import time; time.sleep(5)"
     parent_code = (
         "import subprocess, sys; "
         f"subprocess.Popen([sys.executable, '-c', {child_code!r}])"
@@ -959,11 +954,36 @@ def test_exited_parent_still_terminates_grandchild_holding_discovery_pipes(tmp_p
     output = backend._run_bounded_stdout(
         [sys.executable, "-c", parent_code],
         max_bytes=4096,
-        timeout_seconds=10,
+        timeout_seconds=1,
     )
 
-    assert "holding-pipe" in output
-    assert time.monotonic() - started < 6
+    assert output == ""
+    assert time.monotonic() - started < 1.5
+
+
+def test_overflow_terminates_grandchild_holding_discovery_pipes(tmp_path):
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+    child_code = "import time; time.sleep(5)"
+    parent_code = (
+        "import subprocess, sys; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}]); "
+        "sys.stdout.write('x' * 5000); sys.stdout.flush()"
+    )
+
+    started = time.monotonic()
+    with pytest.raises(BatchSyncError, match="stdout exceeds the 4096-byte discovery limit"):
+        backend._run_bounded_stdout(
+            [sys.executable, "-c", parent_code],
+            max_bytes=4096,
+            timeout_seconds=1,
+        )
+
+    assert time.monotonic() - started < 1.5
 
 
 def test_campaign_discovery_routes_ls_remote_fetch_and_show_through_bounded_runner(

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -23,6 +23,7 @@ from apply_docs_vnext_sync_batches import (  # noqa: E402
     Manifest,
     OrphanBranch,
     PullRequest,
+    WINDOWS_CREATE_SUSPENDED,
     apply_batch,
     branch_name,
     build_pull_request_body,
@@ -1082,6 +1083,43 @@ def test_windows_job_object_uses_kill_on_close_limit():
     assert "LimitFlags = 0x00002000" in source
     assert "TerminateJobObject" in source
     assert "CTRL_BREAK_EVENT" not in source
+    assert WINDOWS_CREATE_SUSPENDED == 0x00000004
+    assert not hasattr(subprocess, "CREATE_SUSPENDED")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process-group lifecycle")
+def test_posix_successful_leader_exit_kills_descendant_with_redirected_pipes(tmp_path):
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+    pid_file = tmp_path / "redirected-child.pid"
+    child_code = (
+        "import os, pathlib, time; "
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+        "time.sleep(5)"
+    )
+    parent_code = (
+        "import pathlib, subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}], "
+        "stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL); "
+        f"pid_file = pathlib.Path({str(pid_file)!r}); "
+        "deadline = time.monotonic() + 2; "
+        "exec(\"while not pid_file.exists() and time.monotonic() < deadline:\\n time.sleep(0.01)\")"
+    )
+
+    output = backend._run_bounded_stdout(
+        [sys.executable, "-c", parent_code],
+        max_bytes=4096,
+        timeout_seconds=1,
+    )
+
+    assert output == ""
+    child_pid = int(pid_file.read_text(encoding="utf-8"))
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
 
 
 def test_overflow_terminates_grandchild_holding_discovery_pipes(tmp_path):

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -1360,6 +1360,69 @@ def test_historical_merged_heads_are_excluded_before_active_candidate_cap():
     assert list(active) == ["automation/docs-vnext-sync/history/batch-100"]
 
 
+def test_discovery_fetches_only_active_head_after_filtering_merged_history(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)], run_id=777)
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    active_head = branch_name(manifest, batch)
+    active_sha = "f" * 40
+    merged = [
+        PullRequest(
+            number=index + 1,
+            state="MERGED",
+            url=f"https://github.com/example/repo/pull/{index + 1}",
+            head_ref=f"automation/docs-vnext-sync/history/batch-{index:03d}",
+            marker=None,
+        )
+        for index in range(100)
+    ]
+    remote_lines = [
+        f"{index:040x}\trefs/heads/{pull_request.head_ref}"
+        for index, pull_request in enumerate(merged)
+    ]
+    remote_lines.append(f"{active_sha}\trefs/heads/{active_head}")
+
+    class RecordingBackend(GitHubGitBackend):
+        def __init__(self):
+            super().__init__(
+                repository_root=tmp_path,
+                repository="example/repository",
+                base_branch="main",
+                runner_temp=tmp_path / "runner",
+            )
+            self.fetches = []
+
+        def _run_bounded_stdout(
+            self,
+            args,
+            *,
+            max_bytes,
+            cwd=None,
+            timeout_seconds=30,
+        ):
+            if args[1] == "ls-remote":
+                return "\n".join(remote_lines) + "\n"
+            if args[1] == "fetch":
+                self.fetches.append(args[-1])
+                return ""
+            if args[1] == "rev-parse":
+                return f"{active_sha}\n"
+            return (
+                "Sync batch\n\n"
+                f"Manifest-SHA256: {manifest.digest}\n"
+                f"Manifest-Run-ID: {manifest.run_id}\n"
+                f"Batch-ID: {batch.id}\n"
+            )
+
+    backend = RecordingBackend()
+
+    identities = backend.discover_campaign_branches(merged)
+
+    assert [identity.head_ref for identity in identities] == [active_head]
+    assert backend.fetches == [
+        f"+refs/heads/{active_head}:refs/remotes/origin/{active_head}"
+    ]
+
+
 def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):
     manifest = _write_manifest(tmp_path, [_operation(1, 1)])
     batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -20,6 +20,7 @@ from apply_docs_vnext_sync_batches import (  # noqa: E402
     BatchSyncError,
     GitHubGitBackend,
     Manifest,
+    OrphanBranch,
     PullRequest,
     apply_batch,
     branch_name,
@@ -108,6 +109,35 @@ def _write(root: Path, relative_path: str, content: bytes | str) -> None:
         path.write_text(content, encoding="utf-8")
 
 
+def _tree_manifest(
+    root: Path,
+    source_files: dict[str, str],
+    target_files: dict[str, str],
+    *,
+    run_id: int = 100,
+) -> Manifest:
+    source = root / "docs"
+    target = root / "docs-vnext"
+    source.mkdir(parents=True)
+    target.mkdir(parents=True)
+    for path, content in source_files.items():
+        _write(source, path, content)
+    for path, content in target_files.items():
+        _write(target, path, content)
+    allowlist = root / "preserve.json"
+    allowlist.write_text(
+        json.dumps({"schemaVersion": 1, "preserve": []}),
+        encoding="utf-8",
+    )
+    manifest_path = root / "manifest.json"
+    manifest_path.write_text(
+        serialize_manifest(build_manifest(source, target, allowlist, root)),
+        encoding="utf-8",
+        newline="\n",
+    )
+    return load_manifest(manifest_path, run_id)
+
+
 def _git(cwd: Path, *args: str) -> None:
     subprocess.run(
         ["git", *args],
@@ -141,6 +171,7 @@ class FakeBackend:
         pull_requests: list[PullRequest] | None = None,
         downloaded_manifests: dict[int, Path] | None = None,
         fail_create_batch: int | None = None,
+        remote_branches: set[str] | None = None,
     ) -> None:
         self.pull_requests = list(pull_requests or [])
         self.downloaded_manifests = downloaded_manifests or {}
@@ -148,15 +179,40 @@ class FakeBackend:
         self.published: list[int] = []
         self.created: list[int] = []
         self.reopened: list[int] = []
+        self.remote_branches = set(remote_branches or set())
+        self.branch_identities: dict[str, OrphanBranch] = {}
+        self.verified_branches: list[int] = []
+        self.reconstructed_branches: list[int] = []
 
     def list_pull_requests(self) -> list[PullRequest]:
         return list(self.pull_requests)
+
+    def list_orphan_branches(
+        self, pull_requests: list[PullRequest]
+    ) -> list[OrphanBranch]:
+        pull_request_heads = {pull_request.head_ref for pull_request in pull_requests}
+        return [
+            identity
+            for branch, identity in self.branch_identities.items()
+            if branch in self.remote_branches and branch not in pull_request_heads
+        ]
 
     def download_manifest(self, run_id: int) -> Path:
         return self.downloaded_manifests[run_id]
 
     def publish_batch(self, manifest: Manifest, batch: Batch, branch: str) -> None:
         assert branch == branch_name(manifest, batch)
+        if branch in self.remote_branches:
+            self.verified_branches.append(batch.number)
+        else:
+            self.remote_branches.add(branch)
+            self.reconstructed_branches.append(batch.number)
+        self.branch_identities[branch] = OrphanBranch(
+            head_ref=branch,
+            manifest_digest=manifest.digest,
+            manifest_run_id=manifest.run_id,
+            batch_id=batch.id,
+        )
         self.published.append(batch.number)
 
     def create_pull_request(
@@ -218,6 +274,56 @@ def test_manifest_consumer_rejects_underreported_payload_accounting(tmp_path):
 
     with pytest.raises(BatchSyncError, match="conservative accounting"):
         _write_manifest(tmp_path, [operation])
+
+
+def test_file_replaces_directory_atomically_under_batch_boundary_pressure(tmp_path):
+    root = tmp_path / "file-replaces-directory"
+    manifest = _tree_manifest(
+        root,
+        {"a.mdx": "independent", "swap": "replacement-file"},
+        {"swap/child.mdx": "old-child"},
+    )
+
+    batches = plan_batches(manifest, max_files=2, max_payload_bytes=1000)
+
+    assert [[operation.path for operation in batch.operations] for batch in batches] == [
+        ["a.mdx"],
+        ["swap", "swap/child.mdx"],
+    ]
+    apply_batch(root, manifest, batches[1])
+    assert (root / "docs-vnext" / "swap").read_text(encoding="utf-8") == "replacement-file"
+
+
+def test_directory_replaces_file_atomically_under_batch_boundary_pressure(tmp_path):
+    root = tmp_path / "directory-replaces-file"
+    manifest = _tree_manifest(
+        root,
+        {"a.mdx": "independent", "swap/child.mdx": "replacement-child"},
+        {"swap": "old-file"},
+    )
+
+    batches = plan_batches(manifest, max_files=2, max_payload_bytes=1000)
+
+    assert [[operation.path for operation in batch.operations] for batch in batches] == [
+        ["a.mdx"],
+        ["swap/child.mdx", "swap"],
+    ]
+    apply_batch(root, manifest, batches[1])
+    assert (root / "docs-vnext" / "swap" / "child.mdx").read_text(
+        encoding="utf-8"
+    ) == "replacement-child"
+
+
+def test_atomic_path_dependency_fails_closed_when_group_exceeds_ceiling(tmp_path):
+    root = tmp_path / "oversize-replacement"
+    manifest = _tree_manifest(
+        root,
+        {"swap": "replacement-file"},
+        {"swap/child.mdx": "old-child"},
+    )
+
+    with pytest.raises(BatchSyncError, match="Atomic path dependency.*exceeding ceilings"):
+        plan_batches(manifest, max_files=1, max_payload_bytes=1000)
 
 
 def test_apply_batch_copies_adds_and_modifications_removes_and_preserves(tmp_path):
@@ -335,7 +441,7 @@ def test_resume_skips_merged_batch_and_creates_only_pending_batch(tmp_path):
     ]
 
 
-def test_closed_pull_request_is_reopened_instead_of_duplicated(tmp_path):
+def test_closed_pull_request_with_missing_branch_is_reconstructed_before_reopen(tmp_path):
     manifest = _write_manifest(tmp_path, [_operation(1, 1)])
     batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
     closed = _pull_request(manifest, batch, number=9, state="CLOSED")
@@ -353,11 +459,38 @@ def test_closed_pull_request_is_reopened_instead_of_duplicated(tmp_path):
 
     assert succeeded is True
     assert backend.reopened == [9]
-    assert backend.published == []
+    assert backend.published == [1]
+    assert backend.reconstructed_branches == [1]
+    assert backend.verified_branches == []
     assert backend.created == []
 
 
-def test_real_git_backend_recovers_existing_branch_with_added_file(tmp_path):
+def test_closed_pull_request_with_existing_branch_is_verified_before_reopen(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)])
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    branch = branch_name(manifest, batch)
+    closed = _pull_request(manifest, batch, number=9, state="CLOSED")
+    backend = FakeBackend([closed], remote_branches={branch})
+
+    succeeded = execute_batches(
+        manifest,
+        [batch],
+        backend,
+        [closed],
+        tmp_path / "checkpoint.json",
+        max_files=1,
+        max_payload_bytes=10,
+    )
+
+    assert succeeded is True
+    assert backend.reopened == [9]
+    assert backend.published == [1]
+    assert backend.reconstructed_branches == []
+    assert backend.verified_branches == [1]
+    assert backend.created == []
+
+
+def test_real_git_backend_recovers_branch_with_add_and_path_replacements(tmp_path):
     remote = tmp_path / "remote.git"
     repository = tmp_path / "repository"
     runner_temp = tmp_path / "runner"
@@ -368,7 +501,11 @@ def test_real_git_backend_recovers_existing_branch_with_added_file(tmp_path):
     _git(repository, "config", "user.name", "Test User")
     _git(repository, "config", "user.email", "test@example.com")
     _write(repository / "docs", "page.mdx", "canonical")
+    _write(repository / "docs", "file-replacement", "replacement-file")
+    _write(repository / "docs", "directory-replacement/child.mdx", "replacement-child")
     _write(repository / "docs-vnext", ".gitkeep", "")
+    _write(repository / "docs-vnext", "file-replacement/old-child.mdx", "old-child")
+    _write(repository / "docs-vnext", "directory-replacement", "old-file")
     allowlist = repository / ".github" / "preserve.json"
     allowlist.parent.mkdir(parents=True)
     allowlist.write_text(
@@ -408,8 +545,17 @@ def test_real_git_backend_recovers_existing_branch_with_added_file(tmp_path):
     )
 
     backend.publish_batch(manifest, batch, branch)
+    orphans = backend.list_orphan_branches([])
     backend.publish_batch(manifest, batch, branch)
 
+    assert orphans == [
+        OrphanBranch(
+            head_ref=branch,
+            manifest_digest=manifest.digest,
+            manifest_run_id=manifest.run_id,
+            batch_id=batch.id,
+        )
+    ]
     result = subprocess.run(
         ["git", "--git-dir", str(remote), "show", f"{branch}:docs-vnext/page.mdx"],
         check=True,
@@ -418,6 +564,28 @@ def test_real_git_backend_recovers_existing_branch_with_added_file(tmp_path):
         encoding="utf-8",
     )
     assert result.stdout == "canonical"
+    file_replacement = subprocess.run(
+        ["git", "--git-dir", str(remote), "show", f"{branch}:docs-vnext/file-replacement"],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert file_replacement.stdout == "replacement-file"
+    directory_replacement = subprocess.run(
+        [
+            "git",
+            "--git-dir",
+            str(remote),
+            "show",
+            f"{branch}:docs-vnext/directory-replacement/child.mdx",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    assert directory_replacement.stdout == "replacement-child"
 
 
 def test_partial_failure_records_completed_failed_and_pending_batches(tmp_path):
@@ -451,6 +619,60 @@ def test_partial_failure_records_completed_failed_and_pending_batches(tmp_path):
         "pending",
     ]
     assert "simulated pull-request failure" in state["batches"][1]["diagnostic"]
+
+
+def test_new_manifest_recovers_orphan_branch_from_failed_pr_creation(tmp_path):
+    original = _write_manifest(
+        tmp_path,
+        [_operation(1, 1), _operation(2, 1)],
+        name="original-orphan.json",
+        run_id=200,
+    )
+    backend = FakeBackend(
+        downloaded_manifests={200: original.path},
+        fail_create_batch=1,
+    )
+    original_batches = plan_batches(original, max_files=1, max_payload_bytes=10)
+
+    first_succeeded = execute_batches(
+        original,
+        original_batches,
+        backend,
+        [],
+        tmp_path / "first-checkpoint.json",
+        max_files=1,
+        max_payload_bytes=10,
+    )
+
+    assert first_succeeded is False
+    orphans = backend.list_orphan_branches([])
+    assert [orphan.head_ref for orphan in orphans] == [
+        branch_name(original, original_batches[0])
+    ]
+    current = _write_manifest(
+        tmp_path,
+        [_operation(2, 1)],
+        name="newer-manifest.json",
+        run_id=300,
+    )
+
+    selected = select_active_manifest(current, backend, [], orphans)
+
+    assert selected.digest == original.digest
+    assert selected.run_id == 200
+    backend.fail_create_batch = None
+    resumed_succeeded = execute_batches(
+        selected,
+        plan_batches(selected, max_files=1, max_payload_bytes=10),
+        backend,
+        [],
+        tmp_path / "resumed-checkpoint.json",
+        max_files=1,
+        max_payload_bytes=10,
+    )
+    assert resumed_succeeded is True
+    assert backend.verified_branches == [1]
+    assert backend.created == [1, 2]
 
 
 def test_active_campaign_resumes_original_retained_manifest(tmp_path):

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -891,6 +891,27 @@ def test_backend_bounds_commit_message_output_before_parsing(tmp_path):
         )
 
 
+def test_single_stream_overflow_cannot_race_natural_completion(tmp_path):
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+
+    for _ in range(20):
+        with pytest.raises(BatchSyncError, match="stdout exceeds the 4096-byte discovery limit"):
+            backend._run_bounded_stdout(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; sys.stderr.close(); sys.stdout.write('x' * 5000)",
+                ],
+                max_bytes=4096,
+                timeout_seconds=1,
+            )
+
+
 def test_backend_bounds_hanging_discovery_command(tmp_path):
     backend = GitHubGitBackend(
         repository_root=tmp_path,
@@ -899,12 +920,14 @@ def test_backend_bounds_hanging_discovery_command(tmp_path):
         runner_temp=tmp_path / "runner",
     )
 
+    started = time.monotonic()
     with pytest.raises(BatchSyncError, match="exceeded the 1-second discovery timeout"):
         backend._run_bounded_stdout(
             [sys.executable, "-c", "import time; time.sleep(5)"],
             max_bytes=4096,
             timeout_seconds=1,
         )
+    assert time.monotonic() - started < 1.5
 
 
 def test_timeout_terminates_child_holding_discovery_pipes(tmp_path):
@@ -934,7 +957,7 @@ def test_timeout_terminates_child_holding_discovery_pipes(tmp_path):
             timeout_seconds=1,
         )
 
-    assert time.monotonic() - started < 6
+    assert time.monotonic() - started < 1.5
 
 
 def test_exited_parent_still_terminates_grandchild_holding_discovery_pipes(tmp_path):
@@ -968,15 +991,20 @@ def test_exited_parent_child_holding_both_streams_uses_one_deadline(tmp_path):
         base_branch="main",
         runner_temp=tmp_path / "runner",
     )
+    started_file = tmp_path / "two-stream-child-started"
     child_code = (
-        "import sys, time; "
+        "import pathlib, sys, time; "
         "print('stdout-held', flush=True); "
         "print('stderr-held', file=sys.stderr, flush=True); "
+        f"pathlib.Path({str(started_file)!r}).write_text('started'); "
         "time.sleep(5)"
     )
     parent_code = (
-        "import subprocess, sys; "
-        f"subprocess.Popen([sys.executable, '-c', {child_code!r}])"
+        "import pathlib, subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}]); "
+        f"started = pathlib.Path({str(started_file)!r}); "
+        "deadline = time.monotonic() + 2; "
+        "exec(\"while not started.exists() and time.monotonic() < deadline:\\n time.sleep(0.01)\")"
     )
 
     started = time.monotonic()

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -28,6 +28,7 @@ from apply_docs_vnext_sync_batches import (  # noqa: E402
     branch_name,
     build_pull_request_body,
     enforce_campaign_candidate_limit,
+    exclude_completed_remote_heads,
     execute_batches,
     load_manifest,
     parse_commit_identity,
@@ -371,6 +372,24 @@ def test_atomic_path_dependency_fails_closed_when_group_exceeds_ceiling(tmp_path
         plan_batches(manifest, max_files=1, max_payload_bytes=1000)
 
 
+def test_path_dependency_span_preserves_intervening_manifest_order(tmp_path):
+    swap = _operation(1, 1)
+    swap["path"] = "swap"
+    intervening = _operation(2, 1)
+    intervening["path"] = "z.mdx"
+    child = _operation(3, 1, decision="remove")
+    child["path"] = "swap/child.mdx"
+    manifest = _write_manifest(tmp_path, [swap, intervening, child])
+
+    batches = plan_batches(manifest, max_files=3, max_payload_bytes=10)
+
+    assert [[operation.path for operation in batch.operations] for batch in batches] == [
+        ["swap", "z.mdx", "swap/child.mdx"]
+    ]
+    with pytest.raises(BatchSyncError, match="Atomic path dependency.*exceeding ceilings"):
+        plan_batches(manifest, max_files=2, max_payload_bytes=10)
+
+
 def test_apply_batch_copies_adds_and_modifications_removes_and_preserves(tmp_path):
     source = tmp_path / "docs"
     target = tmp_path / "docs-vnext"
@@ -709,6 +728,13 @@ def test_real_git_backend_rejects_same_tree_force_push_after_identity_authentica
     forged_pr = _pull_request(manifest, batch)
     campaign_branches = backend.discover_campaign_branches([forged_pr])
     authenticated_sha = campaign_branches[0].commit_sha
+    authenticated_commits = validate_campaign_identities(
+        manifest,
+        [batch],
+        backend,
+        [forged_pr],
+        campaign_branches,
+    )
 
     _git(repository, "fetch", "origin", branch)
     _git(repository, "switch", "--create", "forged", "FETCH_HEAD")
@@ -730,14 +756,20 @@ def test_real_git_backend_rejects_same_tree_force_push_after_identity_authentica
     ).stdout.strip()
     assert forged_sha != authenticated_sha
 
-    with pytest.raises(BatchSyncError, match="moved from authenticated commit"):
-        validate_campaign_identities(
-            manifest,
-            [batch],
-            backend,
-            [forged_pr],
-            campaign_branches,
-        )
+    checkpoint = tmp_path / "force-push-checkpoint.json"
+    succeeded = execute_batches(
+        manifest,
+        [batch],
+        backend,
+        [forged_pr],
+        checkpoint,
+        max_files=10,
+        max_payload_bytes=1000,
+        authenticated_batch_commits=authenticated_commits,
+    )
+    assert succeeded is False
+    state = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert "moved from authenticated commit" in state["batches"][0]["diagnostic"]
     with pytest.raises(BatchSyncError, match="campaign trailer"):
         backend.publish_batch(manifest, batch, branch)
 
@@ -1274,8 +1306,9 @@ def test_remote_branch_discovery_rejects_excessive_branch_count():
         for index in range(101)
     )
 
+    parsed = parse_remote_branch_refs(output)
     with pytest.raises(BatchSyncError, match="above the 100-branch discovery limit"):
-        parse_remote_branch_refs(output)
+        enforce_campaign_candidate_limit(set(parsed), set())
 
 
 def test_remote_branch_discovery_rejects_duplicate_refs():
@@ -1296,6 +1329,35 @@ def test_combined_remote_and_deleted_pr_candidates_are_capped_before_fetch():
 
     with pytest.raises(BatchSyncError, match="101 active automation identity candidates"):
         enforce_campaign_candidate_limit(remote_heads, deleted_pr_heads)
+
+
+def test_historical_merged_heads_are_excluded_before_active_candidate_cap():
+    expected_heads = {
+        f"automation/docs-vnext-sync/history/batch-{index:03d}": f"{index:040x}"
+        for index in range(101)
+    }
+    output = "\n".join(
+        f"{commit_sha}\trefs/heads/{head_ref}"
+        for head_ref, commit_sha in expected_heads.items()
+    )
+    merged = [
+        PullRequest(
+            number=index + 1,
+            state="MERGED",
+            url=f"https://github.com/example/repo/pull/{index + 1}",
+            head_ref=f"automation/docs-vnext-sync/history/batch-{index:03d}",
+            marker=None,
+        )
+        for index in range(100)
+    ]
+
+    active = exclude_completed_remote_heads(
+        parse_remote_branch_refs(output),
+        merged,
+    )
+    enforce_campaign_candidate_limit(set(active), set())
+
+    assert list(active) == ["automation/docs-vnext-sync/history/batch-100"]
 
 
 def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):
@@ -1368,7 +1430,7 @@ def test_missing_or_malformed_pr_marker_recovers_from_verified_head(tmp_path, bo
         tmp_path / "recovered-checkpoint.json",
         max_files=1,
         max_payload_bytes=10,
-        preverified_batch_ids=preverified,
+        authenticated_batch_commits=preverified,
     )
 
     assert succeeded is True

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -27,9 +27,12 @@ from apply_docs_vnext_sync_batches import (  # noqa: E402
     build_pull_request_body,
     execute_batches,
     load_manifest,
+    parse_commit_identity,
     parse_pull_request_marker,
+    parse_remote_branch_refs,
     plan_batches,
     select_active_manifest,
+    validate_campaign_identities,
 )
 from generate_docs_vnext_sync_manifest import build_manifest, serialize_manifest  # noqa: E402
 
@@ -371,7 +374,7 @@ def test_existing_open_pull_request_prevents_duplicate_publish_and_creation(tmp_
     manifest = _write_manifest(tmp_path, [_operation(1, 1)])
     batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
     pull_request = _pull_request(manifest, batch)
-    backend = FakeBackend([pull_request])
+    backend = FakeBackend([pull_request], remote_branches={branch_name(manifest, batch)})
     checkpoint = tmp_path / "checkpoint.json"
 
     succeeded = execute_batches(
@@ -385,7 +388,8 @@ def test_existing_open_pull_request_prevents_duplicate_publish_and_creation(tmp_
     )
 
     assert succeeded is True
-    assert backend.published == []
+    assert backend.published == [1]
+    assert backend.verified_branches == [1]
     assert backend.created == []
     state = json.loads(checkpoint.read_text(encoding="utf-8"))
     assert state["batches"][0]["result"] == "existing-open-pull-request"
@@ -588,6 +592,68 @@ def test_real_git_backend_recovers_branch_with_add_and_path_replacements(tmp_pat
     assert directory_replacement.stdout == "replacement-child"
 
 
+def test_real_git_backend_rejects_force_pushed_open_pr_branch(tmp_path):
+    remote = tmp_path / "forged-remote.git"
+    repository = tmp_path / "forged-repository"
+    runner_temp = tmp_path / "forged-runner"
+    remote.mkdir()
+    repository.mkdir()
+    _git(remote, "init", "--bare")
+    _git(repository, "init", "--initial-branch=main")
+    _git(repository, "config", "user.name", "Test User")
+    _git(repository, "config", "user.email", "test@example.com")
+    _write(repository / "docs", "page.mdx", "canonical")
+    _write(repository / "docs-vnext", ".gitkeep", "")
+    allowlist = repository / "preserve.json"
+    allowlist.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "preserve": [{"kind": "file", "path": ".gitkeep"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "base")
+    _git(repository, "remote", "add", "origin", str(remote))
+    _git(repository, "push", "--set-upstream", "origin", "main")
+    manifest_path = tmp_path / "forged-manifest.json"
+    manifest_path.write_text(
+        serialize_manifest(
+            build_manifest(
+                repository / "docs",
+                repository / "docs-vnext",
+                allowlist,
+                repository,
+            )
+        ),
+        encoding="utf-8",
+        newline="\n",
+    )
+    manifest = load_manifest(manifest_path, 789)
+    batch = plan_batches(manifest, max_files=10, max_payload_bytes=1000)[0]
+    branch = branch_name(manifest, batch)
+    backend = GitHubGitBackend(
+        repository_root=repository,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=runner_temp,
+    )
+    backend.publish_batch(manifest, batch, branch)
+
+    _git(repository, "fetch", "origin", branch)
+    _git(repository, "switch", "--create", "forged", "FETCH_HEAD")
+    _write(repository / "docs-vnext", "page.mdx", "forged")
+    _git(repository, "add", "docs-vnext/page.mdx")
+    _git(repository, "commit", "-m", "forge deterministic branch")
+    _git(repository, "push", "--force", "origin", f"HEAD:refs/heads/{branch}")
+    forged_pr = _pull_request(manifest, batch)
+
+    with pytest.raises(BatchSyncError, match="does not match the reconstructed batch"):
+        validate_campaign_identities(manifest, [batch], backend, [forged_pr], [])
+
+
 def test_partial_failure_records_completed_failed_and_pending_batches(tmp_path):
     manifest = _write_manifest(
         tmp_path,
@@ -673,6 +739,108 @@ def test_new_manifest_recovers_orphan_branch_from_failed_pr_creation(tmp_path):
     assert resumed_succeeded is True
     assert backend.verified_branches == [1]
     assert backend.created == [1, 2]
+
+
+@pytest.mark.parametrize(
+    ("message", "error"),
+    [
+        (
+            "Subject\n\nManifest-SHA256: "
+            + "a" * 64
+            + "\nManifest-Run-ID: 1\nManifest-Run-ID: 2",
+            "duplicate campaign trailer",
+        ),
+        (
+            "Subject\n\nManifest-SHA256: "
+            + "a" * 64
+            + "\nUnknown-ID: 1\nBatch-ID: sha256:"
+            + "b" * 64,
+            "unknown campaign trailer",
+        ),
+        (
+            "Subject\n\nManifest-SHA256: "
+            + "a" * 64
+            + "\nManifest-Run-ID: 1",
+            "exactly 3 trailers",
+        ),
+        (        "Subject without trailers", "missing a final campaign trailer block"),
+        (
+        "Subject\n\nManifest-SHA256: "
+        + "a" * 64
+        + "\nManifest-Run-ID 1\nBatch-ID: sha256:"
+        + "b" * 64,
+        "malformed campaign trailer",
+        ),
+    ],
+)
+def test_commit_identity_rejects_malformed_duplicate_missing_and_unknown_trailers(
+    message,
+    error,
+):
+    with pytest.raises(BatchSyncError, match=error):
+        parse_commit_identity(message, "automation/docs-vnext-sync/forged")
+
+
+def test_commit_identity_rejects_oversize_message():
+    message = "x" * 4097 + "\n\nManifest-SHA256: " + "a" * 64
+
+    with pytest.raises(BatchSyncError, match="above the 4096-byte discovery limit"):
+        parse_commit_identity(message, "automation/docs-vnext-sync/oversize")
+
+
+def test_backend_bounds_commit_message_output_before_parsing(tmp_path):
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+
+    with pytest.raises(BatchSyncError, match="stdout exceeds the 4096-byte discovery limit"):
+        backend._run_bounded_stdout(
+            [sys.executable, "-c", "print('x' * 5000)"],
+            max_bytes=4096,
+        )
+
+    with pytest.raises(BatchSyncError, match="stderr exceeds the 4096-byte discovery limit"):
+        backend._run_bounded_stdout(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.stderr.write('e' * 200000); sys.stderr.flush(); print('ok')",
+            ],
+            max_bytes=4096,
+        )
+
+
+def test_remote_branch_discovery_rejects_excessive_branch_count():
+    output = "\n".join(
+        f"{'a' * 40}\trefs/heads/automation/docs-vnext-sync/campaign/batch-{index}"
+        for index in range(101)
+    )
+
+    with pytest.raises(BatchSyncError, match="above the 100-branch discovery limit"):
+        parse_remote_branch_refs(output)
+
+
+def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)])
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    valid_pr = _pull_request(manifest, batch)
+    forged_pr = replace(valid_pr, head_ref=f"{branch_name(manifest, batch)}-forged")
+    backend = FakeBackend([forged_pr])
+
+    with pytest.raises(BatchSyncError, match="does not match deterministic branch"):
+        validate_campaign_identities(manifest, [batch], backend, [forged_pr], [])
+
+    forged_orphan = OrphanBranch(
+        head_ref=branch_name(manifest, batch),
+        manifest_digest=manifest.digest,
+        manifest_run_id=manifest.run_id,
+        batch_id=f"sha256:{'f' * 64}",
+    )
+    with pytest.raises(BatchSyncError, match="does not match an exact planned batch"):
+        validate_campaign_identities(manifest, [batch], backend, [], [forged_orphan])
 
 
 def test_active_campaign_resumes_original_retained_manifest(tmp_path):

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -901,6 +901,55 @@ def test_backend_bounds_hanging_discovery_command(tmp_path):
         )
 
 
+def test_campaign_discovery_routes_ls_remote_fetch_and_show_through_bounded_runner(
+    tmp_path,
+):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)], run_id=321)
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    branch = branch_name(manifest, batch)
+
+    class RecordingBackend(GitHubGitBackend):
+        def __init__(self):
+            super().__init__(
+                repository_root=tmp_path,
+                repository="example/repository",
+                base_branch="main",
+                runner_temp=tmp_path / "runner",
+            )
+            self.calls = []
+
+        def _run_bounded_stdout(
+            self,
+            args,
+            *,
+            max_bytes,
+            cwd=None,
+            timeout_seconds=30,
+        ):
+            self.calls.append((tuple(args), max_bytes, timeout_seconds))
+            if args[1] == "ls-remote":
+                return f"{'a' * 40}\trefs/heads/{branch}\n"
+            if args[1] == "fetch":
+                return ""
+            return (
+                "Sync batch\n\n"
+                f"Manifest-SHA256: {manifest.digest}\n"
+                f"Manifest-Run-ID: {manifest.run_id}\n"
+                f"Batch-ID: {batch.id}\n"
+            )
+
+    backend = RecordingBackend()
+
+    identities = backend.discover_campaign_branches([])
+
+    assert identities[0].batch_id == batch.id
+    assert [(call[0][1], call[1], call[2]) for call in backend.calls] == [
+        ("ls-remote", 32 * 1024, 30),
+        ("fetch", 4096, 30),
+        ("show", 4096, 30),
+    ]
+
+
 @pytest.mark.parametrize("run_id", ["+1", "01", "1_0", "1 ", "0", "-1"])
 def test_commit_identity_rejects_noncanonical_run_ids(run_id):
     message = (

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -229,6 +229,10 @@ class FakeBackend:
         self.verified_branches: list[int] = []
         self.reconstructed_branches: list[int] = []
         self.downloaded_run_ids: list[int] = []
+        self.remote_commit_shas: dict[str, str] = {}
+        for identity in self.pull_request_identities.values():
+            if identity.head_ref in self.remote_branches:
+                self.remote_commit_shas[identity.head_ref] = identity.commit_sha
 
     def list_pull_requests(self) -> list[PullRequest]:
         return list(self.pull_requests)
@@ -271,20 +275,34 @@ class FakeBackend:
         batch: Batch,
         branch: str,
         expected_commit_sha: str | None = None,
-    ) -> None:
+    ) -> str:
         assert branch == branch_name(manifest, batch)
         if branch in self.remote_branches:
+            actual_commit_sha = self.remote_commit_shas.get(
+                branch,
+                expected_commit_sha or ("c" * 40),
+            )
+            if expected_commit_sha is not None and actual_commit_sha != expected_commit_sha:
+                raise BatchSyncError(
+                    f"Automation branch {branch!r} moved from authenticated commit"
+                )
             self.verified_branches.append(batch.number)
         else:
+            actual_commit_sha = hashlib.sha1(
+                f"{manifest.digest}:{batch.id}:reconstructed".encode()
+            ).hexdigest()
             self.remote_branches.add(branch)
+            self.remote_commit_shas[branch] = actual_commit_sha
             self.reconstructed_branches.append(batch.number)
         self.branch_identities[branch] = OrphanBranch(
             head_ref=branch,
             manifest_digest=manifest.digest,
             manifest_run_id=manifest.run_id,
             batch_id=batch.id,
+            commit_sha=actual_commit_sha,
         )
         self.published.append(batch.number)
+        return actual_commit_sha
 
     def create_pull_request(
         self,
@@ -603,6 +621,51 @@ def test_closed_pull_request_with_existing_branch_is_verified_before_reopen(tmp_
     assert backend.reconstructed_branches == []
     assert backend.verified_branches == [1]
     assert backend.created == []
+
+
+def test_deleted_closed_pr_reconstruction_propagates_new_authenticated_sha(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)], run_id=432)
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    closed = _pull_request(manifest, batch, number=9, state="CLOSED")
+    old_identity = OrphanBranch(
+        head_ref=closed.head_ref,
+        manifest_digest=manifest.digest,
+        manifest_run_id=manifest.run_id,
+        batch_id=batch.id,
+        pull_request_number=closed.number,
+        commit_sha="a" * 40,
+    )
+    backend = FakeBackend(
+        [closed],
+        downloaded_manifests={manifest.run_id: manifest.path},
+        pull_request_identities={closed.number: old_identity},
+    )
+
+    campaign = backend.discover_campaign_branches([closed])
+    selected = select_active_manifest(manifest, backend, campaign)
+    authenticated_commits = validate_campaign_identities(
+        selected,
+        [batch],
+        backend,
+        [closed],
+        campaign,
+    )
+
+    assert authenticated_commits[batch.id] != old_identity.commit_sha
+    assert authenticated_commits[batch.id] == backend.remote_commit_shas[closed.head_ref]
+    succeeded = execute_batches(
+        selected,
+        [batch],
+        backend,
+        [closed],
+        tmp_path / "reconstructed-reopen-checkpoint.json",
+        max_files=1,
+        max_payload_bytes=10,
+        authenticated_batch_commits=authenticated_commits,
+    )
+    assert succeeded is True
+    assert backend.reopened == [closed.number]
+    assert backend.verified_branches == [batch.number]
 
 
 def test_real_git_backend_recovers_branch_with_add_and_path_replacements(tmp_path):

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -950,6 +950,52 @@ def test_campaign_discovery_routes_ls_remote_fetch_and_show_through_bounded_runn
     ]
 
 
+def test_deleted_pr_head_with_missing_marker_recovers_via_bounded_pull_ref(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)], run_id=654)
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    pull_request = replace(_pull_request(manifest, batch), marker=None)
+
+    class RecordingBackend(GitHubGitBackend):
+        def __init__(self):
+            super().__init__(
+                repository_root=tmp_path,
+                repository="example/repository",
+                base_branch="main",
+                runner_temp=tmp_path / "runner",
+            )
+            self.calls = []
+
+        def _run_bounded_stdout(
+            self,
+            args,
+            *,
+            max_bytes,
+            cwd=None,
+            timeout_seconds=30,
+        ):
+            self.calls.append((tuple(args), max_bytes, timeout_seconds))
+            if args[1] in {"ls-remote", "fetch"}:
+                return ""
+            return (
+                "Sync batch\n\n"
+                f"Manifest-SHA256: {manifest.digest}\n"
+                f"Manifest-Run-ID: {manifest.run_id}\n"
+                f"Batch-ID: {batch.id}\n"
+            )
+
+    backend = RecordingBackend()
+
+    identities = backend.discover_campaign_branches([pull_request])
+    selected = select_active_manifest(manifest, backend, identities)
+
+    assert selected.digest == manifest.digest
+    assert identities[0].pull_request_number == pull_request.number
+    fetch_call = backend.calls[1]
+    assert fetch_call[0][1] == "fetch"
+    assert f"refs/pull/{pull_request.number}/head" in fetch_call[0][-1]
+    assert fetch_call[1:] == (4096, 30)
+
+
 @pytest.mark.parametrize("run_id", ["+1", "01", "1_0", "1 ", "0", "-1"])
 def test_commit_identity_rejects_noncanonical_run_ids(run_id):
     message = (

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -707,6 +707,7 @@ def test_real_git_backend_rejects_same_tree_force_push_after_identity_authentica
     backend.publish_batch(manifest, batch, branch)
     forged_pr = _pull_request(manifest, batch)
     campaign_branches = backend.discover_campaign_branches([forged_pr])
+    authenticated_sha = campaign_branches[0].commit_sha
 
     _git(repository, "fetch", "origin", branch)
     _git(repository, "switch", "--create", "forged", "FETCH_HEAD")
@@ -718,6 +719,15 @@ def test_real_git_backend_rejects_same_tree_force_push_after_identity_authentica
         "same tree with malformed identity",
     )
     _git(repository, "push", "--force", "origin", f"HEAD:refs/heads/{branch}")
+    forged_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    ).stdout.strip()
+    assert forged_sha != authenticated_sha
 
     with pytest.raises(BatchSyncError, match="moved from authenticated commit"):
         validate_campaign_identities(
@@ -1058,6 +1068,18 @@ def test_windows_job_terminates_child_ignoring_ctrl_break(tmp_path):
         )
         ctypes.windll.kernel32.CloseHandle(process_handle)
         assert exit_code.value != 259
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows Job Object configuration")
+def test_windows_job_object_uses_kill_on_close_limit():
+    source = (REPO_ROOT / "scripts" / "apply_docs_vnext_sync_batches.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "SetInformationJobObject" in source
+    assert "LimitFlags = 0x00002000" in source
+    assert "TerminateJobObject" in source
+    assert "CTRL_BREAK_EVENT" not in source
 
 
 def test_overflow_terminates_grandchild_holding_discovery_pipes(tmp_path):

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -230,7 +231,12 @@ class FakeBackend:
 
     def download_manifest(self, run_id: int) -> Path:
         self.downloaded_run_ids.append(run_id)
-        return self.downloaded_manifests[run_id]
+        try:
+            return self.downloaded_manifests[run_id]
+        except KeyError as exc:
+            raise BatchSyncError(
+                f"Manifest artifact for workflow run {run_id} is unavailable"
+            ) from exc
 
     def publish_batch(self, manifest: Manifest, batch: Batch, branch: str) -> None:
         assert branch == branch_name(manifest, batch)
@@ -901,6 +907,65 @@ def test_backend_bounds_hanging_discovery_command(tmp_path):
         )
 
 
+def test_timeout_terminates_child_holding_discovery_pipes(tmp_path):
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+    child_code = (
+        "import time\n"
+        "while True:\n"
+        " print('holding-pipe', flush=True)\n"
+        " time.sleep(0.1)\n"
+    )
+    parent_code = (
+        "import subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}]); "
+        "time.sleep(30)"
+    )
+
+    started = time.monotonic()
+    with pytest.raises(BatchSyncError, match="exceeded the 1-second discovery timeout"):
+        backend._run_bounded_stdout(
+            [sys.executable, "-c", parent_code],
+            max_bytes=4096,
+            timeout_seconds=1,
+        )
+
+    assert time.monotonic() - started < 6
+
+
+def test_exited_parent_still_terminates_grandchild_holding_discovery_pipes(tmp_path):
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+    child_code = (
+        "import time\n"
+        "while True:\n"
+        " print('holding-pipe', flush=True)\n"
+        " time.sleep(0.1)\n"
+    )
+    parent_code = (
+        "import subprocess, sys; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}])"
+    )
+
+    started = time.monotonic()
+    output = backend._run_bounded_stdout(
+        [sys.executable, "-c", parent_code],
+        max_bytes=4096,
+        timeout_seconds=10,
+    )
+
+    assert "holding-pipe" in output
+    assert time.monotonic() - started < 6
+
+
 def test_campaign_discovery_routes_ls_remote_fetch_and_show_through_bounded_runner(
     tmp_path,
 ):
@@ -937,6 +1002,10 @@ def test_campaign_discovery_routes_ls_remote_fetch_and_show_through_bounded_runn
                 f"Manifest-Run-ID: {manifest.run_id}\n"
                 f"Batch-ID: {batch.id}\n"
             )
+
+        def download_manifest(self, run_id):
+            assert run_id == manifest.run_id
+            return manifest.path
 
     backend = RecordingBackend()
 
@@ -982,6 +1051,10 @@ def test_deleted_pr_head_with_missing_marker_recovers_via_bounded_pull_ref(tmp_p
                 f"Manifest-Run-ID: {manifest.run_id}\n"
                 f"Batch-ID: {batch.id}\n"
             )
+
+        def download_manifest(self, run_id):
+            assert run_id == manifest.run_id
+            return manifest.path
 
     backend = RecordingBackend()
 
@@ -1087,6 +1160,7 @@ def test_missing_or_malformed_pr_marker_recovers_from_verified_head(tmp_path, bo
     )
     backend = FakeBackend(
         [pull_request],
+        downloaded_manifests={manifest.run_id: manifest.path},
         remote_branches={pull_request.head_ref},
         pull_request_identities={pull_request.number: identity},
     )
@@ -1112,7 +1186,7 @@ def test_missing_or_malformed_pr_marker_recovers_from_verified_head(tmp_path, bo
     )
 
     assert succeeded is True
-    assert backend.downloaded_run_ids == []
+    assert backend.downloaded_run_ids == [manifest.run_id]
 
 
 def test_forged_marker_cannot_pin_manifest_before_head_authentication(tmp_path):
@@ -1171,6 +1245,67 @@ def test_pr_and_orphan_cannot_claim_the_same_derived_batch(tmp_path):
             [pull_request],
             [*pull_request_identity, orphan],
         )
+
+
+def test_same_digest_claim_cannot_adopt_nonexistent_run_id(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)], run_id=300)
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    claimed = OrphanBranch(
+        head_ref=branch_name(manifest, batch),
+        manifest_digest=manifest.digest,
+        manifest_run_id=999,
+        batch_id=batch.id,
+    )
+    backend = FakeBackend()
+
+    with pytest.raises(BatchSyncError, match="workflow run 999 is unavailable"):
+        select_active_manifest(manifest, backend, [claimed])
+    assert backend.downloaded_run_ids == [999]
+
+
+def test_same_digest_claim_cannot_adopt_unrelated_run_artifact(tmp_path):
+    manifest = _write_manifest(
+        tmp_path,
+        [_operation(1, 1)],
+        name="same-digest-current.json",
+        run_id=300,
+    )
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    unrelated = _write_manifest(
+        tmp_path,
+        [_operation(2, 1)],
+        name="unrelated-run.json",
+        run_id=998,
+    )
+    claimed = OrphanBranch(
+        head_ref=branch_name(manifest, batch),
+        manifest_digest=manifest.digest,
+        manifest_run_id=998,
+        batch_id=batch.id,
+    )
+    backend = FakeBackend(downloaded_manifests={998: unrelated.path})
+
+    with pytest.raises(BatchSyncError, match="has digest.*expected"):
+        select_active_manifest(manifest, backend, [claimed])
+    assert backend.downloaded_run_ids == [998]
+
+
+def test_same_digest_claim_adopts_only_verified_run_artifact(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)], run_id=300)
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    claimed = OrphanBranch(
+        head_ref=branch_name(manifest, batch),
+        manifest_digest=manifest.digest,
+        manifest_run_id=997,
+        batch_id=batch.id,
+    )
+    backend = FakeBackend(downloaded_manifests={997: manifest.path})
+
+    selected = select_active_manifest(manifest, backend, [claimed])
+
+    assert selected.digest == manifest.digest
+    assert selected.run_id == 997
+    assert backend.downloaded_run_ids == [997]
 
 
 def test_active_campaign_resumes_original_retained_manifest(tmp_path):

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -823,6 +823,15 @@ def test_remote_branch_discovery_rejects_excessive_branch_count():
         parse_remote_branch_refs(output)
 
 
+def test_remote_branch_discovery_rejects_duplicate_refs():
+    line = (
+        f"{'a' * 40}\trefs/heads/automation/docs-vnext-sync/campaign/batch-001"
+    )
+
+    with pytest.raises(BatchSyncError, match="duplicate references"):
+        parse_remote_branch_refs(f"{line}\n{line}\n")
+
+
 def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):
     manifest = _write_manifest(tmp_path, [_operation(1, 1)])
     batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
@@ -841,6 +850,29 @@ def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):
     )
     with pytest.raises(BatchSyncError, match="does not match an exact planned batch"):
         validate_campaign_identities(manifest, [batch], backend, [], [forged_orphan])
+
+
+def test_pr_and_orphan_cannot_claim_the_same_derived_batch(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)])
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    branch = branch_name(manifest, batch)
+    pull_request = _pull_request(manifest, batch)
+    orphan = OrphanBranch(
+        head_ref=branch,
+        manifest_digest=manifest.digest,
+        manifest_run_id=manifest.run_id,
+        batch_id=batch.id,
+    )
+    backend = FakeBackend([pull_request], remote_branches={branch})
+
+    with pytest.raises(BatchSyncError, match="claimed by both"):
+        validate_campaign_identities(
+            manifest,
+            [batch],
+            backend,
+            [pull_request],
+            [orphan],
+        )
 
 
 def test_active_campaign_resumes_original_retained_manifest(tmp_path):

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -737,6 +737,8 @@ def test_real_git_backend_rejects_same_tree_force_push_after_identity_authentica
             [forged_pr],
             campaign_branches,
         )
+    with pytest.raises(BatchSyncError, match="campaign trailer"):
+        backend.publish_batch(manifest, batch, branch)
 
 
 def test_partial_failure_records_completed_failed_and_pending_batches(tmp_path):

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -395,6 +395,31 @@ def test_existing_open_pull_request_prevents_duplicate_publish_and_creation(tmp_
     assert state["batches"][0]["result"] == "existing-open-pull-request"
 
 
+def test_open_pull_request_with_missing_branch_is_reconstructed_before_completion(tmp_path):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)])
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    pull_request = _pull_request(manifest, batch)
+    backend = FakeBackend([pull_request])
+    checkpoint = tmp_path / "checkpoint.json"
+
+    succeeded = execute_batches(
+        manifest,
+        [batch],
+        backend,
+        [pull_request],
+        checkpoint,
+        max_files=1,
+        max_payload_bytes=10,
+    )
+
+    assert succeeded is True
+    assert backend.published == [1]
+    assert backend.reconstructed_branches == [1]
+    assert backend.created == []
+    state = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert state["batches"][0]["result"] == "existing-open-pull-request"
+
+
 def test_preserve_only_batch_completes_without_branch_or_pull_request(tmp_path):
     manifest = _write_manifest(tmp_path, [_operation(1, 0, decision="preserve")])
     batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -1639,6 +1639,49 @@ def test_completed_cleanup_tolerates_ref_deleted_before_push(tmp_path):
     assert backend.remote == {}
 
 
+def test_historical_cleanup_then_reconstruction_propagates_sha_and_reopens(tmp_path):
+    historical = [_synthetic_completed_pull_request(index) for index in range(300)]
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)], run_id=876)
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    closed = _pull_request(manifest, batch, number=999, state="CLOSED")
+    old_identity = OrphanBranch(
+        head_ref=closed.head_ref,
+        manifest_digest=manifest.digest,
+        manifest_run_id=manifest.run_id,
+        batch_id=batch.id,
+        pull_request_number=closed.number,
+        commit_sha="d" * 40,
+    )
+    backend = FakeBackend(
+        [*historical, closed],
+        downloaded_manifests={manifest.run_id: manifest.path},
+        pull_request_identities={closed.number: old_identity},
+    )
+
+    assert len(completed_branch_deletions([*historical, closed])) == 300
+    campaign = backend.discover_campaign_branches([*historical, closed])
+    selected = select_active_manifest(manifest, backend, campaign)
+    authenticated = validate_campaign_identities(
+        selected,
+        [batch],
+        backend,
+        [*historical, closed],
+        campaign,
+    )
+    assert authenticated[batch.id] != old_identity.commit_sha
+    assert execute_batches(
+        selected,
+        [batch],
+        backend,
+        [*historical, closed],
+        tmp_path / "combined-closure-checkpoint.json",
+        max_files=1,
+        max_payload_bytes=10,
+        authenticated_batch_commits=authenticated,
+    )
+    assert backend.reopened == [closed.number]
+
+
 def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):
     manifest = _write_manifest(tmp_path, [_operation(1, 1)])
     batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -961,6 +961,35 @@ def test_exited_parent_still_terminates_grandchild_holding_discovery_pipes(tmp_p
     assert time.monotonic() - started < 1.5
 
 
+def test_exited_parent_child_holding_both_streams_uses_one_deadline(tmp_path):
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+    child_code = (
+        "import sys, time; "
+        "print('stdout-held', flush=True); "
+        "print('stderr-held', file=sys.stderr, flush=True); "
+        "time.sleep(5)"
+    )
+    parent_code = (
+        "import subprocess, sys; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}])"
+    )
+
+    started = time.monotonic()
+    output = backend._run_bounded_stdout(
+        [sys.executable, "-c", parent_code],
+        max_bytes=4096,
+        timeout_seconds=1,
+    )
+
+    assert output.strip() == "stdout-held"
+    assert time.monotonic() - started < 1.5
+
+
 def test_overflow_terminates_grandchild_holding_discovery_pipes(tmp_path):
     backend = GitHubGitBackend(
         repository_root=tmp_path,

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -722,9 +722,14 @@ def test_real_git_backend_recovers_branch_with_add_and_path_replacements(tmp_pat
         runner_temp=runner_temp,
     )
 
-    backend.publish_batch(manifest, batch, branch)
+    reconstructed_sha = backend.publish_batch(manifest, batch, branch)
     orphans = backend.discover_campaign_branches([])
-    backend.publish_batch(manifest, batch, branch)
+    verified_sha = backend.publish_batch(
+        manifest,
+        batch,
+        branch,
+        expected_commit_sha=orphans[0].commit_sha,
+    )
 
     assert len(orphans) == 1
     assert orphans[0].head_ref == branch
@@ -732,6 +737,7 @@ def test_real_git_backend_recovers_branch_with_add_and_path_replacements(tmp_pat
     assert orphans[0].manifest_run_id == manifest.run_id
     assert orphans[0].batch_id == batch.id
     assert len(orphans[0].commit_sha) == 40
+    assert reconstructed_sha == orphans[0].commit_sha == verified_sha
     result = subprocess.run(
         ["git", "--git-dir", str(remote), "show", f"{branch}:docs-vnext/page.mdx"],
         check=True,

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -238,7 +238,13 @@ class FakeBackend:
                 f"Manifest artifact for workflow run {run_id} is unavailable"
             ) from exc
 
-    def publish_batch(self, manifest: Manifest, batch: Batch, branch: str) -> None:
+    def publish_batch(
+        self,
+        manifest: Manifest,
+        batch: Batch,
+        branch: str,
+        expected_commit_sha: str | None = None,
+    ) -> None:
         assert branch == branch_name(manifest, batch)
         if branch in self.remote_branches:
             self.verified_branches.append(batch.number)
@@ -612,14 +618,12 @@ def test_real_git_backend_recovers_branch_with_add_and_path_replacements(tmp_pat
     orphans = backend.discover_campaign_branches([])
     backend.publish_batch(manifest, batch, branch)
 
-    assert orphans == [
-        OrphanBranch(
-            head_ref=branch,
-            manifest_digest=manifest.digest,
-            manifest_run_id=manifest.run_id,
-            batch_id=batch.id,
-        )
-    ]
+    assert len(orphans) == 1
+    assert orphans[0].head_ref == branch
+    assert orphans[0].manifest_digest == manifest.digest
+    assert orphans[0].manifest_run_id == manifest.run_id
+    assert orphans[0].batch_id == batch.id
+    assert len(orphans[0].commit_sha) == 40
     result = subprocess.run(
         ["git", "--git-dir", str(remote), "show", f"{branch}:docs-vnext/page.mdx"],
         check=True,
@@ -652,7 +656,7 @@ def test_real_git_backend_recovers_branch_with_add_and_path_replacements(tmp_pat
     assert directory_replacement.stdout == "replacement-child"
 
 
-def test_real_git_backend_rejects_force_pushed_open_pr_branch(tmp_path):
+def test_real_git_backend_rejects_same_tree_force_push_after_identity_authentication(tmp_path):
     remote = tmp_path / "forged-remote.git"
     repository = tmp_path / "forged-repository"
     runner_temp = tmp_path / "forged-runner"
@@ -701,28 +705,21 @@ def test_real_git_backend_rejects_force_pushed_open_pr_branch(tmp_path):
         runner_temp=runner_temp,
     )
     backend.publish_batch(manifest, batch, branch)
-
-    _git(repository, "fetch", "origin", branch)
-    _git(repository, "switch", "--create", "forged", "FETCH_HEAD")
-    _write(repository / "docs-vnext", "page.mdx", "forged")
-    _git(repository, "add", "docs-vnext/page.mdx")
-    _git(
-        repository,
-        "commit",
-        "-m",
-        "forge deterministic branch",
-        "-m",
-        (
-            f"Manifest-SHA256: {manifest.digest}\n"
-            f"Manifest-Run-ID: {manifest.run_id}\n"
-            f"Batch-ID: {batch.id}"
-        ),
-    )
-    _git(repository, "push", "--force", "origin", f"HEAD:refs/heads/{branch}")
     forged_pr = _pull_request(manifest, batch)
     campaign_branches = backend.discover_campaign_branches([forged_pr])
 
-    with pytest.raises(BatchSyncError, match="does not match the reconstructed batch"):
+    _git(repository, "fetch", "origin", branch)
+    _git(repository, "switch", "--create", "forged", "FETCH_HEAD")
+    _git(
+        repository,
+        "commit",
+        "--allow-empty",
+        "-m",
+        "same tree with malformed identity",
+    )
+    _git(repository, "push", "--force", "origin", f"HEAD:refs/heads/{branch}")
+
+    with pytest.raises(BatchSyncError, match="moved from authenticated commit"):
         validate_campaign_identities(
             manifest,
             [batch],
@@ -1018,6 +1015,51 @@ def test_exited_parent_child_holding_both_streams_uses_one_deadline(tmp_path):
     assert time.monotonic() - started < 1.5
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows process-tree escalation")
+def test_windows_job_terminates_child_ignoring_ctrl_break(tmp_path):
+    import ctypes
+
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+    pid_file = tmp_path / "break-ignoring-child.pid"
+    child_code = (
+        "import os, pathlib, signal, time; "
+        "signal.signal(signal.SIGBREAK, signal.SIG_IGN); "
+        f"pathlib.Path({str(pid_file)!r}).write_text(str(os.getpid())); "
+        "time.sleep(10)"
+    )
+    parent_code = (
+        "import pathlib, subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {child_code!r}]); "
+        f"pid_file = pathlib.Path({str(pid_file)!r}); "
+        "deadline = time.monotonic() + 2; "
+        "exec(\"while not pid_file.exists() and time.monotonic() < deadline:\\n time.sleep(0.01)\"); "
+        "time.sleep(10)"
+    )
+
+    with pytest.raises(BatchSyncError, match="exceeded the 1-second discovery timeout"):
+        backend._run_bounded_stdout(
+            [sys.executable, "-c", parent_code],
+            max_bytes=4096,
+            timeout_seconds=1,
+        )
+
+    child_pid = int(pid_file.read_text(encoding="utf-8"))
+    process_handle = ctypes.windll.kernel32.OpenProcess(0x1000, False, child_pid)
+    if process_handle:
+        exit_code = ctypes.c_ulong()
+        ctypes.windll.kernel32.GetExitCodeProcess(
+            process_handle,
+            ctypes.byref(exit_code),
+        )
+        ctypes.windll.kernel32.CloseHandle(process_handle)
+        assert exit_code.value != 259
+
+
 def test_overflow_terminates_grandchild_holding_discovery_pipes(tmp_path):
     backend = GitHubGitBackend(
         repository_root=tmp_path,
@@ -1073,6 +1115,8 @@ def test_campaign_discovery_routes_ls_remote_fetch_and_show_through_bounded_runn
                 return f"{'a' * 40}\trefs/heads/{branch}\n"
             if args[1] == "fetch":
                 return ""
+            if args[1] == "rev-parse":
+                return f"{'a' * 40}\n"
             return (
                 "Sync batch\n\n"
                 f"Manifest-SHA256: {manifest.digest}\n"
@@ -1092,6 +1136,7 @@ def test_campaign_discovery_routes_ls_remote_fetch_and_show_through_bounded_runn
     assert [(call[0][1], call[1], call[2]) for call in backend.calls] == [
         ("ls-remote", 32 * 1024, 30),
         ("fetch", 4096, 30),
+        ("rev-parse", 4096, 30),
         ("show", 4096, 30),
     ]
 
@@ -1122,6 +1167,8 @@ def test_deleted_pr_head_with_missing_marker_recovers_via_bounded_pull_ref(tmp_p
             self.calls.append((tuple(args), max_bytes, timeout_seconds))
             if args[1] in {"ls-remote", "fetch"}:
                 return ""
+            if args[1] == "rev-parse":
+                return f"{'a' * 40}\n"
             return (
                 "Sync batch\n\n"
                 f"Manifest-SHA256: {manifest.digest}\n"

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -25,6 +25,7 @@ from apply_docs_vnext_sync_batches import (  # noqa: E402
     apply_batch,
     branch_name,
     build_pull_request_body,
+    enforce_campaign_candidate_limit,
     execute_batches,
     load_manifest,
     parse_commit_identity,
@@ -33,6 +34,7 @@ from apply_docs_vnext_sync_batches import (  # noqa: E402
     plan_batches,
     select_active_manifest,
     validate_campaign_identities,
+    validate_marker_claim,
 )
 from generate_docs_vnext_sync_manifest import build_manifest, serialize_manifest  # noqa: E402
 
@@ -175,6 +177,7 @@ class FakeBackend:
         downloaded_manifests: dict[int, Path] | None = None,
         fail_create_batch: int | None = None,
         remote_branches: set[str] | None = None,
+        pull_request_identities: dict[int, OrphanBranch] | None = None,
     ) -> None:
         self.pull_requests = list(pull_requests or [])
         self.downloaded_manifests = downloaded_manifests or {}
@@ -184,23 +187,49 @@ class FakeBackend:
         self.reopened: list[int] = []
         self.remote_branches = set(remote_branches or set())
         self.branch_identities: dict[str, OrphanBranch] = {}
+        self.pull_request_identities = dict(pull_request_identities or {})
+        for pull_request in self.pull_requests:
+            marker = pull_request.marker
+            if marker is not None and pull_request.number not in self.pull_request_identities:
+                self.pull_request_identities[pull_request.number] = OrphanBranch(
+                    head_ref=pull_request.head_ref,
+                    manifest_digest=marker["manifestSha256"],
+                    manifest_run_id=marker["manifestRunId"],
+                    batch_id=marker["batchId"],
+                    pull_request_number=pull_request.number,
+                )
         self.verified_branches: list[int] = []
         self.reconstructed_branches: list[int] = []
+        self.downloaded_run_ids: list[int] = []
 
     def list_pull_requests(self) -> list[PullRequest]:
         return list(self.pull_requests)
 
-    def list_orphan_branches(
+    def discover_campaign_branches(
         self, pull_requests: list[PullRequest]
     ) -> list[OrphanBranch]:
         pull_request_heads = {pull_request.head_ref for pull_request in pull_requests}
-        return [
+        identities = [
             identity
             for branch, identity in self.branch_identities.items()
             if branch in self.remote_branches and branch not in pull_request_heads
         ]
+        for pull_request in pull_requests:
+            if not pull_request.incomplete or not pull_request.head_ref.startswith(
+                "automation/docs-vnext-sync/"
+            ):
+                continue
+            identity = self.pull_request_identities.get(pull_request.number)
+            if identity is None:
+                raise BatchSyncError(
+                    f"Pull request #{pull_request.number} has no recoverable head identity"
+                )
+            validate_marker_claim(pull_request, identity)
+            identities.append(identity)
+        return identities
 
     def download_manifest(self, run_id: int) -> Path:
+        self.downloaded_run_ids.append(run_id)
         return self.downloaded_manifests[run_id]
 
     def publish_batch(self, manifest: Manifest, batch: Batch, branch: str) -> None:
@@ -574,7 +603,7 @@ def test_real_git_backend_recovers_branch_with_add_and_path_replacements(tmp_pat
     )
 
     backend.publish_batch(manifest, batch, branch)
-    orphans = backend.list_orphan_branches([])
+    orphans = backend.discover_campaign_branches([])
     backend.publish_batch(manifest, batch, branch)
 
     assert orphans == [
@@ -671,12 +700,30 @@ def test_real_git_backend_rejects_force_pushed_open_pr_branch(tmp_path):
     _git(repository, "switch", "--create", "forged", "FETCH_HEAD")
     _write(repository / "docs-vnext", "page.mdx", "forged")
     _git(repository, "add", "docs-vnext/page.mdx")
-    _git(repository, "commit", "-m", "forge deterministic branch")
+    _git(
+        repository,
+        "commit",
+        "-m",
+        "forge deterministic branch",
+        "-m",
+        (
+            f"Manifest-SHA256: {manifest.digest}\n"
+            f"Manifest-Run-ID: {manifest.run_id}\n"
+            f"Batch-ID: {batch.id}"
+        ),
+    )
     _git(repository, "push", "--force", "origin", f"HEAD:refs/heads/{branch}")
     forged_pr = _pull_request(manifest, batch)
+    campaign_branches = backend.discover_campaign_branches([forged_pr])
 
     with pytest.raises(BatchSyncError, match="does not match the reconstructed batch"):
-        validate_campaign_identities(manifest, [batch], backend, [forged_pr], [])
+        validate_campaign_identities(
+            manifest,
+            [batch],
+            backend,
+            [forged_pr],
+            campaign_branches,
+        )
 
 
 def test_partial_failure_records_completed_failed_and_pending_batches(tmp_path):
@@ -736,7 +783,7 @@ def test_new_manifest_recovers_orphan_branch_from_failed_pr_creation(tmp_path):
     )
 
     assert first_succeeded is False
-    orphans = backend.list_orphan_branches([])
+    orphans = backend.discover_campaign_branches([])
     assert [orphan.head_ref for orphan in orphans] == [
         branch_name(original, original_batches[0])
     ]
@@ -747,7 +794,7 @@ def test_new_manifest_recovers_orphan_branch_from_failed_pr_creation(tmp_path):
         run_id=300,
     )
 
-    selected = select_active_manifest(current, backend, [], orphans)
+    selected = select_active_manifest(current, backend, orphans)
 
     assert selected.digest == original.digest
     assert selected.run_id == 200
@@ -838,6 +885,35 @@ def test_backend_bounds_commit_message_output_before_parsing(tmp_path):
         )
 
 
+def test_backend_bounds_hanging_discovery_command(tmp_path):
+    backend = GitHubGitBackend(
+        repository_root=tmp_path,
+        repository="example/repository",
+        base_branch="main",
+        runner_temp=tmp_path / "runner",
+    )
+
+    with pytest.raises(BatchSyncError, match="exceeded the 1-second discovery timeout"):
+        backend._run_bounded_stdout(
+            [sys.executable, "-c", "import time; time.sleep(5)"],
+            max_bytes=4096,
+            timeout_seconds=1,
+        )
+
+
+@pytest.mark.parametrize("run_id", ["+1", "01", "1_0", "1 ", "0", "-1"])
+def test_commit_identity_rejects_noncanonical_run_ids(run_id):
+    message = (
+        "Subject\n\n"
+        f"Manifest-SHA256: {'a' * 64}\n"
+        f"Manifest-Run-ID: {run_id}\n"
+        f"Batch-ID: sha256:{'b' * 64}"
+    )
+
+    with pytest.raises(BatchSyncError, match="canonical positive decimal"):
+        parse_commit_identity(message, "automation/docs-vnext-sync/noncanonical")
+
+
 def test_remote_branch_discovery_rejects_excessive_branch_count():
     output = "\n".join(
         f"{'a' * 40}\trefs/heads/automation/docs-vnext-sync/campaign/batch-{index}"
@@ -857,15 +933,33 @@ def test_remote_branch_discovery_rejects_duplicate_refs():
         parse_remote_branch_refs(f"{line}\n{line}\n")
 
 
+def test_combined_remote_and_deleted_pr_candidates_are_capped_before_fetch():
+    remote_heads = {
+        f"automation/docs-vnext-sync/campaign/batch-{index:03d}"
+        for index in range(100)
+    }
+    deleted_pr_heads = {"automation/docs-vnext-sync/campaign/deleted-pr-head"}
+
+    with pytest.raises(BatchSyncError, match="101 active automation identity candidates"):
+        enforce_campaign_candidate_limit(remote_heads, deleted_pr_heads)
+
+
 def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):
     manifest = _write_manifest(tmp_path, [_operation(1, 1)])
     batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
     valid_pr = _pull_request(manifest, batch)
     forged_pr = replace(valid_pr, head_ref=f"{branch_name(manifest, batch)}-forged")
     backend = FakeBackend([forged_pr])
+    forged_pr_identity = backend.discover_campaign_branches([forged_pr])
 
     with pytest.raises(BatchSyncError, match="does not match deterministic branch"):
-        validate_campaign_identities(manifest, [batch], backend, [forged_pr], [])
+        validate_campaign_identities(
+            manifest,
+            [batch],
+            backend,
+            [forged_pr],
+            forged_pr_identity,
+        )
 
     forged_orphan = OrphanBranch(
         head_ref=branch_name(manifest, batch),
@@ -875,6 +969,89 @@ def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):
     )
     with pytest.raises(BatchSyncError, match="does not match an exact planned batch"):
         validate_campaign_identities(manifest, [batch], backend, [], [forged_orphan])
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        None,
+        "<!-- docs-vnext-sync-state\n{malformed-json}\n-->",
+    ],
+)
+def test_missing_or_malformed_pr_marker_recovers_from_verified_head(tmp_path, body):
+    manifest = _write_manifest(tmp_path, [_operation(1, 1)])
+    batch = plan_batches(manifest, max_files=1, max_payload_bytes=10)[0]
+    valid = _pull_request(manifest, batch)
+    pull_request = replace(valid, marker=parse_pull_request_marker(body))
+    identity = OrphanBranch(
+        head_ref=pull_request.head_ref,
+        manifest_digest=manifest.digest,
+        manifest_run_id=manifest.run_id,
+        batch_id=batch.id,
+        pull_request_number=pull_request.number,
+    )
+    backend = FakeBackend(
+        [pull_request],
+        remote_branches={pull_request.head_ref},
+        pull_request_identities={pull_request.number: identity},
+    )
+
+    campaign_branches = backend.discover_campaign_branches([pull_request])
+    selected = select_active_manifest(manifest, backend, campaign_branches)
+    preverified = validate_campaign_identities(
+        selected,
+        [batch],
+        backend,
+        [pull_request],
+        campaign_branches,
+    )
+    succeeded = execute_batches(
+        selected,
+        [batch],
+        backend,
+        [pull_request],
+        tmp_path / "recovered-checkpoint.json",
+        max_files=1,
+        max_payload_bytes=10,
+        preverified_batch_ids=preverified,
+    )
+
+    assert succeeded is True
+    assert backend.downloaded_run_ids == []
+
+
+def test_forged_marker_cannot_pin_manifest_before_head_authentication(tmp_path):
+    current = _write_manifest(
+        tmp_path,
+        [_operation(1, 1)],
+        name="current-authenticated.json",
+        run_id=300,
+    )
+    current_batch = plan_batches(current, max_files=1, max_payload_bytes=10)[0]
+    old = _write_manifest(
+        tmp_path,
+        [_operation(2, 1)],
+        name="forged-old.json",
+        run_id=200,
+    )
+    old_batch = plan_batches(old, max_files=1, max_payload_bytes=10)[0]
+    forged_marker_pr = _pull_request(old, old_batch)
+    authenticated_identity = OrphanBranch(
+        head_ref=forged_marker_pr.head_ref,
+        manifest_digest=current.digest,
+        manifest_run_id=current.run_id,
+        batch_id=current_batch.id,
+        pull_request_number=forged_marker_pr.number,
+    )
+    backend = FakeBackend(
+        [forged_marker_pr],
+        downloaded_manifests={200: old.path},
+        pull_request_identities={forged_marker_pr.number: authenticated_identity},
+    )
+
+    with pytest.raises(BatchSyncError, match="conflicts with its verified head commit"):
+        backend.discover_campaign_branches([forged_marker_pr])
+    assert backend.downloaded_run_ids == []
 
 
 def test_pr_and_orphan_cannot_claim_the_same_derived_batch(tmp_path):
@@ -889,6 +1066,7 @@ def test_pr_and_orphan_cannot_claim_the_same_derived_batch(tmp_path):
         batch_id=batch.id,
     )
     backend = FakeBackend([pull_request], remote_branches={branch})
+    pull_request_identity = backend.discover_campaign_branches([pull_request])
 
     with pytest.raises(BatchSyncError, match="claimed by both"):
         validate_campaign_identities(
@@ -896,7 +1074,7 @@ def test_pr_and_orphan_cannot_claim_the_same_derived_batch(tmp_path):
             [batch],
             backend,
             [pull_request],
-            [orphan],
+            [*pull_request_identity, orphan],
         )
 
 
@@ -917,7 +1095,11 @@ def test_active_campaign_resumes_original_retained_manifest(tmp_path):
     active = _pull_request(original, original_batch)
     backend = FakeBackend([active], downloaded_manifests={200: original.path})
 
-    selected = select_active_manifest(current, backend, [active])
+    selected = select_active_manifest(
+        current,
+        backend,
+        backend.discover_campaign_branches([active]),
+    )
 
     assert selected.digest == original.digest
     assert selected.run_id == 200

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -27,6 +27,7 @@ from apply_docs_vnext_sync_batches import (  # noqa: E402
     apply_batch,
     branch_name,
     build_pull_request_body,
+    completed_branch_deletions,
     enforce_campaign_candidate_limit,
     exclude_completed_remote_heads,
     execute_batches,
@@ -170,6 +171,30 @@ def _pull_request(
         url=f"https://github.com/example/repo/pull/{number}",
         head_ref=branch_name(manifest, batch),
         marker=parse_pull_request_marker(build_pull_request_body(manifest, batch)),
+    )
+
+
+def _synthetic_completed_pull_request(index: int, state: str = "MERGED") -> PullRequest:
+    manifest_digest = hashlib.sha256(f"manifest-{index}".encode()).hexdigest()
+    batch_digest = hashlib.sha256(f"batch-{index}".encode()).hexdigest()
+    head_ref = (
+        f"automation/docs-vnext-sync/{manifest_digest[:16]}/"
+        f"batch-001-{batch_digest[:12]}"
+    )
+    return PullRequest(
+        number=index + 1,
+        state=state,
+        url=f"https://github.com/example/repo/pull/{index + 1}",
+        head_ref=head_ref,
+        marker={
+            "schemaVersion": 1,
+            "manifestSha256": manifest_digest,
+            "manifestRunId": index + 1,
+            "batchId": f"sha256:{batch_digest}",
+            "batchNumber": 1,
+            "batchCount": 1,
+            "operationIds": [],
+        },
     )
 
 
@@ -1421,6 +1446,134 @@ def test_discovery_fetches_only_active_head_after_filtering_merged_history(tmp_p
     assert backend.fetches == [
         f"+refs/heads/{active_head}:refs/remotes/origin/{active_head}"
     ]
+
+
+def test_cleanup_removes_more_than_276_verified_completed_refs_before_discovery(
+    tmp_path,
+):
+    merged = [_synthetic_completed_pull_request(index) for index in range(300)]
+
+    class CleanupBackend(GitHubGitBackend):
+        def __init__(self):
+            super().__init__(
+                repository_root=tmp_path,
+                repository="example/repository",
+                base_branch="main",
+                runner_temp=tmp_path / "runner",
+            )
+            self.remote = {
+                pull_request.head_ref: f"{index + 1:040x}"
+                for index, pull_request in enumerate(merged)
+            }
+            self.deleted = []
+
+        def _run_bounded_stdout(
+            self,
+            args,
+            *,
+            max_bytes,
+            cwd=None,
+            timeout_seconds=30,
+        ):
+            if args[1] == "ls-remote":
+                requested = [
+                    item.removeprefix("refs/heads/")
+                    for item in args[4:]
+                ]
+                if requested == ["automation/docs-vnext-sync/*"]:
+                    requested = []
+                heads = self.remote if not requested else {
+                    head: self.remote[head]
+                    for head in requested
+                    if head in self.remote
+                }
+                return "".join(
+                    f"{commit}\trefs/heads/{head}\n"
+                    for head, commit in heads.items()
+                )
+            if args[1] == "push":
+                for head in args[4:]:
+                    self.remote.pop(head, None)
+                    self.deleted.append(head)
+                return ""
+            raise AssertionError(args)
+
+    backend = CleanupBackend()
+
+    identities = backend.discover_campaign_branches(merged)
+
+    assert identities == []
+    assert len(backend.deleted) == 300
+    assert backend.remote == {}
+
+
+def test_completed_cleanup_preserves_active_ref(tmp_path):
+    merged = [_synthetic_completed_pull_request(index) for index in range(10)]
+    active = _synthetic_completed_pull_request(500, state="OPEN")
+    remote = {
+        pull_request.head_ref: f"{index + 1:040x}"
+        for index, pull_request in enumerate([*merged, active])
+    }
+
+    assert active.head_ref not in completed_branch_deletions([*merged, active])
+    for head_ref in completed_branch_deletions([*merged, active]):
+        remote.pop(head_ref)
+
+    assert remote == {active.head_ref: f"{len(merged) + 1:040x}"}
+
+
+def test_completed_cleanup_tolerates_ref_deleted_before_push(tmp_path):
+    merged = [_synthetic_completed_pull_request(index) for index in range(2)]
+
+    class RacingCleanupBackend(GitHubGitBackend):
+        def __init__(self):
+            super().__init__(
+                repository_root=tmp_path,
+                repository="example/repository",
+                base_branch="main",
+                runner_temp=tmp_path / "runner",
+            )
+            self.remote = {merged[1].head_ref: "b" * 40}
+            self.attempted = []
+
+        def _run_bounded_stdout(
+            self,
+            args,
+            *,
+            max_bytes,
+            cwd=None,
+            timeout_seconds=30,
+        ):
+            if args[1] == "push":
+                head_ref = args[-1]
+                self.attempted.append(head_ref)
+                if head_ref not in self.remote:
+                    raise BatchSyncError("remote ref does not exist")
+                self.remote.pop(head_ref)
+                return ""
+            if args[1] == "ls-remote":
+                requested = args[-1].removeprefix("refs/heads/")
+                if requested == "automation/docs-vnext-sync/*":
+                    heads = self.remote
+                elif requested in self.remote:
+                    heads = {requested: self.remote[requested]}
+                else:
+                    heads = {}
+                return "".join(
+                    f"{commit}\trefs/heads/{head}\n"
+                    for head, commit in heads.items()
+                )
+            raise AssertionError(args)
+
+    backend = RacingCleanupBackend()
+
+    identities = backend.discover_campaign_branches(merged)
+
+    assert identities == []
+    assert backend.attempted == sorted(
+        [pull_request.head_ref for pull_request in merged]
+    )
+    assert backend.remote == {}
 
 
 def test_forged_pr_and_orphan_identities_cannot_bind_to_campaign(tmp_path):


### PR DESCRIPTION
## Summary

Corrective follow-up to merged #650 and #635. This PR contains deterministic sync durability and campaign-identity fixes only.

- supervised cross-platform discovery process trees and bounded cleanup
- authenticated retained manifests, exact commit SHAs, strict trailers, deterministic branches, and final reconstructed trees across validation and execution
- contiguous manifest-order replacement spans and resumable PR/orphan recovery
- bounded deletion of only verified completed automation branches before wildcard discovery, preventing historical merged refs from overflowing the 32 KiB discovery capture while preserving active heads
- reconstructed missing branches return their new remote commit SHA; validation propagates that SHA into execution-time refetch/revalidation before reopening, rather than retaining the stale pull-ref SHA

## Validation

- focused pytest — 79 passed, 1 POSIX-only test skipped on Windows
- targeted Ruff — passed
- production cleanup path handles 300 historical merged refs and concurrent already-deleted refs
- end-to-end missing closed-PR branch test reconstructs a new SHA, propagates it, verifies it again in execution, then reopens successfully
- independent final review — no findings

## Post-merge evidence

Trigger two genuinely new **Docs-vnext Baseline Sync Manifest** runs. The first creates/resumes bounded PRs and the second resumes or no-ops without duplicates. Do not rerun `30384546930`; reruns use its original workflow definition.

Related to #635.