### PR TITLE
Validate source navigation from trusted base

### DIFF
--- a/.github/workflows/docs-vnext-source-navigation-required.yml
+++ b/.github/workflows/docs-vnext-source-navigation-required.yml
@@ -27,6 +27,43 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
+      - name: Initialize failure inventory
+        run: |
+          mkdir -p tests/eval_results
+          cat > tests/eval_results/docs-vnext-route-inventory.json <<'JSON'
+          {
+            "schemaVersion": 1,
+            "status": "failed",
+            "navigationSource": "docs-vnext/docs.json",
+            "routes": [],
+            "openapi": [],
+            "aliases": [],
+            "externalNavigation": [],
+            "linkSummary": {
+              "currentStale": 0,
+              "baselineStale": 0,
+              "grandfathered": 0,
+              "introduced": 0
+            },
+            "diagnosticSummary": {
+              "total": 1,
+              "counts": {"workflow_incomplete": 1},
+              "truncated": false
+            },
+            "diagnostics": [
+              {
+                "sourceNavigationEntry": "navigation",
+                "route": null,
+                "failureClass": "workflow_incomplete",
+                "candidateSourcePath": "docs-vnext/docs.json",
+                "detail": "Trusted validation did not complete."
+              }
+            ]
+          }
+          JSON
+          cp tests/eval_results/docs-vnext-route-inventory.json \
+            "$RUNNER_TEMP/source-navigation-failure-inventory.json"
+
       - name: Fetch and classify proposed changes
         id: changes
         env:
@@ -83,60 +120,15 @@ jobs:
             esac
           done < "$changed_paths"
           echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          if [[ "$relevant" == "true" ]]; then
+            echo "irrelevant=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "irrelevant=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: No relevant source navigation changes
-        if: steps.changes.outputs.relevant != 'true'
+        if: steps.changes.outputs.irrelevant == 'true'
         run: echo "No docs-vnext source navigation changes require validation."
-
-      - name: Initialize failure inventory
-        if: steps.changes.outputs.relevant == 'true'
-        run: |
-          mkdir -p tests/eval_results
-          cat > tests/eval_results/docs-vnext-route-inventory.json <<'JSON'
-          {
-            "schemaVersion": 1,
-            "status": "failed",
-            "navigationSource": "docs-vnext/docs.json",
-            "routes": [],
-            "openapi": [],
-            "aliases": [],
-            "externalNavigation": [],
-            "linkSummary": {
-              "currentStale": 0,
-              "baselineStale": 0,
-              "grandfathered": 0,
-              "introduced": 0
-            },
-            "diagnosticSummary": {
-              "total": 1,
-              "counts": {"workflow_incomplete": 1},
-              "truncated": false
-            },
-            "diagnostics": [
-              {
-                "sourceNavigationEntry": "navigation",
-                "route": null,
-                "failureClass": "workflow_incomplete",
-                "candidateSourcePath": "docs-vnext/docs.json",
-                "detail": "Trusted validation did not complete."
-              }
-            ]
-          }
-          JSON
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        if: steps.changes.outputs.relevant == 'true'
-        with:
-          python-version: "3.12"
-          cache: "pip"
-
-      - name: Install trusted test dependencies
-        if: steps.changes.outputs.relevant == 'true'
-        run: pip install -e ".[dev]"
-
-      - name: Run trusted navigation validator tests
-        if: steps.changes.outputs.relevant == 'true'
-        run: python -m pytest tests/test_validate_docs_vnext_navigation.py -q
 
       - name: Extract proposed documentation as data
         if: steps.changes.outputs.relevant == 'true'
@@ -173,28 +165,40 @@ jobs:
       - name: Validate merged docs-vnext source navigation
         if: steps.changes.outputs.relevant == 'true'
         run: |
-          python scripts/validate_docs_vnext_navigation.py \
+          python3 -I scripts/validate_docs_vnext_navigation.py \
             --docs-dir "$RUNNER_TEMP/source-navigation-merged/docs-vnext" \
             --base-docs-dir "$RUNNER_TEMP/source-navigation-base/docs-vnext" \
             --output tests/eval_results/docs-vnext-route-inventory.json
 
       - name: Confirm current base branch
+        id: freshness
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          rewrite_failure_inventory() {
+            if ! cp "$RUNNER_TEMP/source-navigation-failure-inventory.json" \
+              tests/eval_results/docs-vnext-route-inventory.json; then
+              echo "::error::Unable to rewrite the route inventory as failed."
+              exit 1
+            fi
+            echo "failure=true" >> "$GITHUB_OUTPUT"
+          }
+
           if ! remote_base="$(git ls-remote --exit-code origin "refs/heads/$BASE_REF" | awk 'NR == 1 { print $1 }')"; then
+            rewrite_failure_inventory
             echo "::error::Unable to resolve the current pull request base branch."
             exit 1
           fi
           if [[ "$remote_base" != "$BASE_SHA" ]]; then
+            rewrite_failure_inventory
             echo "::error::The pull request base advanced during validation."
             echo "::error::The repository ruleset must require branches to be up to date before merging."
             exit 1
           fi
 
       - name: Upload trusted route inventory
-        if: always() && steps.changes.outputs.relevant == 'true'
+        if: always() && (steps.changes.outputs.irrelevant != 'true' || steps.freshness.outputs.failure == 'true')
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: docs-vnext-required-route-inventory

--- a/.github/workflows/docs-vnext-source-navigation-required.yml
+++ b/.github/workflows/docs-vnext-source-navigation-required.yml
@@ -2,10 +2,9 @@ name: docs-vnext source navigation required check
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions:
-  actions: read
   contents: read
 
 concurrency:
@@ -18,38 +17,141 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
-      - name: Require successful pull request validation
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+
+      - name: Fetch and classify proposed changes
+        id: changes
         env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          WORKFLOW_FILE: docs-vnext-source-navigation.yml
         run: |
-          for attempt in {1..132}; do
-            if ! run="$(
-              gh api \
-                "/repos/$REPOSITORY/actions/workflows/$WORKFLOW_FILE/runs?event=pull_request&head_sha=$HEAD_SHA&per_page=100" \
-                --jq ".workflow_runs | map(select(any(.pull_requests[]?; .number == $PR_NUMBER))) | .[0] // empty | [.id, .status, (.conclusion // \"\")] | @tsv"
-            )"; then
-              echo "::error::Unable to query source navigation workflow runs."
-              exit 1
-            fi
+          if [[ "$(git rev-parse HEAD)" != "$BASE_SHA" ]]; then
+            echo "::error::Trusted checkout does not match the current pull request base."
+            exit 1
+          fi
+          if ! git fetch --no-tags origin "refs/pull/$PR_NUMBER/head"; then
+            echo "::error::Unable to fetch the current pull request head object."
+            exit 1
+          fi
+          if [[ "$(git rev-parse FETCH_HEAD)" != "$HEAD_SHA" ]]; then
+            echo "::error::Fetched pull request head does not match the current event."
+            exit 1
+          fi
+          if ! merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "::error::Unable to determine the current pull request merge base."
+            exit 1
+          fi
 
-            if [[ -n "$run" ]]; then
-              IFS=$'\t' read -r run_id status conclusion <<< "$run"
-              if [[ "$status" == "completed" ]]; then
-                if [[ "$conclusion" == "success" ]]; then
-                  echo "Source navigation validation run $run_id succeeded."
-                  exit 0
-                fi
-                echo "::error::Source navigation validation run $run_id concluded with: $conclusion"
-                exit 1
-              fi
-            fi
-            sleep 5
-          done
+          changed_paths="$RUNNER_TEMP/source-navigation-required-changed-paths"
+          if ! git diff --no-renames --name-only -z "$merge_base" "$HEAD_SHA" -- > "$changed_paths"; then
+            echo "::error::Unable to enumerate current pull request paths."
+            exit 1
+          fi
 
-          echo "::error::No completed source navigation validation run was found for $HEAD_SHA."
-          echo "::error::Remove any [skip ci] directive or resolve merge conflicts, then push a new commit."
-          exit 1
+          relevant=false
+          while IFS= read -r -d '' path; do
+            case "$path" in
+              docs-vnext/*|scripts/validate_docs_vnext_navigation.py|tests/test_validate_docs_vnext_navigation.py|.github/workflows/docs-vnext-source-navigation.yml|.github/workflows/docs-vnext-source-navigation-required.yml)
+                relevant=true
+                break
+                ;;
+            esac
+          done < "$changed_paths"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
+      - name: No relevant source navigation changes
+        if: steps.changes.outputs.relevant != 'true'
+        run: echo "No docs-vnext source navigation changes require validation."
+
+      - name: Initialize failure inventory
+        if: steps.changes.outputs.relevant == 'true'
+        run: |
+          mkdir -p tests/eval_results
+          cat > tests/eval_results/docs-vnext-route-inventory.json <<'JSON'
+          {
+            "schemaVersion": 1,
+            "status": "failed",
+            "navigationSource": "docs-vnext/docs.json",
+            "routes": [],
+            "openapi": [],
+            "aliases": [],
+            "externalNavigation": [],
+            "linkSummary": {
+              "currentStale": 0,
+              "baselineStale": 0,
+              "grandfathered": 0,
+              "introduced": 0
+            },
+            "diagnosticSummary": {
+              "total": 1,
+              "counts": {"workflow_incomplete": 1},
+              "truncated": false
+            },
+            "diagnostics": [
+              {
+                "sourceNavigationEntry": "navigation",
+                "route": null,
+                "failureClass": "workflow_incomplete",
+                "candidateSourcePath": "docs-vnext/docs.json",
+                "detail": "Trusted validation did not complete."
+              }
+            ]
+          }
+          JSON
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        if: steps.changes.outputs.relevant == 'true'
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install trusted test dependencies
+        if: steps.changes.outputs.relevant == 'true'
+        run: pip install -e ".[dev]"
+
+      - name: Run trusted navigation validator tests
+        if: steps.changes.outputs.relevant == 'true'
+        run: python -m pytest tests/test_validate_docs_vnext_navigation.py -q
+
+      - name: Extract proposed documentation as data
+        if: steps.changes.outputs.relevant == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          base_dir="$RUNNER_TEMP/source-navigation-base"
+          head_dir="$RUNNER_TEMP/source-navigation-head"
+          mkdir -p "$base_dir" "$head_dir"
+          if ! git archive "$BASE_SHA" docs-vnext | tar -x -C "$base_dir"; then
+            echo "::error::Unable to extract the current base documentation tree."
+            exit 1
+          fi
+          if ! git archive "$HEAD_SHA" docs-vnext | tar -x -C "$head_dir"; then
+            echo "::error::Unable to extract the proposed documentation tree."
+            exit 1
+          fi
+          if find "$head_dir/docs-vnext" -type l -print -quit | grep -q .; then
+            echo "::error::Proposed docs-vnext tree contains symbolic links."
+            exit 1
+          fi
+
+      - name: Validate proposed docs-vnext source navigation
+        if: steps.changes.outputs.relevant == 'true'
+        run: |
+          python scripts/validate_docs_vnext_navigation.py \
+            --docs-dir "$RUNNER_TEMP/source-navigation-head/docs-vnext" \
+            --base-docs-dir "$RUNNER_TEMP/source-navigation-base/docs-vnext" \
+            --output tests/eval_results/docs-vnext-route-inventory.json
+
+      - name: Upload trusted route inventory
+        if: always() && steps.changes.outputs.relevant == 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: docs-vnext-required-route-inventory
+          path: tests/eval_results/docs-vnext-route-inventory.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/docs-vnext-source-navigation-required.yml
+++ b/.github/workflows/docs-vnext-source-navigation-required.yml
@@ -1,5 +1,10 @@
 name: docs-vnext source navigation required check
 
+# REQUIRED RULESET PREREQUISITE:
+# Require "Validate source navigation" and require branches to be up to date
+# before merging. Legitimate trusted-gate migrations require a dedicated
+# repository-admin ruleset bypass and independent review.
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, edited]
@@ -52,12 +57,28 @@ jobs:
             exit 1
           fi
 
+          if ! merge_result="$(git merge-tree --write-tree "$BASE_SHA" "$HEAD_SHA" 2>&1)"; then
+            echo "::error::The current pull request does not produce a clean synthetic merge."
+            printf '%s\n' "$merge_result"
+            exit 1
+          fi
+          merge_tree="${merge_result%%$'\n'*}"
+          if [[ ! "$merge_tree" =~ ^[0-9a-f]{40,64}$ ]] || ! git cat-file -e "$merge_tree^{tree}"; then
+            echo "::error::Unable to verify the synthetic merge tree."
+            exit 1
+          fi
+          echo "merge_tree=$merge_tree" >> "$GITHUB_OUTPUT"
+
           relevant=false
           while IFS= read -r -d '' path; do
             case "$path" in
-              docs-vnext/*|scripts/validate_docs_vnext_navigation.py|tests/test_validate_docs_vnext_navigation.py|.github/workflows/docs-vnext-source-navigation.yml|.github/workflows/docs-vnext-source-navigation-required.yml)
+              .github/workflows/docs-vnext-source-navigation-required.yml|scripts/validate_docs_vnext_navigation.py)
+                echo "::error::Trusted source navigation enforcement cannot be changed in a normal pull request."
+                echo "::error::Use a dedicated gate-migration pull request with independent review and repository-admin ruleset bypass."
+                exit 1
+                ;;
+              docs-vnext/*|tests/test_validate_docs_vnext_navigation.py|.github/workflows/docs-vnext-source-navigation.yml)
                 relevant=true
-                break
                 ;;
             esac
           done < "$changed_paths"
@@ -121,31 +142,56 @@ jobs:
         if: steps.changes.outputs.relevant == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_TREE: ${{ steps.changes.outputs.merge_tree }}
         run: |
           base_dir="$RUNNER_TEMP/source-navigation-base"
-          head_dir="$RUNNER_TEMP/source-navigation-head"
-          mkdir -p "$base_dir" "$head_dir"
-          if ! git archive "$BASE_SHA" docs-vnext | tar -x -C "$base_dir"; then
+          merged_dir="$RUNNER_TEMP/source-navigation-merged"
+          base_archive="$RUNNER_TEMP/source-navigation-base.tar"
+          merged_archive="$RUNNER_TEMP/source-navigation-merged.tar"
+          mkdir -p "$base_dir" "$merged_dir"
+          if ! git archive -o "$base_archive" "$BASE_SHA" docs-vnext; then
             echo "::error::Unable to extract the current base documentation tree."
             exit 1
           fi
-          if ! git archive "$HEAD_SHA" docs-vnext | tar -x -C "$head_dir"; then
-            echo "::error::Unable to extract the proposed documentation tree."
+          if ! tar -xf "$base_archive" -C "$base_dir"; then
+            echo "::error::Unable to unpack the current base documentation tree."
             exit 1
           fi
-          if find "$head_dir/docs-vnext" -type l -print -quit | grep -q .; then
-            echo "::error::Proposed docs-vnext tree contains symbolic links."
+          if ! git archive -o "$merged_archive" "$MERGE_TREE" docs-vnext; then
+            echo "::error::Unable to extract the synthetic merge documentation tree."
+            exit 1
+          fi
+          if ! tar -xf "$merged_archive" -C "$merged_dir"; then
+            echo "::error::Unable to unpack the synthetic merge documentation tree."
+            exit 1
+          fi
+          if find "$merged_dir/docs-vnext" -type l -print -quit | grep -q .; then
+            echo "::error::Synthetic merge docs-vnext tree contains symbolic links."
             exit 1
           fi
 
-      - name: Validate proposed docs-vnext source navigation
+      - name: Validate merged docs-vnext source navigation
         if: steps.changes.outputs.relevant == 'true'
         run: |
           python scripts/validate_docs_vnext_navigation.py \
-            --docs-dir "$RUNNER_TEMP/source-navigation-head/docs-vnext" \
+            --docs-dir "$RUNNER_TEMP/source-navigation-merged/docs-vnext" \
             --base-docs-dir "$RUNNER_TEMP/source-navigation-base/docs-vnext" \
             --output tests/eval_results/docs-vnext-route-inventory.json
+
+      - name: Confirm current base branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if ! remote_base="$(git ls-remote --exit-code origin "refs/heads/$BASE_REF" | awk 'NR == 1 { print $1 }')"; then
+            echo "::error::Unable to resolve the current pull request base branch."
+            exit 1
+          fi
+          if [[ "$remote_base" != "$BASE_SHA" ]]; then
+            echo "::error::The pull request base advanced during validation."
+            echo "::error::The repository ruleset must require branches to be up to date before merging."
+            exit 1
+          fi
 
       - name: Upload trusted route inventory
         if: always() && steps.changes.outputs.relevant == 'true'

--- a/tests/test_validate_docs_vnext_navigation.py
+++ b/tests/test_validate_docs_vnext_navigation.py
@@ -379,7 +379,7 @@ def test_workflow_fails_closed_when_path_diff_generation_fails() -> None:
     assert detector["run"].count("exit 1") >= 2
 
 
-def test_required_context_is_trusted_read_only_and_skip_ci_resistant() -> None:
+def test_required_context_uses_current_trusted_base_and_head_objects() -> None:
     workflow = yaml.load(REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
     sentinel = workflow["jobs"]["require-source-navigation"]
 
@@ -388,15 +388,60 @@ def test_required_context_is_trusted_read_only_and_skip_ci_resistant() -> None:
         "synchronize",
         "reopened",
         "ready_for_review",
+        "edited",
     ]
-    assert workflow["permissions"] == {"actions": "read", "contents": "read"}
+    assert workflow["permissions"] == {"contents": "read"}
     assert sentinel["name"] == "Validate source navigation"
-    assert all("uses" not in step for step in sentinel["steps"])
-    script = sentinel["steps"][0]["run"]
-    assert "event=pull_request" in script
-    assert "head_sha=$HEAD_SHA" in script
-    assert ".pull_requests[]?" in script
-    assert ".number == $PR_NUMBER" in script
-    assert "No completed source navigation validation run was found" in script
-    assert "Remove any [skip ci] directive or resolve merge conflicts" in script
-    assert script.count("exit 1") >= 3
+    checkout = sentinel["steps"][0]
+    assert checkout["with"]["ref"] == "${{ github.event.pull_request.base.sha }}"
+    assert checkout["with"]["fetch-depth"] == "0"
+
+    by_name = {step["name"]: step for step in sentinel["steps"] if "name" in step}
+    classifier = by_name["Fetch and classify proposed changes"]["run"]
+    assert '$(git rev-parse HEAD)" != "$BASE_SHA"' in classifier
+    assert 'git fetch --no-tags origin "refs/pull/$PR_NUMBER/head"' in classifier
+    assert '$(git rev-parse FETCH_HEAD)" != "$HEAD_SHA"' in classifier
+    assert 'git merge-base "$BASE_SHA" "$HEAD_SHA"' in classifier
+    assert 'git diff --no-renames --name-only -z "$merge_base" "$HEAD_SHA"' in classifier
+    assert '> "$changed_paths"' in classifier
+    assert 'done < "$changed_paths"' in classifier
+    assert classifier.count("exit 1") >= 4
+
+
+def test_required_context_never_checks_out_or_executes_untrusted_pr_code() -> None:
+    workflow = yaml.load(REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["require-source-navigation"]["steps"]
+    by_name = {step["name"]: step for step in steps if "name" in step}
+
+    checkout_steps = [step for step in steps if str(step.get("uses", "")).startswith("actions/checkout@")]
+    assert len(checkout_steps) == 1
+    assert checkout_steps[0]["with"]["ref"] == "${{ github.event.pull_request.base.sha }}"
+    assert "GH_TOKEN" not in str(workflow)
+    assert "github.event.pull_request.head.repo" not in str(workflow)
+
+    extraction = by_name["Extract proposed documentation as data"]["run"]
+    assert 'git archive "$BASE_SHA" docs-vnext' in extraction
+    assert 'git archive "$HEAD_SHA" docs-vnext' in extraction
+    assert 'find "$head_dir/docs-vnext" -type l' in extraction
+    validation = by_name["Validate proposed docs-vnext source navigation"]["run"]
+    assert "python scripts/validate_docs_vnext_navigation.py" in validation
+    assert '--docs-dir "$RUNNER_TEMP/source-navigation-head/docs-vnext"' in validation
+    assert '--base-docs-dir "$RUNNER_TEMP/source-navigation-base/docs-vnext"' in validation
+    assert "source-navigation-head/scripts" not in str(workflow)
+
+
+def test_required_context_noops_irrelevant_and_runs_trusted_gate_for_relevant_changes() -> None:
+    workflow = yaml.load(REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["require-source-navigation"]["steps"]
+    by_name = {step["name"]: step for step in steps if "name" in step}
+
+    assert by_name["No relevant source navigation changes"]["if"] == "steps.changes.outputs.relevant != 'true'"
+    for step_name in (
+        "Initialize failure inventory",
+        "Install trusted test dependencies",
+        "Run trusted navigation validator tests",
+        "Extract proposed documentation as data",
+        "Validate proposed docs-vnext source navigation",
+    ):
+        assert by_name[step_name]["if"] == "steps.changes.outputs.relevant == 'true'"
+    assert by_name["Upload trusted route inventory"]["if"] == "always() && steps.changes.outputs.relevant == 'true'"

--- a/tests/test_validate_docs_vnext_navigation.py
+++ b/tests/test_validate_docs_vnext_navigation.py
@@ -448,6 +448,9 @@ def test_required_context_never_checks_out_or_executes_untrusted_pr_code() -> No
     assert checkout_steps[0]["with"]["ref"] == "${{ github.event.pull_request.base.sha }}"
     assert "GH_TOKEN" not in str(workflow)
     assert "github.event.pull_request.head.repo" not in str(workflow)
+    assert "pip install" not in str(workflow)
+    assert "pytest" not in str(workflow)
+    assert "actions/setup-python" not in str(workflow)
 
     extraction = by_name["Extract proposed documentation as data"]["run"]
     assert 'git archive -o "$base_archive" "$BASE_SHA" docs-vnext' in extraction
@@ -457,10 +460,18 @@ def test_required_context_never_checks_out_or_executes_untrusted_pr_code() -> No
     assert 'tar -xf "$merged_archive" -C "$merged_dir"' in extraction
     assert 'find "$merged_dir/docs-vnext" -type l' in extraction
     validation = by_name["Validate merged docs-vnext source navigation"]["run"]
-    assert "python scripts/validate_docs_vnext_navigation.py" in validation
+    assert "python3 -I scripts/validate_docs_vnext_navigation.py" in validation
     assert '--docs-dir "$RUNNER_TEMP/source-navigation-merged/docs-vnext"' in validation
     assert '--base-docs-dir "$RUNNER_TEMP/source-navigation-base/docs-vnext"' in validation
     assert "source-navigation-head/scripts" not in str(workflow)
+    python_commands = [
+        line.strip()
+        for step in steps
+        for line in str(step.get("run", "")).splitlines()
+        if "python" in line
+    ]
+    assert python_commands
+    assert all("python3 -I scripts/validate_docs_vnext_navigation.py" in command for command in python_commands)
 
 
 def test_required_context_noops_irrelevant_and_runs_trusted_gate_for_relevant_changes() -> None:
@@ -468,16 +479,60 @@ def test_required_context_noops_irrelevant_and_runs_trusted_gate_for_relevant_ch
     steps = workflow["jobs"]["require-source-navigation"]["steps"]
     by_name = {step["name"]: step for step in steps if "name" in step}
 
-    assert by_name["No relevant source navigation changes"]["if"] == "steps.changes.outputs.relevant != 'true'"
+    assert "if [[ \"$relevant\" == \"true\" ]]" in by_name["Fetch and classify proposed changes"]["run"]
+    assert 'echo "irrelevant=true" >> "$GITHUB_OUTPUT"' in by_name["Fetch and classify proposed changes"]["run"]
+    assert by_name["No relevant source navigation changes"]["if"] == "steps.changes.outputs.irrelevant == 'true'"
     for step_name in (
-        "Initialize failure inventory",
-        "Install trusted test dependencies",
-        "Run trusted navigation validator tests",
         "Extract proposed documentation as data",
         "Validate merged docs-vnext source navigation",
     ):
         assert by_name[step_name]["if"] == "steps.changes.outputs.relevant == 'true'"
-    assert by_name["Upload trusted route inventory"]["if"] == "always() && steps.changes.outputs.relevant == 'true'"
+    assert "Install trusted test dependencies" not in by_name
+    assert "Run trusted navigation validator tests" not in by_name
+    assert by_name["Upload trusted route inventory"]["if"] == (
+        "always() && (steps.changes.outputs.irrelevant != 'true' || steps.freshness.outputs.failure == 'true')"
+    )
+
+
+def test_required_context_initializes_failure_before_classification_and_uploads_failures() -> None:
+    workflow = yaml.load(REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["require-source-navigation"]["steps"]
+    names = [step.get("name") for step in steps]
+    by_name = {step["name"]: step for step in steps if "name" in step}
+
+    assert names.index("Initialize failure inventory") < names.index("Fetch and classify proposed changes")
+    assert "if" not in by_name["Initialize failure inventory"]
+    assert "$RUNNER_TEMP/source-navigation-failure-inventory.json" in by_name["Initialize failure inventory"]["run"]
+    assert by_name["Upload trusted route inventory"]["if"].startswith(
+        "always() && (steps.changes.outputs.irrelevant != 'true'"
+    )
+    classifier = by_name["Fetch and classify proposed changes"]["run"]
+    assert classifier.count("exit 1") >= 7
+
+
+def test_required_context_skips_successful_irrelevant_artifact() -> None:
+    workflow = yaml.load(REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["require-source-navigation"]["steps"]
+    by_name = {step["name"]: step for step in steps if "name" in step}
+
+    assert by_name["No relevant source navigation changes"]["if"] == "steps.changes.outputs.irrelevant == 'true'"
+    assert 'echo "irrelevant=true" >> "$GITHUB_OUTPUT"' in by_name["Fetch and classify proposed changes"]["run"]
+    assert "steps.changes.outputs.irrelevant != 'true'" in by_name["Upload trusted route inventory"]["if"]
+
+
+def test_stale_base_failure_rewrites_passed_inventory_before_upload() -> None:
+    workflow = yaml.load(REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["require-source-navigation"]["steps"]
+    by_name = {step["name"]: step for step in steps if "name" in step}
+    freshness = by_name["Confirm current base branch"]
+
+    assert freshness["id"] == "freshness"
+    script = freshness["run"]
+    assert 'cp "$RUNNER_TEMP/source-navigation-failure-inventory.json"' in script
+    assert "tests/eval_results/docs-vnext-route-inventory.json" in script
+    assert 'echo "failure=true" >> "$GITHUB_OUTPUT"' in script
+    assert script.index("rewrite_failure_inventory") < script.index("exit 1")
+    assert "steps.freshness.outputs.failure == 'true'" in by_name["Upload trusted route inventory"]["if"]
 
 
 def test_synthetic_merge_catches_failure_that_raw_behind_head_misses(tmp_path: Path) -> None:

--- a/tests/test_validate_docs_vnext_navigation.py
+++ b/tests/test_validate_docs_vnext_navigation.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import io
 import json
 import os
+import subprocess
 import sys
+import tarfile
 from pathlib import Path
 
 import pytest
@@ -33,6 +36,30 @@ def _write_navigation(docs_dir: Path, pages: list[object], **extra: object) -> P
     path = docs_dir / "docs.json"
     path.write_text(json.dumps(config), encoding="utf-8")
     return path
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _extract_git_tree(repo: Path, ref: str, destination: Path) -> Path:
+    archive = subprocess.run(
+        ["git", "-C", str(repo), "archive", ref, "docs-vnext"],
+        check=True,
+        capture_output=True,
+    ).stdout
+    destination.mkdir(parents=True)
+    with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+        if sys.version_info >= (3, 12):
+            tar.extractall(destination, filter="data")
+        else:
+            tar.extractall(destination)
+    return destination / "docs-vnext"
 
 
 def test_valid_routes_produce_ordered_publishable_inventory(tmp_path: Path) -> None:
@@ -404,8 +431,11 @@ def test_required_context_uses_current_trusted_base_and_head_objects() -> None:
     assert 'git merge-base "$BASE_SHA" "$HEAD_SHA"' in classifier
     assert 'git diff --no-renames --name-only -z "$merge_base" "$HEAD_SHA"' in classifier
     assert '> "$changed_paths"' in classifier
+    assert 'git merge-tree --write-tree "$BASE_SHA" "$HEAD_SHA"' in classifier
+    assert 'git cat-file -e "$merge_tree^{tree}"' in classifier
+    assert 'echo "merge_tree=$merge_tree" >> "$GITHUB_OUTPUT"' in classifier
     assert 'done < "$changed_paths"' in classifier
-    assert classifier.count("exit 1") >= 4
+    assert classifier.count("exit 1") >= 7
 
 
 def test_required_context_never_checks_out_or_executes_untrusted_pr_code() -> None:
@@ -420,12 +450,15 @@ def test_required_context_never_checks_out_or_executes_untrusted_pr_code() -> No
     assert "github.event.pull_request.head.repo" not in str(workflow)
 
     extraction = by_name["Extract proposed documentation as data"]["run"]
-    assert 'git archive "$BASE_SHA" docs-vnext' in extraction
-    assert 'git archive "$HEAD_SHA" docs-vnext' in extraction
-    assert 'find "$head_dir/docs-vnext" -type l' in extraction
-    validation = by_name["Validate proposed docs-vnext source navigation"]["run"]
+    assert 'git archive -o "$base_archive" "$BASE_SHA" docs-vnext' in extraction
+    assert 'git archive -o "$merged_archive" "$MERGE_TREE" docs-vnext' in extraction
+    assert 'git archive "$HEAD_SHA" docs-vnext' not in extraction
+    assert 'tar -xf "$base_archive" -C "$base_dir"' in extraction
+    assert 'tar -xf "$merged_archive" -C "$merged_dir"' in extraction
+    assert 'find "$merged_dir/docs-vnext" -type l' in extraction
+    validation = by_name["Validate merged docs-vnext source navigation"]["run"]
     assert "python scripts/validate_docs_vnext_navigation.py" in validation
-    assert '--docs-dir "$RUNNER_TEMP/source-navigation-head/docs-vnext"' in validation
+    assert '--docs-dir "$RUNNER_TEMP/source-navigation-merged/docs-vnext"' in validation
     assert '--base-docs-dir "$RUNNER_TEMP/source-navigation-base/docs-vnext"' in validation
     assert "source-navigation-head/scripts" not in str(workflow)
 
@@ -441,7 +474,105 @@ def test_required_context_noops_irrelevant_and_runs_trusted_gate_for_relevant_ch
         "Install trusted test dependencies",
         "Run trusted navigation validator tests",
         "Extract proposed documentation as data",
-        "Validate proposed docs-vnext source navigation",
+        "Validate merged docs-vnext source navigation",
     ):
         assert by_name[step_name]["if"] == "steps.changes.outputs.relevant == 'true'"
     assert by_name["Upload trusted route inventory"]["if"] == "always() && steps.changes.outputs.relevant == 'true'"
+
+
+def test_synthetic_merge_catches_failure_that_raw_behind_head_misses(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    docs_dir = repo / "docs-vnext"
+    _write_navigation(docs_dir, ["guide/start", "guide/target"])
+    _write_page(docs_dir, "guide/start")
+    _write_page(docs_dir, "guide/target")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "common")
+    common_sha = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "switch", "-c", "feature")
+    _write_page(docs_dir, "guide/start", "Read the [target](/guide/target).\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "feature links target")
+    head_sha = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "switch", "main")
+    _write_navigation(docs_dir, ["guide/start"])
+    (docs_dir / "guide" / "target.mdx").unlink()
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "base removes target")
+    base_sha = _git(repo, "rev-parse", "HEAD")
+
+    merge_tree = _git(repo, "merge-tree", "--write-tree", base_sha, head_sha).splitlines()[0]
+    raw_docs = _extract_git_tree(repo, head_sha, tmp_path / "raw")
+    common_docs = _extract_git_tree(repo, common_sha, tmp_path / "common")
+    merged_docs = _extract_git_tree(repo, merge_tree, tmp_path / "merged")
+    base_docs = _extract_git_tree(repo, base_sha, tmp_path / "base")
+
+    assert validate_navigation(raw_docs, raw_docs / "docs.json", base_docs_dir=common_docs)["status"] == "passed"
+    merged = validate_navigation(merged_docs, merged_docs / "docs.json", base_docs_dir=base_docs)
+    assert merged["status"] == "failed"
+    assert merged["diagnosticSummary"]["counts"] == {"stale_internal_link": 1}
+
+
+@pytest.mark.parametrize("operation", ["modify", "delete"])
+def test_trusted_surface_changes_are_rejected_even_when_renames_are_disabled(
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    repo = tmp_path / operation
+    trusted_path = repo / ".github" / "workflows" / "docs-vnext-source-navigation-required.yml"
+    trusted_path.parent.mkdir(parents=True)
+    trusted_path.write_text("trusted\n", encoding="utf-8")
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "trusted base")
+    base_sha = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "switch", "-c", "feature")
+    if operation == "modify":
+        trusted_path.write_text("untrusted change\n", encoding="utf-8")
+    else:
+        trusted_path.unlink()
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", operation)
+    head_sha = _git(repo, "rev-parse", "HEAD")
+
+    changed = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--no-renames", "--name-only", "-z", base_sha, head_sha],
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    assert b".github/workflows/docs-vnext-source-navigation-required.yml" in changed
+
+    workflow = yaml.load(REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    classifier = next(
+        step["run"]
+        for step in workflow["jobs"]["require-source-navigation"]["steps"]
+        if step.get("name") == "Fetch and classify proposed changes"
+    )
+    assert ".github/workflows/docs-vnext-source-navigation-required.yml" in classifier
+    assert "Trusted source navigation enforcement cannot be changed" in classifier
+    assert "repository-admin ruleset bypass" in classifier
+
+
+def test_required_context_encodes_strict_up_to_date_ruleset_prerequisite() -> None:
+    workflow_text = REQUIRED_WORKFLOW_PATH.read_text(encoding="utf-8")
+    workflow = yaml.load(workflow_text, Loader=yaml.BaseLoader)
+    by_name = {
+        step["name"]: step
+        for step in workflow["jobs"]["require-source-navigation"]["steps"]
+        if "name" in step
+    }
+
+    assert "REQUIRED RULESET PREREQUISITE" in workflow_text
+    assert "require branches to be up to date" in workflow_text
+    final_check = by_name["Confirm current base branch"]["run"]
+    assert 'git ls-remote --exit-code origin "refs/heads/$BASE_REF"' in final_check
+    assert '"$remote_base" != "$BASE_SHA"' in final_check
+    assert "must require branches to be up to date before merging" in final_check


### PR DESCRIPTION
## Summary

Final #629 security correction after independent review:

- authoritative `pull_request_target` validation checks out only the exact trusted current base SHA and never delegates success to the PR-controlled workflow
- fetch current PR head as Git objects, verify current base/head identities, construct a checked conflict-free synthetic merge tree, and validate only archived merged docs data
- fail closed on fetch/correlation/diff/merge/archive/symlink/validation/base-freshness errors
- reject any PR modification/deletion/rename of the trusted required workflow or stdlib-only validator; legitimate gate migrations require independent review plus repository-admin ruleset bypass
- no-op irrelevant paths; permit non-authoritative developer workflow/test changes without trusting or executing them
- execute no mutable repo installation, dependencies, tests, configs, or imports in the authoritative job; invoke only protected validator with `python3 -I`
- initialize a bounded failed inventory before fetch/classification, upload it on pre-validation failures, skip artifact on successful irrelevant no-op, and restore failed inventory if base freshness fails after validator success

## Validation

- `python -m pytest tests/test_validate_docs_vnext_navigation.py -q` (33 passed)
- `python -m ruff check tests/test_validate_docs_vnext_navigation.py`
- workflow YAML parse and `git diff --check`
- behind-base integration test proves raw head passes while synthetic merged docs fail
- protected workflow modification/deletion tests pass
- contract tests prove no setup-python/pip/pytest, isolated validator invocation only, pre-classification failure artifact upload, irrelevant artifact skip, and stale-base failure rewrite
- final review of the current staged file found no significant issues

## Mandatory ruleset prerequisite

After post-merge live proofs pass, the main-targeting ruleset must:

1. require status context **`Validate source navigation`** from workflow **`docs-vnext source navigation required check`**; and
2. **require branches to be up to date before merging**.

The second setting is mandatory: it forces a fresh event/check whenever main advances. Trusted workflow or validator migrations require a dedicated PR and temporary repository-admin ruleset bypass.

## Live evidence boundary

GitHub loads `pull_request_target` workflow code from the default branch. Therefore this PR cannot execute the newly proposed authoritative workflow on itself. After merge, genuinely new irrelevant, relevant docs-vnext, `[skip ci]`, behind-base, and base-retarget/edited events must prove the direct trusted workflow before the ruleset is configured.

Related to #629, #638, #645, and #647. Do not merge until independent review is complete.