### PR TITLE
Proof: authoritative base retarget

### DIFF
--- a/.github/issue-629-proof-retarget-head.txt
+++ b/.github/issue-629-proof-retarget-head.txt
@@ -1,0 +1,1 @@
+Disposable PR head for base-retarget proof.


### PR DESCRIPTION
Disposable #629 proof. Capture initial trusted run on main, retarget to alternate base, and verify edited event revalidates current base/head. Do not merge.