### PR TITLE
Proof: synthetic merge catches behind-base defect

### DIFF
--- a/docs-vnext/overview/developer-guide.mdx
+++ b/docs-vnext/overview/developer-guide.mdx
@@ -155,3 +155,4 @@ For maximum flexibility, build backend logic in Foundry and compose user-facing 
 - [Classic vs. New: terminology and feature comparison](/overview/classic-vs-new)
 - [SDK comparison: Classic vs. New](/api-sdk/sdk-classic-vs-new)
 - [Quickstart: Get started with Microsoft Foundry](/get-started/quickstart-create-foundry-resources)
+[Disposable target proof](/overview/classic-vs-new)

--- a/docs-vnext/overview/developer-guide.mdx
+++ b/docs-vnext/overview/developer-guide.mdx
@@ -155,4 +155,3 @@ For maximum flexibility, build backend logic in Foundry and compose user-facing 
 - [Classic vs. New: terminology and feature comparison](/overview/classic-vs-new)
 - [SDK comparison: Classic vs. New](/api-sdk/sdk-classic-vs-new)
 - [Quickstart: Get started with Microsoft Foundry](/get-started/quickstart-create-foundry-resources)
-[Disposable target proof](/overview/classic-vs-new)

--- a/docs-vnext/what-is-microsoft-foundry/what-is-foundry.mdx
+++ b/docs-vnext/what-is-microsoft-foundry/what-is-foundry.mdx
@@ -255,3 +255,4 @@ You need an [Azure account](https://azure.microsoft.com/pricing/purchase-options
 - [Get started with an AI template](/developer-experience/ai-template-get-started)
 - [Use the Microsoft Foundry Skill in coding agents](/developer-experience/use-microsoft-foundry-skill)
 - [What's new in Microsoft Foundry documentation?](/operate/whats-new-foundry)
+[Disposable target proof](/overview/classic-vs-new)


### PR DESCRIPTION
Disposable #629 proof. Raw feature head is valid against common base; synthetic merge into advanced base removes the target and must fail trusted validation. Do not merge.