### PR TITLE
Proof: authoritative irrelevant no-op

### DIFF
--- a/.github/issue-629-proof-irrelevant.txt
+++ b/.github/issue-629-proof-irrelevant.txt
@@ -1,0 +1,1 @@
+Disposable irrelevant-path proof for trusted source navigation enforcement.


### PR DESCRIPTION
Disposable #629 proof. One irrelevant path; trusted required check must no-op successfully with no artifact. Do not merge.