### PR TITLE
Proof: strict up-to-date prerequisite

### DIFF
--- a/.github/issue-629-proof-behind-head.txt
+++ b/.github/issue-629-proof-behind-head.txt
@@ -1,0 +1,1 @@
+Disposable head for strict up-to-date proof.


### PR DESCRIPTION
Disposable #629 proof. Capture trusted success, then advance base branch and show the PR becomes behind while old success remains, proving strict up-to-date ruleset is mandatory. Do not merge.