### PR TITLE
Enforce hosted docs-vnext route readiness

### DIFF
--- a/.github/workflows/docs-vnext-hosted-routes.yml
+++ b/.github/workflows/docs-vnext-hosted-routes.yml
@@ -1,0 +1,190 @@
+name: docs-vnext hosted route readiness
+
+on:
+  deployment_status:
+  schedule:
+    - cron: "17 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+env:
+  DOCS_VNEXT_ENVIRONMENT: staging - docs-vnext
+  DOCS_PRIMARY_ENVIRONMENT: staging - docs
+  DOCS_VNEXT_BASE_URL: https://hobbyist-e43fa225.mintlify.app
+
+jobs:
+  hosted-route-readiness:
+    name: Verify hosted docs-vnext routes
+    if: >-
+      github.event_name != 'deployment_status' ||
+      (
+        (
+          github.event.deployment.environment == 'staging - docs-vnext' ||
+          github.event.deployment.environment == 'staging - docs'
+        ) &&
+        contains(fromJSON('["success","failure","error"]'), github.event.deployment_status.state)
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: >-
+            ${{ github.event_name == 'deployment_status' &&
+                github.event.deployment.environment == 'staging - docs-vnext' &&
+                github.event.deployment.sha || 'main' }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Initialize blocked diagnostics
+        run: |
+          python scripts/check_hosted_docs_routes.py \
+            --base-url "$DOCS_VNEXT_BASE_URL" \
+            --output tests/eval_results/docs-vnext-hosted-routes.json \
+            --summary-output tests/eval_results/docs-vnext-hosted-routes.md \
+            --initialize-output || true
+
+      - name: Generate validated route inventory
+        run: |
+          python scripts/validate_docs_vnext_navigation.py \
+            --base-docs-dir docs-vnext \
+            --output tests/eval_results/docs-vnext-route-inventory.json
+
+      - name: Resolve hosted deployment
+        id: deployment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ENVIRONMENT: ${{ github.event.deployment.environment }}
+          EVENT_SHA: ${{ github.event.deployment.sha }}
+          EVENT_STATE: ${{ github.event.deployment_status.state }}
+          EVENT_URL: ${{ github.event.deployment_status.environment_url }}
+        run: |
+          set -euo pipefail
+          expected_commit_sha="$(git rev-parse HEAD)"
+          expected_sha="$(git rev-parse HEAD:docs-vnext)"
+          environment="$EVENT_ENVIRONMENT"
+          deployed_commit_sha="$EVENT_SHA"
+          state="$EVENT_STATE"
+          observed_url="$EVENT_URL"
+
+          if [[ "$EVENT_NAME" != "deployment_status" || "$EVENT_ENVIRONMENT" != "$DOCS_VNEXT_ENVIRONMENT" ]]; then
+            deployment="$(
+              gh api -X GET "repos/$GITHUB_REPOSITORY/deployments" \
+                -f environment="$DOCS_VNEXT_ENVIRONMENT" \
+                -f per_page=1 \
+                --jq '.[0] // empty'
+            )"
+            if [[ -z "$deployment" ]]; then
+              environment="$DOCS_VNEXT_ENVIRONMENT"
+              deployed_commit_sha=""
+              state="missing"
+              observed_url=""
+            else
+              deployment_id="$(jq -r '.id' <<<"$deployment")"
+              environment="$(jq -r '.environment' <<<"$deployment")"
+              deployed_commit_sha="$(jq -r '.sha' <<<"$deployment")"
+              status="$(
+                gh api -X GET "repos/$GITHUB_REPOSITORY/deployments/$deployment_id/statuses" \
+                  -f per_page=1 \
+                  --jq '.[0] // empty'
+              )"
+              if [[ -z "$status" ]]; then
+                state="missing"
+                observed_url=""
+              else
+                state="$(jq -r '.state // "missing"' <<<"$status")"
+                observed_url="$(jq -r '.environment_url // ""' <<<"$status")"
+              fi
+            fi
+
+            deployed_sha=""
+            if [[ -n "$deployed_commit_sha" ]]; then
+              if ! git cat-file -e "$deployed_commit_sha^{commit}" 2>/dev/null; then
+                git fetch --no-tags --depth=1 origin "$deployed_commit_sha"
+              fi
+              if git cat-file -e "$deployed_commit_sha:docs-vnext" 2>/dev/null; then
+                deployed_sha="$(git rev-parse "$deployed_commit_sha:docs-vnext")"
+              fi
+            fi
+          fi
+
+          conflicting_deployment="$(
+            gh api -X GET "repos/$GITHUB_REPOSITORY/deployments" \
+              -f environment="$DOCS_PRIMARY_ENVIRONMENT" \
+              -f per_page=1 \
+              --jq '.[0] // empty'
+          )"
+          conflicting_environment=""
+          conflicting_sha=""
+          conflicting_url=""
+          if [[ -n "$conflicting_deployment" ]]; then
+            conflicting_id="$(jq -r '.id' <<<"$conflicting_deployment")"
+            conflicting_environment="$(jq -r '.environment' <<<"$conflicting_deployment")"
+            conflicting_sha="$(jq -r '.sha' <<<"$conflicting_deployment")"
+            conflicting_status="$(
+              gh api -X GET "repos/$GITHUB_REPOSITORY/deployments/$conflicting_id/statuses" \
+                -f per_page=1 \
+                --jq '.[0] // empty'
+            )"
+            if [[ -n "$conflicting_status" ]]; then
+              conflicting_url="$(jq -r '.environment_url // ""' <<<"$conflicting_status")"
+            fi
+          fi
+
+          {
+            echo "expected_commit_sha=$expected_commit_sha"
+            echo "expected_sha=$expected_sha"
+            echo "deployed_commit_sha=$deployed_commit_sha"
+            echo "deployed_sha=$deployed_sha"
+            echo "environment=$environment"
+            echo "state=$state"
+            echo "observed_url=$observed_url"
+            echo "conflicting_environment=$conflicting_environment"
+            echo "conflicting_sha=$conflicting_sha"
+            echo "conflicting_url=$conflicting_url"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check every hosted route
+        run: |
+          python scripts/check_hosted_docs_routes.py \
+            --inventory tests/eval_results/docs-vnext-route-inventory.json \
+            --repository-root . \
+            --base-url "$DOCS_VNEXT_BASE_URL" \
+            --expected-source-sha "${{ steps.deployment.outputs.expected_sha }}" \
+            --deployed-source-sha "${{ steps.deployment.outputs.deployed_sha }}" \
+            --deployment-state "${{ steps.deployment.outputs.state }}" \
+            --expected-environment "$DOCS_VNEXT_ENVIRONMENT" \
+            --deployment-environment "${{ steps.deployment.outputs.environment }}" \
+            --observed-base-url "${{ steps.deployment.outputs.observed_url }}" \
+            --conflicting-environment "${{ steps.deployment.outputs.conflicting_environment }}" \
+            --conflicting-source-sha "${{ steps.deployment.outputs.conflicting_sha }}" \
+            --conflicting-base-url "${{ steps.deployment.outputs.conflicting_url }}" \
+            --output tests/eval_results/docs-vnext-hosted-routes.json \
+            --summary-output tests/eval_results/docs-vnext-hosted-routes.md
+
+      - name: Publish hosted readiness summary
+        if: always()
+        run: cat tests/eval_results/docs-vnext-hosted-routes.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload hosted route diagnostics
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: docs-vnext-hosted-route-readiness
+          path: |
+            tests/eval_results/docs-vnext-route-inventory.json
+            tests/eval_results/docs-vnext-hosted-routes.json
+            tests/eval_results/docs-vnext-hosted-routes.md
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/docs-vnext-hosted-routes.yml
+++ b/.github/workflows/docs-vnext-hosted-routes.yml
@@ -79,6 +79,7 @@ jobs:
             deployment="$(
               gh api -X GET "repos/$GITHUB_REPOSITORY/deployments" \
                 -f environment="$DOCS_VNEXT_ENVIRONMENT" \
+                -f ref=main \
                 -f per_page=1 \
                 --jq '.[0] // empty'
             )"
@@ -120,6 +121,7 @@ jobs:
           conflicting_deployment="$(
             gh api -X GET "repos/$GITHUB_REPOSITORY/deployments" \
               -f environment="$DOCS_PRIMARY_ENVIRONMENT" \
+              -f ref=main \
               -f per_page=1 \
               --jq '.[0] // empty'
           )"

--- a/.github/workflows/docs-vnext-hosted-routes.yml
+++ b/.github/workflows/docs-vnext-hosted-routes.yml
@@ -36,10 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: >-
-            ${{ github.event_name == 'deployment_status' &&
-                github.event.deployment.environment == 'staging - docs-vnext' &&
-                github.event.deployment.sha || 'main' }}
+          ref: main
           fetch-depth: 0
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/docs-vnext-hosted-routes.yml
+++ b/.github/workflows/docs-vnext-hosted-routes.yml
@@ -17,7 +17,7 @@ concurrency:
 env:
   DOCS_VNEXT_ENVIRONMENT: staging - docs-vnext
   DOCS_PRIMARY_ENVIRONMENT: staging - docs
-  DOCS_VNEXT_BASE_URL: https://hobbyist-e43fa225.mintlify.app
+  DOCS_VNEXT_BASE_URL: ${{ vars.DOCS_VNEXT_BASE_URL }}
 
 jobs:
   hosted-route-readiness:
@@ -105,14 +105,15 @@ jobs:
               fi
             fi
 
-            deployed_sha=""
-            if [[ -n "$deployed_commit_sha" ]]; then
-              if ! git cat-file -e "$deployed_commit_sha^{commit}" 2>/dev/null; then
-                git fetch --no-tags --depth=1 origin "$deployed_commit_sha"
-              fi
-              if git cat-file -e "$deployed_commit_sha:docs-vnext" 2>/dev/null; then
-                deployed_sha="$(git rev-parse "$deployed_commit_sha:docs-vnext")"
-              fi
+          fi
+
+          deployed_sha=""
+          if [[ -n "$deployed_commit_sha" ]]; then
+            if ! git cat-file -e "$deployed_commit_sha^{commit}" 2>/dev/null; then
+              git fetch --no-tags --depth=1 origin "$deployed_commit_sha"
+            fi
+            if git cat-file -e "$deployed_commit_sha:docs-vnext" 2>/dev/null; then
+              deployed_sha="$(git rev-parse "$deployed_commit_sha:docs-vnext")"
             fi
           fi
 

--- a/scripts/check_hosted_docs_routes.py
+++ b/scripts/check_hosted_docs_routes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import html
+from http.client import HTTPException
 import json
 import re
 import sys
@@ -382,24 +383,46 @@ def fetch_url(url: str, timeout_seconds: float, max_response_bytes: int) -> Http
     )
     try:
         with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310 - caller controls the trusted base URL
-            body_bytes = response.read(max_response_bytes + 1)
-            charset = response.headers.get_content_charset() or "utf-8"
+            try:
+                body_bytes = response.read(max_response_bytes + 1)
+                charset = response.headers.get_content_charset() or "utf-8"
+                body = body_bytes[:max_response_bytes].decode(charset, errors="replace")
+            except (HTTPException, LookupError, OSError) as exc:
+                return HttpResult(
+                    status_code=response.status,
+                    body="",
+                    final_url=response.geturl(),
+                    error=f"{type(exc).__name__}: {exc}",
+                )
             return HttpResult(
                 status_code=response.status,
-                body=body_bytes[:max_response_bytes].decode(charset, errors="replace"),
+                body=body,
                 final_url=response.geturl(),
-                error="response exceeded maximum inspection size" if len(body_bytes) > max_response_bytes else None,
+                error=(
+                    f"response exceeded maximum inspection size ({max_response_bytes} bytes)"
+                    if len(body_bytes) > max_response_bytes
+                    else None
+                ),
             )
     except HTTPError as exc:
-        body_bytes = exc.read(max_response_bytes)
-        charset = exc.headers.get_content_charset() or "utf-8"
+        try:
+            body_bytes = exc.read(max_response_bytes)
+            charset = exc.headers.get_content_charset() or "utf-8"
+            body = body_bytes.decode(charset, errors="replace")
+        except (HTTPException, LookupError, OSError) as read_exc:
+            return HttpResult(
+                status_code=exc.code,
+                body="",
+                final_url=exc.geturl(),
+                error=f"{type(read_exc).__name__}: {read_exc}",
+            )
         return HttpResult(
             status_code=exc.code,
-            body=body_bytes.decode(charset, errors="replace"),
+            body=body,
             final_url=exc.geturl(),
             error=None,
         )
-    except (TimeoutError, URLError, OSError) as exc:
+    except (HTTPException, TimeoutError, URLError, OSError) as exc:
         return HttpResult(status_code=None, body="", final_url=url, error=f"{type(exc).__name__}: {exc}")
 
 
@@ -528,6 +551,14 @@ def _probe_route(
             response.final_url,
             "route_http_error",
             "hosted route did not return a successful response",
+        )
+    if response.error:
+        return RouteResult(
+            target,
+            response.status_code,
+            response.final_url,
+            "route_response_invalid",
+            response.error,
         )
 
     if target.kind == "openapi_source":
@@ -739,6 +770,7 @@ def check_hosted_routes(
     if (
         preflight.status_code is None
         or not 200 <= preflight.status_code < 300
+        or preflight.error is not None
         or (preflight.final_url and not _same_origin(base_url, preflight.final_url))
     ):
         collector.add(

--- a/scripts/check_hosted_docs_routes.py
+++ b/scripts/check_hosted_docs_routes.py
@@ -1,0 +1,739 @@
+#!/usr/bin/env python3
+"""Verify every publishable docs-vnext route against the hosted site."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import html
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlsplit
+from urllib.request import Request, urlopen
+
+SCHEMA_VERSION = 1
+DEFAULT_MAX_DIAGNOSTICS = 100
+DEFAULT_MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+DEFAULT_MIN_CONTENT_CHARACTERS = 80
+DEFAULT_TIMEOUT_SECONDS = 20.0
+DEFAULT_WORKERS = 16
+MAX_DIAGNOSTIC_STRING_LENGTH = 500
+IGNORED_HTML_TAGS = {"script", "style", "svg", "noscript", "template"}
+CONTENT_HTML_TAGS = {"main", "article"}
+FRONT_MATTER_PATTERN = re.compile(r"\A---\s*\r?\n(?P<body>.*?)\r?\n---\s*(?:\r?\n|\Z)", re.DOTALL)
+FENCED_CODE_PATTERN = re.compile(r"(?ms)^(`{3,}|~{3,}).*?^\1\s*$")
+JSX_COMMENT_PATTERN = re.compile(r"\{/\*.*?\*/\}", re.DOTALL)
+MARKDOWN_LINK_PATTERN = re.compile(r"!?\[([^\]]*)]\([^)]+\)")
+MARKDOWN_MARKUP_PATTERN = re.compile(r"[*_`~>#|{}\[\]()]")
+JSX_TAG_PATTERN = re.compile(r"<[^>]+>")
+MAX_SOURCE_MARKERS = 32
+
+
+@dataclass(frozen=True, slots=True)
+class RouteTarget:
+    route: str
+    source_navigation_entry: str
+    candidate_source_path: str
+    markers: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class HttpResult:
+    status_code: int | None
+    body: str
+    final_url: str
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RouteResult:
+    target: RouteTarget
+    response_status: int | None
+    final_url: str
+    failure_class: str | None = None
+    detail: str | None = None
+
+
+class VisibleTextParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._ignored_depth = 0
+        self._content_depth = 0
+        self._all_parts: list[str] = []
+        self._content_parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del attrs
+        if self._ignored_depth:
+            self._ignored_depth += 1
+            return
+        if tag in IGNORED_HTML_TAGS:
+            self._ignored_depth = 1
+            return
+        if tag in CONTENT_HTML_TAGS:
+            self._content_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._ignored_depth:
+            self._ignored_depth -= 1
+            return
+        if tag in CONTENT_HTML_TAGS and self._content_depth:
+            self._content_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if self._ignored_depth:
+            return
+        self._all_parts.append(data)
+        if self._content_depth:
+            self._content_parts.append(data)
+
+    @property
+    def all_text(self) -> str:
+        return " ".join(self._all_parts)
+
+    @property
+    def content_text(self) -> str:
+        return " ".join(self._content_parts)
+
+
+class DiagnosticCollector:
+    def __init__(self, max_diagnostics: int) -> None:
+        self.max_diagnostics = max_diagnostics
+        self.total = 0
+        self.counts: Counter[str] = Counter()
+        self.diagnostics: list[dict[str, Any]] = []
+
+    def add(
+        self,
+        *,
+        failure_class: str,
+        route: str | None,
+        source_navigation_entry: str,
+        candidate_source_path: str | None,
+        response_status: int | None = None,
+        detail: str | None = None,
+    ) -> None:
+        self.total += 1
+        self.counts[failure_class] += 1
+        if len(self.diagnostics) >= self.max_diagnostics:
+            return
+        diagnostic: dict[str, Any] = {
+            "route": route,
+            "sourceNavigationEntry": source_navigation_entry,
+            "candidateSourcePath": candidate_source_path,
+            "responseStatus": response_status,
+            "failureClass": failure_class,
+        }
+        if detail:
+            diagnostic["detail"] = bounded_value(detail)
+        self.diagnostics.append(diagnostic)
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "total": self.total,
+            "counts": dict(sorted(self.counts.items())),
+            "truncated": self.total > len(self.diagnostics),
+        }
+
+
+Fetcher = Callable[[str, float, int], HttpResult]
+
+
+def bounded_value(value: Any) -> Any:
+    if isinstance(value, str) and len(value) > MAX_DIAGNOSTIC_STRING_LENGTH:
+        return value[: MAX_DIAGNOSTIC_STRING_LENGTH - 3] + "..."
+    return value
+
+
+def normalize_text(value: str) -> str:
+    unescaped = html.unescape(value).lower()
+    return " ".join(re.sub(r"[^\w]+", " ", unescaped, flags=re.UNICODE).split())
+
+
+def _front_matter_value(front_matter: str, key: str) -> str | None:
+    match = re.search(rf"(?m)^{re.escape(key)}:\s*(.+?)\s*$", front_matter)
+    if not match:
+        return None
+    value = match.group(1).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value
+
+
+def source_markers(source_path: Path) -> tuple[str, ...]:
+    text = source_path.read_text(encoding="utf-8")
+    front_matter_match = FRONT_MATTER_PATTERN.match(text)
+    front_matter = front_matter_match.group("body") if front_matter_match else ""
+    body = text[front_matter_match.end() :] if front_matter_match else text
+    body = JSX_COMMENT_PATTERN.sub(" ", FENCED_CODE_PATTERN.sub(" ", body))
+
+    markers: list[str] = []
+    for key in ("title", "description"):
+        value = _front_matter_value(front_matter, key)
+        if value and len(normalize_text(value)) >= 12:
+            markers.append(value)
+
+    body_markers: list[str] = []
+    for paragraph in re.split(r"\n\s*\n", body):
+        candidate = " ".join(line.strip() for line in paragraph.splitlines())
+        if not candidate or candidate.startswith(("import ", "export ")):
+            continue
+        candidate = JSX_TAG_PATTERN.sub(" ", candidate)
+        candidate = MARKDOWN_LINK_PATTERN.sub(r"\1", candidate)
+        candidate = MARKDOWN_MARKUP_PATTERN.sub(" ", candidate)
+        candidate = " ".join(candidate.split())
+        if len(normalize_text(candidate)) >= 40:
+            body_markers.append(candidate[:240])
+
+    if len(body_markers) > MAX_SOURCE_MARKERS:
+        last_index = len(body_markers) - 1
+        indexes = {round(position * last_index / (MAX_SOURCE_MARKERS - 1)) for position in range(MAX_SOURCE_MARKERS)}
+        body_markers = [body_markers[index] for index in sorted(indexes)]
+    markers.extend(body_markers)
+
+    return tuple(dict.fromkeys(markers))
+
+
+def load_targets(inventory_path: Path, repository_root: Path) -> tuple[dict[str, Any], list[RouteTarget]]:
+    inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
+    if inventory.get("schemaVersion") != 1:
+        raise ValueError("route inventory schemaVersion must be 1")
+    if inventory.get("status") != "passed":
+        raise ValueError(f"route inventory status must be passed, got {inventory.get('status')!r}")
+    routes = inventory.get("routes")
+    if not isinstance(routes, list) or not routes:
+        raise ValueError("route inventory must contain at least one route")
+
+    targets: list[RouteTarget] = []
+    seen: dict[str, str] = {}
+    for entry in routes:
+        if not isinstance(entry, dict) or entry.get("kind") != "page":
+            raise ValueError("route inventory contains a non-page route entry")
+        route = entry.get("route")
+        source_entry = entry.get("sourceNavigationEntry")
+        candidate = entry.get("candidateSourcePath")
+        if not all(isinstance(value, str) and value for value in (route, source_entry, candidate)):
+            raise ValueError("route inventory contains an incomplete route entry")
+        if not route.startswith("/"):
+            raise ValueError(f"route inventory contains an invalid route: {route!r}")
+        if route in seen:
+            if seen[route] != candidate:
+                raise ValueError(
+                    f"route inventory maps {route!r} to both {seen[route]!r} and {candidate!r}"
+                )
+            continue
+        seen[route] = candidate
+        source_path = repository_root / candidate
+        if not source_path.is_file():
+            raise ValueError(f"route source does not exist: {candidate}")
+        targets.append(
+            RouteTarget(
+                route=route,
+                source_navigation_entry=source_entry,
+                candidate_source_path=candidate,
+                markers=source_markers(source_path),
+            )
+        )
+    return inventory, targets
+
+
+def fetch_url(url: str, timeout_seconds: float, max_response_bytes: int) -> HttpResult:
+    request = Request(
+        url,
+        headers={
+            "Accept": "text/html,application/xhtml+xml",
+            "User-Agent": "foundry-docs-hosted-route-smoke/1.0",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310 - caller controls the trusted base URL
+            body_bytes = response.read(max_response_bytes + 1)
+            charset = response.headers.get_content_charset() or "utf-8"
+            return HttpResult(
+                status_code=response.status,
+                body=body_bytes[:max_response_bytes].decode(charset, errors="replace"),
+                final_url=response.geturl(),
+                error="response exceeded maximum inspection size" if len(body_bytes) > max_response_bytes else None,
+            )
+    except HTTPError as exc:
+        body_bytes = exc.read(max_response_bytes)
+        charset = exc.headers.get_content_charset() or "utf-8"
+        return HttpResult(
+            status_code=exc.code,
+            body=body_bytes.decode(charset, errors="replace"),
+            final_url=exc.geturl(),
+            error=None,
+        )
+    except (TimeoutError, URLError, OSError) as exc:
+        return HttpResult(status_code=None, body="", final_url=url, error=f"{type(exc).__name__}: {exc}")
+
+
+def _same_origin(expected: str, observed: str) -> bool:
+    expected_parts = urlsplit(expected)
+    observed_parts = urlsplit(observed)
+    return (
+        expected_parts.scheme.lower(),
+        expected_parts.netloc.lower(),
+    ) == (
+        observed_parts.scheme.lower(),
+        observed_parts.netloc.lower(),
+    )
+
+
+def _deployment_diagnostics(
+    collector: DiagnosticCollector,
+    *,
+    expected_source_sha: str,
+    deployed_source_sha: str,
+    deployment_state: str,
+    expected_environment: str,
+    deployment_environment: str,
+    base_url: str,
+    observed_base_url: str,
+    conflicting_environment: str,
+    conflicting_source_sha: str,
+    conflicting_base_url: str,
+) -> None:
+    if deployment_environment != expected_environment:
+        collector.add(
+            failure_class="deployment_environment_mismatch",
+            route=None,
+            source_navigation_entry="deployment",
+            candidate_source_path=None,
+            detail=f"expected environment {expected_environment!r}, observed {deployment_environment!r}",
+        )
+    if deployment_state != "success":
+        if deployment_state == "missing":
+            failure_class = "deployment_missing"
+        elif deployment_state in {"failure", "error"}:
+            failure_class = "deployment_failed"
+        else:
+            failure_class = "deployment_incomplete"
+        collector.add(
+            failure_class=failure_class,
+            route=None,
+            source_navigation_entry="deployment",
+            candidate_source_path=None,
+            detail=f"latest deployment state is {deployment_state!r}",
+        )
+    if not deployed_source_sha:
+        collector.add(
+            failure_class="deployment_missing",
+            route=None,
+            source_navigation_entry="deployment",
+            candidate_source_path=None,
+            detail="no deployed source SHA was reported",
+        )
+    elif expected_source_sha and deployed_source_sha != expected_source_sha:
+        collector.add(
+            failure_class="stale_deployment",
+            route=None,
+            source_navigation_entry="deployment",
+            candidate_source_path=None,
+            detail=f"expected source SHA {expected_source_sha}, deployed source SHA {deployed_source_sha}",
+        )
+    if observed_base_url and not _same_origin(base_url, observed_base_url):
+        collector.add(
+            failure_class="deployment_url_mismatch",
+            route=None,
+            source_navigation_entry="deployment",
+            candidate_source_path=None,
+            detail=f"expected hosted origin {base_url!r}, deployment reported {observed_base_url!r}",
+        )
+    if conflicting_base_url and _same_origin(base_url, conflicting_base_url):
+        collector.add(
+            failure_class="deployment_host_collision",
+            route=None,
+            source_navigation_entry="deployment",
+            candidate_source_path=None,
+            detail=(
+                f"{expected_environment!r} and {conflicting_environment!r} report the same hosted origin; "
+                f"conflicting source SHA is {conflicting_source_sha or 'unknown'}"
+            ),
+        )
+
+
+def _probe_route(
+    target: RouteTarget,
+    *,
+    base_url: str,
+    timeout_seconds: float,
+    max_response_bytes: int,
+    min_content_characters: int,
+    fetcher: Fetcher,
+) -> RouteResult:
+    url = urljoin(base_url.rstrip("/") + "/", target.route.lstrip("/"))
+    response = fetcher(url, timeout_seconds, max_response_bytes)
+    if response.final_url and not _same_origin(base_url, response.final_url):
+        return RouteResult(
+            target,
+            response.status_code,
+            response.final_url,
+            "cross_origin_redirect",
+            f"hosted route redirected to a different origin: {response.final_url}",
+        )
+    if response.status_code is None:
+        return RouteResult(target, None, response.final_url, "route_unavailable", response.error)
+    if response.status_code == 404:
+        return RouteResult(target, 404, response.final_url, "route_missing", "hosted route returned 404")
+    if response.status_code >= 500:
+        return RouteResult(
+            target,
+            response.status_code,
+            response.final_url,
+            "route_server_error",
+            "hosted route returned a server error",
+        )
+    if response.status_code < 200 or response.status_code >= 300:
+        return RouteResult(
+            target,
+            response.status_code,
+            response.final_url,
+            "route_http_error",
+            "hosted route did not return a successful response",
+        )
+    parser = VisibleTextParser()
+    try:
+        parser.feed(response.body)
+    except Exception as exc:  # noqa: BLE001 - malformed hosted HTML is a route failure
+        return RouteResult(
+            target,
+            response.status_code,
+            response.final_url,
+            "route_response_invalid",
+            f"{type(exc).__name__}: {exc}",
+        )
+
+    content_text = normalize_text(parser.content_text)
+    if len(content_text) < min_content_characters:
+        return RouteResult(
+            target,
+            response.status_code,
+            response.final_url,
+            "empty_content",
+            f"hosted main content contained {len(content_text)} normalized characters",
+        )
+
+    document_text = normalize_text(parser.all_text)
+    normalized_markers = [normalize_text(marker) for marker in target.markers if normalize_text(marker)]
+    missing_markers = [marker for marker in normalized_markers if marker not in document_text]
+    if missing_markers:
+        return RouteResult(
+            target,
+            response.status_code,
+            response.final_url,
+            "stale_content",
+            f"hosted content is missing {len(missing_markers)} of {len(normalized_markers)} distributed source markers",
+        )
+    return RouteResult(target, response.status_code, response.final_url)
+
+
+def build_initial_report(base_url: str, *, max_diagnostics: int, detail: str) -> dict[str, Any]:
+    collector = DiagnosticCollector(max_diagnostics)
+    collector.add(
+        failure_class="workflow_incomplete",
+        route=None,
+        source_navigation_entry="workflow",
+        candidate_source_path=None,
+        detail=detail,
+    )
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "status": "blocked",
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "baseUrl": base_url,
+        "deployment": {},
+        "routeSummary": {"required": 0, "checked": 0, "passed": 0, "failed": 0},
+        "diagnosticSummary": collector.summary(),
+        "diagnostics": collector.diagnostics,
+    }
+
+
+def check_hosted_routes(
+    *,
+    inventory_path: Path,
+    repository_root: Path,
+    base_url: str,
+    expected_source_sha: str,
+    deployed_source_sha: str,
+    deployment_state: str,
+    expected_environment: str,
+    deployment_environment: str,
+    observed_base_url: str,
+    conflicting_environment: str = "",
+    conflicting_source_sha: str = "",
+    conflicting_base_url: str = "",
+    max_diagnostics: int = DEFAULT_MAX_DIAGNOSTICS,
+    max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
+    min_content_characters: int = DEFAULT_MIN_CONTENT_CHARACTERS,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    workers: int = DEFAULT_WORKERS,
+    fetcher: Fetcher = fetch_url,
+) -> dict[str, Any]:
+    collector = DiagnosticCollector(max_diagnostics)
+    try:
+        inventory, targets = load_targets(inventory_path, repository_root)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        collector.add(
+            failure_class="source_inventory_invalid",
+            route=None,
+            source_navigation_entry="navigation",
+            candidate_source_path=str(inventory_path),
+            detail=str(exc),
+        )
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "status": "blocked",
+            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "baseUrl": base_url,
+            "deployment": {},
+            "routeSummary": {"required": 0, "checked": 0, "passed": 0, "failed": 0},
+            "diagnosticSummary": collector.summary(),
+            "diagnostics": collector.diagnostics,
+        }
+
+    _deployment_diagnostics(
+        collector,
+        expected_source_sha=expected_source_sha,
+        deployed_source_sha=deployed_source_sha,
+        deployment_state=deployment_state,
+        expected_environment=expected_environment,
+        deployment_environment=deployment_environment,
+        base_url=base_url,
+        observed_base_url=observed_base_url,
+        conflicting_environment=conflicting_environment,
+        conflicting_source_sha=conflicting_source_sha,
+        conflicting_base_url=conflicting_base_url,
+    )
+    deployment = {
+        "expectedSourceSha": expected_source_sha,
+        "deployedSourceSha": deployed_source_sha,
+        "state": deployment_state,
+        "expectedEnvironment": expected_environment,
+        "environment": deployment_environment,
+        "reportedBaseUrl": observed_base_url,
+        "conflictingEnvironment": conflicting_environment,
+        "conflictingSourceSha": conflicting_source_sha,
+        "conflictingBaseUrl": conflicting_base_url,
+    }
+    if collector.total:
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "status": "blocked",
+            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "baseUrl": base_url,
+            "navigationSource": inventory.get("navigationSource"),
+            "deployment": deployment,
+            "routeSummary": {"required": len(targets), "checked": 0, "passed": 0, "failed": 0},
+            "diagnosticSummary": collector.summary(),
+            "diagnostics": collector.diagnostics,
+        }
+
+    preflight = fetcher(base_url.rstrip("/") + "/", timeout_seconds, max_response_bytes)
+    if (
+        preflight.status_code is None
+        or not 200 <= preflight.status_code < 300
+        or (preflight.final_url and not _same_origin(base_url, preflight.final_url))
+    ):
+        collector.add(
+            failure_class="host_unavailable",
+            route=None,
+            source_navigation_entry="host",
+            candidate_source_path=None,
+            response_status=preflight.status_code,
+            detail=(
+                preflight.error
+                or (
+                    f"host preflight redirected to a different origin: {preflight.final_url}"
+                    if preflight.final_url and not _same_origin(base_url, preflight.final_url)
+                    else "host preflight did not return a successful response"
+                )
+            ),
+        )
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "status": "blocked",
+            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "baseUrl": base_url,
+            "navigationSource": inventory.get("navigationSource"),
+            "deployment": deployment,
+            "routeSummary": {"required": len(targets), "checked": 0, "passed": 0, "failed": 0},
+            "diagnosticSummary": collector.summary(),
+            "diagnostics": collector.diagnostics,
+        }
+
+    probe = lambda target: _probe_route(  # noqa: E731 - executor map needs a single-argument callable
+        target,
+        base_url=base_url,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        min_content_characters=min_content_characters,
+        fetcher=fetcher,
+    )
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(probe, targets))
+
+    failed = [result for result in results if result.failure_class]
+    host_failure_classes = {"route_unavailable", "route_server_error"}
+    infrastructure_statuses = {401, 403, 429}
+    host_wide_failure = bool(failed) and len(failed) == len(results) and (
+        all(result.failure_class in host_failure_classes for result in failed)
+        or (
+            len({result.response_status for result in failed}) == 1
+            and failed[0].response_status in infrastructure_statuses
+        )
+    )
+    if host_wide_failure:
+        collector.add(
+            failure_class="host_unavailable",
+            route=None,
+            source_navigation_entry="host",
+            candidate_source_path=None,
+            detail="every required route was unavailable or returned a server error",
+        )
+    for result in failed:
+        collector.add(
+            failure_class=result.failure_class or "route_failure",
+            route=result.target.route,
+            source_navigation_entry=result.target.source_navigation_entry,
+            candidate_source_path=result.target.candidate_source_path,
+            response_status=result.response_status,
+            detail=result.detail,
+        )
+
+    status = "blocked" if host_wide_failure else ("failed" if failed else "passed")
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "status": status,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "baseUrl": base_url,
+        "navigationSource": inventory.get("navigationSource"),
+        "deployment": deployment,
+        "routeSummary": {
+            "required": len(targets),
+            "checked": len(results),
+            "passed": len(results) - len(failed),
+            "failed": len(failed),
+        },
+        "diagnosticSummary": collector.summary(),
+        "diagnostics": collector.diagnostics,
+    }
+
+
+def render_summary(report: dict[str, Any]) -> str:
+    routes = report["routeSummary"]
+    lines = [
+        "# docs-vnext hosted route readiness",
+        "",
+        f"- **Status:** {report['status']}",
+        f"- **Hosted base URL:** {report['baseUrl']}",
+        f"- **Required routes:** {routes['required']}",
+        f"- **Checked:** {routes['checked']}",
+        f"- **Passed:** {routes['passed']}",
+        f"- **Failed:** {routes['failed']}",
+    ]
+    deployment = report.get("deployment", {})
+    if deployment:
+        lines.extend(
+            [
+                f"- **Expected source SHA:** `{deployment.get('expectedSourceSha', '')}`",
+                f"- **Deployed source SHA:** `{deployment.get('deployedSourceSha', '')}`",
+                f"- **Deployment state:** {deployment.get('state', '')}",
+            ]
+        )
+    lines.extend(["", "## Diagnostics", ""])
+    diagnostics = report.get("diagnostics", [])
+    if not diagnostics:
+        lines.append("No hosted readiness failures.")
+    else:
+        for diagnostic in diagnostics[:20]:
+            route = diagnostic.get("route") or "(host/deployment)"
+            status = diagnostic.get("responseStatus")
+            status_text = f", HTTP {status}" if status is not None else ""
+            lines.append(
+                f"- `{diagnostic['failureClass']}`: `{route}`{status_text} "
+                f"from `{diagnostic.get('candidateSourcePath') or diagnostic['sourceNavigationEntry']}`"
+            )
+        if report["diagnosticSummary"]["truncated"] or len(diagnostics) > 20:
+            lines.append("- Additional diagnostics are available in the JSON artifact.")
+    return "\n".join(lines) + "\n"
+
+
+def write_outputs(report: dict[str, Any], output_path: Path, summary_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    summary_path.write_text(render_summary(report), encoding="utf-8")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inventory", type=Path)
+    parser.add_argument("--repository-root", type=Path, default=Path("."))
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--expected-source-sha", default="")
+    parser.add_argument("--deployed-source-sha", default="")
+    parser.add_argument("--deployment-state", default="missing")
+    parser.add_argument("--expected-environment", default="staging - docs-vnext")
+    parser.add_argument("--deployment-environment", default="")
+    parser.add_argument("--observed-base-url", default="")
+    parser.add_argument("--conflicting-environment", default="")
+    parser.add_argument("--conflicting-source-sha", default="")
+    parser.add_argument("--conflicting-base-url", default="")
+    parser.add_argument("--output", type=Path, default=Path("tests/eval_results/docs-vnext-hosted-routes.json"))
+    parser.add_argument("--summary-output", type=Path, default=Path("tests/eval_results/docs-vnext-hosted-routes.md"))
+    parser.add_argument("--max-diagnostics", type=int, default=DEFAULT_MAX_DIAGNOSTICS)
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
+    parser.add_argument("--initialize-output", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.initialize_output:
+        report = build_initial_report(
+            args.base_url,
+            max_diagnostics=args.max_diagnostics,
+            detail="Workflow did not reach hosted route verification.",
+        )
+    elif args.inventory is None:
+        print("--inventory is required unless --initialize-output is used", file=sys.stderr)
+        return 2
+    else:
+        report = check_hosted_routes(
+            inventory_path=args.inventory,
+            repository_root=args.repository_root,
+            base_url=args.base_url,
+            expected_source_sha=args.expected_source_sha,
+            deployed_source_sha=args.deployed_source_sha,
+            deployment_state=args.deployment_state,
+            expected_environment=args.expected_environment,
+            deployment_environment=args.deployment_environment,
+            observed_base_url=args.observed_base_url,
+            conflicting_environment=args.conflicting_environment,
+            conflicting_source_sha=args.conflicting_source_sha,
+            conflicting_base_url=args.conflicting_base_url,
+            max_diagnostics=args.max_diagnostics,
+            timeout_seconds=args.timeout_seconds,
+            workers=args.workers,
+        )
+    write_outputs(report, args.output, args.summary_output)
+    print(
+        f"docs-vnext hosted routes: {report['status']} "
+        f"({report['routeSummary']['passed']}/{report['routeSummary']['required']} passed); "
+        f"report: {args.output}"
+    )
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_hosted_docs_routes.py
+++ b/scripts/check_hosted_docs_routes.py
@@ -9,14 +9,15 @@ import html
 import json
 import re
 import sys
+import unicodedata
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from html.parser import HTMLParser
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 from urllib.error import HTTPError, URLError
-from urllib.parse import urljoin, urlsplit
+from urllib.parse import quote, urljoin, urlsplit
 from urllib.request import Request, urlopen
 
 SCHEMA_VERSION = 1
@@ -39,10 +40,12 @@ MAX_SOURCE_MARKERS = 32
 
 @dataclass(frozen=True, slots=True)
 class RouteTarget:
+    kind: str
     route: str
     source_navigation_entry: str
     candidate_source_path: str
     markers: tuple[str, ...]
+    expected_json: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -158,6 +161,36 @@ def normalize_text(value: str) -> str:
     return " ".join(re.sub(r"[^\w]+", " ", unescaped, flags=re.UNICODE).split())
 
 
+def normalize_origin(value: str, *, require_origin_only: bool = False) -> str | None:
+    if not value:
+        return None
+    try:
+        parts = urlsplit(value)
+        port = parts.port
+    except ValueError:
+        return None
+    if parts.scheme not in {"http", "https"} or not parts.hostname or parts.username or parts.password:
+        return None
+    if require_origin_only and (parts.path not in {"", "/"} or parts.query or parts.fragment):
+        return None
+    default_port = 80 if parts.scheme == "http" else 443
+    port_suffix = f":{port}" if port is not None and port != default_port else ""
+    return f"{parts.scheme.lower()}://{parts.hostname.lower()}{port_suffix}"
+
+
+def mintlify_slug(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode().lower()
+    normalized = normalized.replace(" ", "-")
+    normalized = re.sub(r"[^a-z0-9_`\[\]-]", "", normalized)
+    return re.sub(r"-+", "-", normalized).strip("-")
+
+
+def openapi_summary_marker(value: str) -> str:
+    value = MARKDOWN_LINK_PATTERN.sub(r"\1", value)
+    value = MARKDOWN_MARKUP_PATTERN.sub(" ", value)
+    return " ".join(value.split())
+
+
 def _front_matter_value(front_matter: str, key: str) -> str | None:
     match = re.search(rf"(?m)^{re.escape(key)}:\s*(.+?)\s*$", front_matter)
     if not match:
@@ -202,7 +235,10 @@ def source_markers(source_path: Path) -> tuple[str, ...]:
     return tuple(dict.fromkeys(markers))
 
 
-def load_targets(inventory_path: Path, repository_root: Path) -> tuple[dict[str, Any], list[RouteTarget]]:
+def load_targets(
+    inventory_path: Path,
+    repository_root: Path,
+) -> tuple[dict[str, Any], list[RouteTarget], dict[str, int]]:
     inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
     if inventory.get("schemaVersion") != 1:
         raise ValueError("route inventory schemaVersion must be 1")
@@ -214,6 +250,7 @@ def load_targets(inventory_path: Path, repository_root: Path) -> tuple[dict[str,
 
     targets: list[RouteTarget] = []
     seen: dict[str, str] = {}
+    page_entries = 0
     for entry in routes:
         if not isinstance(entry, dict) or entry.get("kind") != "page":
             raise ValueError("route inventory contains a non-page route entry")
@@ -224,6 +261,7 @@ def load_targets(inventory_path: Path, repository_root: Path) -> tuple[dict[str,
             raise ValueError("route inventory contains an incomplete route entry")
         if not route.startswith("/"):
             raise ValueError(f"route inventory contains an invalid route: {route!r}")
+        page_entries += 1
         if route in seen:
             if seen[route] != candidate:
                 raise ValueError(
@@ -236,13 +274,102 @@ def load_targets(inventory_path: Path, repository_root: Path) -> tuple[dict[str,
             raise ValueError(f"route source does not exist: {candidate}")
         targets.append(
             RouteTarget(
+                kind="page",
                 route=route,
                 source_navigation_entry=source_entry,
                 candidate_source_path=candidate,
                 markers=source_markers(source_path),
             )
         )
-    return inventory, targets
+
+    openapi_entries = inventory.get("openapi")
+    if not isinstance(openapi_entries, list):
+        raise ValueError("route inventory openapi must be an array")
+    openapi_operations = 0
+    for entry in openapi_entries:
+        if not isinstance(entry, dict) or entry.get("kind") != "openapi":
+            raise ValueError("route inventory contains an invalid OpenAPI entry")
+        directory = entry.get("route")
+        source_entry = entry.get("sourceNavigationEntry")
+        candidate = entry.get("candidateSourcePath")
+        if not all(isinstance(value, str) and value for value in (directory, source_entry, candidate)):
+            raise ValueError("route inventory contains an incomplete OpenAPI entry")
+        if not directory.startswith("/"):
+            raise ValueError(f"OpenAPI directory must be root-relative: {directory!r}")
+        source_path = repository_root / candidate
+        if not source_path.is_file():
+            raise ValueError(f"OpenAPI source does not exist: {candidate}")
+        try:
+            specification = json.loads(source_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError(f"OpenAPI source is not valid JSON: {candidate}: {exc}") from exc
+        hosted_source_route = "/" + PurePosixPath(candidate).relative_to("docs-vnext").as_posix()
+        canonical_specification = json.dumps(specification, sort_keys=True, separators=(",", ":"))
+        if hosted_source_route not in seen:
+            seen[hosted_source_route] = candidate
+            targets.append(
+                RouteTarget(
+                    kind="openapi_source",
+                    route=hosted_source_route,
+                    source_navigation_entry=source_entry,
+                    candidate_source_path=candidate,
+                    markers=(),
+                    expected_json=canonical_specification,
+                )
+            )
+
+        paths = specification.get("paths")
+        if not isinstance(paths, dict):
+            raise ValueError(f"OpenAPI source paths must be an object: {candidate}")
+        for operation_path, path_item in paths.items():
+            if not isinstance(operation_path, str) or not isinstance(path_item, dict):
+                raise ValueError(f"OpenAPI source contains an invalid path item: {candidate}")
+            for method, operation in path_item.items():
+                method_lower = method.lower()
+                if method_lower not in {"get", "put", "post", "delete", "options", "head", "patch", "trace"}:
+                    continue
+                if not isinstance(operation, dict):
+                    raise ValueError(f"OpenAPI operation must be an object: {candidate} {method} {operation_path}")
+                if operation.get("x-excluded") is True:
+                    continue
+                tags = operation.get("tags")
+                tag = tags[0] if isinstance(tags, list) and tags and isinstance(tags[0], str) else "default"
+                summary = operation.get("summary")
+                if isinstance(summary, str) and summary.strip():
+                    route_label = summary
+                    summary_marker = openapi_summary_marker(summary)
+                else:
+                    static_segments = [
+                        segment
+                        for segment in operation_path.split("/")
+                        if segment and not (segment.startswith("{") and segment.endswith("}"))
+                    ]
+                    route_label = f"{method_lower} {' '.join(static_segments)}"
+                    summary_marker = f"{method_lower.upper()} {operation_path}"
+                operation_route = (
+                    f"{directory.rstrip('/')}/{mintlify_slug(tag)}/{mintlify_slug(route_label)}"
+                )
+                openapi_operations += 1
+                if operation_route in seen:
+                    continue
+                seen[operation_route] = f"{candidate} {method_lower.upper()} {operation_path}"
+                targets.append(
+                    RouteTarget(
+                        kind="openapi_operation",
+                        route=operation_route,
+                        source_navigation_entry=f"{source_entry}[{method_lower.upper()} {operation_path}]",
+                        candidate_source_path=candidate,
+                        markers=(summary_marker, f"{method_lower.upper()} {operation_path}"),
+                    )
+                )
+
+    return inventory, targets, {
+        "pageEntries": page_entries,
+        "uniquePageRoutes": len({entry["route"] for entry in routes}),
+        "openapiSources": len(openapi_entries),
+        "openapiOperations": openapi_operations,
+        "requiredTargets": len(targets),
+    }
 
 
 def fetch_url(url: str, timeout_seconds: float, max_response_bytes: int) -> HttpResult:
@@ -277,15 +404,9 @@ def fetch_url(url: str, timeout_seconds: float, max_response_bytes: int) -> Http
 
 
 def _same_origin(expected: str, observed: str) -> bool:
-    expected_parts = urlsplit(expected)
-    observed_parts = urlsplit(observed)
-    return (
-        expected_parts.scheme.lower(),
-        expected_parts.netloc.lower(),
-    ) == (
-        observed_parts.scheme.lower(),
-        observed_parts.netloc.lower(),
-    )
+    expected_origin = normalize_origin(expected)
+    observed_origin = normalize_origin(observed)
+    return expected_origin is not None and expected_origin == observed_origin
 
 
 def _deployment_diagnostics(
@@ -340,7 +461,15 @@ def _deployment_diagnostics(
             candidate_source_path=None,
             detail=f"expected source SHA {expected_source_sha}, deployed source SHA {deployed_source_sha}",
         )
-    if observed_base_url and not _same_origin(base_url, observed_base_url):
+    if not observed_base_url:
+        collector.add(
+            failure_class="deployment_url_missing",
+            route=None,
+            source_navigation_entry="deployment",
+            candidate_source_path=None,
+            detail="deployment did not report environment_url",
+        )
+    elif normalize_origin(observed_base_url) is None or not _same_origin(base_url, observed_base_url):
         collector.add(
             failure_class="deployment_url_mismatch",
             route=None,
@@ -370,7 +499,7 @@ def _probe_route(
     min_content_characters: int,
     fetcher: Fetcher,
 ) -> RouteResult:
-    url = urljoin(base_url.rstrip("/") + "/", target.route.lstrip("/"))
+    url = urljoin(base_url.rstrip("/") + "/", quote(target.route.lstrip("/"), safe="/-._~"))
     response = fetcher(url, timeout_seconds, max_response_bytes)
     if response.final_url and not _same_origin(base_url, response.final_url):
         return RouteResult(
@@ -400,6 +529,29 @@ def _probe_route(
             "route_http_error",
             "hosted route did not return a successful response",
         )
+
+    if target.kind == "openapi_source":
+        try:
+            hosted_specification = json.loads(response.body)
+        except json.JSONDecodeError as exc:
+            return RouteResult(
+                target,
+                response.status_code,
+                response.final_url,
+                "openapi_source_invalid",
+                f"hosted OpenAPI source is not valid JSON: {exc}",
+            )
+        hosted_canonical = json.dumps(hosted_specification, sort_keys=True, separators=(",", ":"))
+        if hosted_canonical != target.expected_json:
+            return RouteResult(
+                target,
+                response.status_code,
+                response.final_url,
+                "stale_openapi_source",
+                "hosted OpenAPI source does not match the validated source inventory",
+            )
+        return RouteResult(target, response.status_code, response.final_url)
+
     parser = VisibleTextParser()
     try:
         parser.feed(response.body)
@@ -451,6 +603,13 @@ def build_initial_report(base_url: str, *, max_diagnostics: int, detail: str) ->
         "generatedAt": datetime.now(timezone.utc).isoformat(),
         "baseUrl": base_url,
         "deployment": {},
+        "targetSummary": {
+            "pageEntries": 0,
+            "uniquePageRoutes": 0,
+            "openapiSources": 0,
+            "openapiOperations": 0,
+            "requiredTargets": 0,
+        },
         "routeSummary": {"required": 0, "checked": 0, "passed": 0, "failed": 0},
         "diagnosticSummary": collector.summary(),
         "diagnostics": collector.diagnostics,
@@ -479,8 +638,39 @@ def check_hosted_routes(
     fetcher: Fetcher = fetch_url,
 ) -> dict[str, Any]:
     collector = DiagnosticCollector(max_diagnostics)
+    configured_origin = normalize_origin(base_url, require_origin_only=True)
+    if configured_origin is None:
+        failure_class = "host_configuration_missing" if not base_url else "host_configuration_invalid"
+        collector.add(
+            failure_class=failure_class,
+            route=None,
+            source_navigation_entry="configuration",
+            candidate_source_path=None,
+            detail=(
+                "repository variable DOCS_VNEXT_BASE_URL is not configured"
+                if not base_url
+                else "DOCS_VNEXT_BASE_URL must be an HTTP(S) origin without a path, query, or fragment"
+            ),
+        )
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "status": "blocked",
+            "generatedAt": datetime.now(timezone.utc).isoformat(),
+            "baseUrl": base_url,
+            "deployment": {},
+            "targetSummary": {
+                "pageEntries": 0,
+                "uniquePageRoutes": 0,
+                "openapiSources": 0,
+                "openapiOperations": 0,
+                "requiredTargets": 0,
+            },
+            "routeSummary": {"required": 0, "checked": 0, "passed": 0, "failed": 0},
+            "diagnosticSummary": collector.summary(),
+            "diagnostics": collector.diagnostics,
+        }
     try:
-        inventory, targets = load_targets(inventory_path, repository_root)
+        inventory, targets, target_summary = load_targets(inventory_path, repository_root)
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
         collector.add(
             failure_class="source_inventory_invalid",
@@ -495,6 +685,13 @@ def check_hosted_routes(
             "generatedAt": datetime.now(timezone.utc).isoformat(),
             "baseUrl": base_url,
             "deployment": {},
+            "targetSummary": {
+                "pageEntries": 0,
+                "uniquePageRoutes": 0,
+                "openapiSources": 0,
+                "openapiOperations": 0,
+                "requiredTargets": 0,
+            },
             "routeSummary": {"required": 0, "checked": 0, "passed": 0, "failed": 0},
             "diagnosticSummary": collector.summary(),
             "diagnostics": collector.diagnostics,
@@ -532,6 +729,7 @@ def check_hosted_routes(
             "baseUrl": base_url,
             "navigationSource": inventory.get("navigationSource"),
             "deployment": deployment,
+            "targetSummary": target_summary,
             "routeSummary": {"required": len(targets), "checked": 0, "passed": 0, "failed": 0},
             "diagnosticSummary": collector.summary(),
             "diagnostics": collector.diagnostics,
@@ -565,6 +763,7 @@ def check_hosted_routes(
             "baseUrl": base_url,
             "navigationSource": inventory.get("navigationSource"),
             "deployment": deployment,
+            "targetSummary": target_summary,
             "routeSummary": {"required": len(targets), "checked": 0, "passed": 0, "failed": 0},
             "diagnosticSummary": collector.summary(),
             "diagnostics": collector.diagnostics,
@@ -617,6 +816,7 @@ def check_hosted_routes(
         "baseUrl": base_url,
         "navigationSource": inventory.get("navigationSource"),
         "deployment": deployment,
+        "targetSummary": target_summary,
         "routeSummary": {
             "required": len(targets),
             "checked": len(results),
@@ -630,12 +830,17 @@ def check_hosted_routes(
 
 def render_summary(report: dict[str, Any]) -> str:
     routes = report["routeSummary"]
+    targets = report.get("targetSummary", {})
     lines = [
         "# docs-vnext hosted route readiness",
         "",
         f"- **Status:** {report['status']}",
         f"- **Hosted base URL:** {report['baseUrl']}",
-        f"- **Required routes:** {routes['required']}",
+        f"- **Page entries / unique routes:** {targets.get('pageEntries', 0)} / "
+        f"{targets.get('uniquePageRoutes', 0)}",
+        f"- **OpenAPI sources / operations:** {targets.get('openapiSources', 0)} / "
+        f"{targets.get('openapiOperations', 0)}",
+        f"- **Required hosted targets:** {routes['required']}",
         f"- **Checked:** {routes['checked']}",
         f"- **Passed:** {routes['passed']}",
         f"- **Failed:** {routes['failed']}",

--- a/tests/test_check_hosted_docs_routes.py
+++ b/tests/test_check_hosted_docs_routes.py
@@ -368,8 +368,7 @@ def test_workflow_runs_after_deployment_and_on_schedule_with_retained_diagnostic
     assert "success" in job["if"]
     assert "failure" in job["if"]
     checkout = next(step for step in job["steps"] if step.get("uses", "").startswith("actions/checkout@"))
-    assert "github.event.deployment.sha" in checkout["with"]["ref"]
-    assert "staging - docs-vnext" in checkout["with"]["ref"]
+    assert checkout["with"]["ref"] == "main"
     assert checkout["with"]["fetch-depth"] == 0
     by_name = {step.get("name"): step for step in job["steps"] if "name" in step}
     assert "Initialize blocked diagnostics" in by_name

--- a/tests/test_check_hosted_docs_routes.py
+++ b/tests/test_check_hosted_docs_routes.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from check_hosted_docs_routes import HttpResult, check_hosted_routes, main  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "docs-vnext-hosted-routes.yml"
+BASE_URL = "https://docs.example.test"
+SHA = "a" * 40
+
+
+def _write_inventory(tmp_path: Path, routes: list[str]) -> Path:
+    entries = []
+    for index, route in enumerate(routes):
+        source_path = tmp_path / "docs-vnext" / f"{route}.mdx"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_text(
+            "---\n"
+            f'title: "Title {index}"\n'
+            f'description: "Current description for route {index}."\n'
+            "---\n\n"
+            f"Current hosted body marker for route {index} with enough useful documentation content.\n\n"
+            f"Middle source marker for route {index} that must remain synchronized after deployment.\n\n"
+            f"Final source marker for route {index} that detects stale content near the end of the page.\n",
+            encoding="utf-8",
+        )
+        entries.append(
+            {
+                "kind": "page",
+                "sourceNavigationEntry": f"navigation.groups[0].pages[{index}]",
+                "route": f"/{route}",
+                "candidateSourcePath": f"docs-vnext/{route}.mdx",
+            }
+        )
+    inventory = {
+        "schemaVersion": 1,
+        "status": "passed",
+        "navigationSource": "docs-vnext/docs.json",
+        "routes": entries,
+    }
+    path = tmp_path / "inventory.json"
+    path.write_text(json.dumps(inventory), encoding="utf-8")
+    return path
+
+
+def _html(index: int, body: str | None = None) -> str:
+    content = body or (
+        f"Current hosted body marker for route {index} with enough useful documentation content."
+        f"</p><p>Middle source marker for route {index} that must remain synchronized after deployment."
+        f"</p><p>Final source marker for route {index} that detects stale content near the end of the page."
+    )
+    return (
+        "<html><head><title>"
+        f"Title {index}"
+        "</title></head><body><main><h1>"
+        f"Title {index}"
+        "</h1><p>"
+        f"Current description for route {index}."
+        "</p><p>"
+        f"{content}"
+        "</p></main></body></html>"
+    )
+
+
+def _run(tmp_path: Path, fetcher, routes: list[str] | None = None, **overrides):
+    routes = routes or ["guide/one", "guide/two"]
+    inventory = _write_inventory(tmp_path, routes)
+    args = {
+        "inventory_path": inventory,
+        "repository_root": tmp_path,
+        "base_url": BASE_URL,
+        "expected_source_sha": SHA,
+        "deployed_source_sha": SHA,
+        "deployment_state": "success",
+        "expected_environment": "staging - docs-vnext",
+        "deployment_environment": "staging - docs-vnext",
+        "observed_base_url": BASE_URL,
+        "fetcher": fetcher,
+        "workers": 2,
+    }
+    args.update(overrides)
+    return check_hosted_routes(**args)
+
+
+def test_all_inventory_routes_are_checked(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        calls.append(url)
+        if url == f"{BASE_URL}/":
+            return HttpResult(200, "<html><main>Healthy host preflight content.</main></html>", url)
+        index = 0 if url.endswith("/guide/one") else 1
+        return HttpResult(200, _html(index), url)
+
+    report = _run(tmp_path, fetcher)
+
+    assert report["status"] == "passed"
+    assert report["routeSummary"] == {"required": 2, "checked": 2, "passed": 2, "failed": 0}
+    assert sorted(calls) == sorted([f"{BASE_URL}/", f"{BASE_URL}/guide/one", f"{BASE_URL}/guide/two"])
+
+
+def test_route_failure_preserves_inventory_evidence(tmp_path: Path) -> None:
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url.endswith("/guide/two"):
+            return HttpResult(404, "<html><main>Not found</main></html>", url)
+        index = 0
+        return HttpResult(200, _html(index), url)
+
+    report = _run(tmp_path, fetcher)
+
+    assert report["status"] == "failed"
+    assert report["routeSummary"]["failed"] == 1
+    assert report["diagnostics"] == [
+        {
+            "route": "/guide/two",
+            "sourceNavigationEntry": "navigation.groups[0].pages[1]",
+            "candidateSourcePath": "docs-vnext/guide/two.mdx",
+            "responseStatus": 404,
+            "failureClass": "route_missing",
+            "detail": "hosted route returned 404",
+        }
+    ]
+
+
+def test_empty_and_stale_content_fail_readiness(tmp_path: Path) -> None:
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url.endswith("/guide/one"):
+            return HttpResult(200, "<html><main>FAQ</main></html>", url)
+        if url.endswith("/guide/two"):
+            return HttpResult(
+                200,
+                "<html><head><title>Old page</title></head><body><main>"
+                + ("Old hosted content. " * 20)
+                + "</main></body></html>",
+                url,
+            )
+        return HttpResult(200, "<html><main>Healthy host preflight content.</main></html>", url)
+
+    report = _run(tmp_path, fetcher)
+
+    assert report["status"] == "failed"
+    assert report["diagnosticSummary"]["counts"] == {"empty_content": 1, "stale_content": 1}
+
+
+def test_late_source_change_is_detected_as_stale_content(tmp_path: Path) -> None:
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url.endswith("/guide/two"):
+            body = (
+                "Current hosted body marker for route 1 with enough useful documentation content."
+                "</p><p>Middle source marker for route 1 that must remain synchronized after deployment."
+                "</p><p>Old final content that no longer matches the source."
+            )
+            return HttpResult(200, _html(1, body), url)
+        return HttpResult(200, _html(0), url)
+
+    report = _run(tmp_path, fetcher)
+
+    assert report["status"] == "failed"
+    assert report["diagnosticSummary"]["counts"] == {"stale_content": 1}
+    assert report["diagnostics"][0]["route"] == "/guide/two"
+
+
+def test_host_unavailability_is_blocked_without_false_route_success(tmp_path: Path) -> None:
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        return HttpResult(None, "", url, "TimeoutError: timed out")
+
+    report = _run(tmp_path, fetcher)
+
+    assert report["status"] == "blocked"
+    assert report["routeSummary"] == {"required": 2, "checked": 0, "passed": 0, "failed": 0}
+    assert report["diagnosticSummary"]["counts"] == {"host_unavailable": 1}
+
+
+def test_uniform_infrastructure_4xx_is_host_unavailable(tmp_path: Path) -> None:
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url == f"{BASE_URL}/":
+            return HttpResult(200, "<html><main>Healthy host preflight content.</main></html>", url)
+        return HttpResult(429, "<html><main>Rate limited</main></html>", url)
+
+    report = _run(tmp_path, fetcher)
+
+    assert report["status"] == "blocked"
+    assert report["diagnosticSummary"]["counts"] == {"host_unavailable": 1, "route_http_error": 2}
+
+
+def test_cross_origin_preflight_is_host_unavailable(tmp_path: Path) -> None:
+    report = _run(
+        tmp_path,
+        lambda _url, _timeout, _max_bytes: HttpResult(
+            200,
+            "<html><main>Unexpected external content.</main></html>",
+            "https://other.example.test/",
+        ),
+    )
+
+    assert report["status"] == "blocked"
+    assert report["diagnosticSummary"]["counts"] == {"host_unavailable": 1}
+
+
+def test_cross_origin_route_redirect_fails_that_route(tmp_path: Path) -> None:
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url == f"{BASE_URL}/":
+            return HttpResult(200, "<html><main>Healthy host preflight content.</main></html>", url)
+        if url.endswith("/guide/two"):
+            return HttpResult(200, _html(1), "https://other.example.test/guide/two")
+        return HttpResult(200, _html(0), url)
+
+    report = _run(tmp_path, fetcher)
+
+    assert report["status"] == "failed"
+    assert report["diagnosticSummary"]["counts"] == {"cross_origin_redirect": 1}
+    assert report["diagnostics"][0]["route"] == "/guide/two"
+
+
+def test_stale_deployment_blocks_before_route_requests(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        calls.append(url)
+        return HttpResult(200, "<html><main>Unexpected request</main></html>", url)
+
+    report = _run(tmp_path, fetcher, deployed_source_sha="b" * 40)
+
+    assert report["status"] == "blocked"
+    assert report["routeSummary"]["checked"] == 0
+    assert report["diagnosticSummary"]["counts"] == {"stale_deployment": 1}
+    assert calls == []
+
+
+def test_failed_deployment_is_distinct_from_route_failure(tmp_path: Path) -> None:
+    report = _run(
+        tmp_path,
+        lambda url, _timeout, _max_bytes: HttpResult(200, _html(0), url),
+        deployment_state="failure",
+    )
+
+    assert report["status"] == "blocked"
+    assert report["routeSummary"]["checked"] == 0
+    assert report["diagnosticSummary"]["counts"] == {"deployment_failed": 1}
+
+
+def test_shared_hosting_origin_blocks_colliding_deployment_projects(tmp_path: Path) -> None:
+    report = _run(
+        tmp_path,
+        lambda url, _timeout, _max_bytes: HttpResult(200, _html(0), url),
+        conflicting_environment="staging - docs",
+        conflicting_source_sha="b" * 40,
+        conflicting_base_url=BASE_URL,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["routeSummary"]["checked"] == 0
+    assert report["diagnosticSummary"]["counts"] == {"deployment_host_collision": 1}
+
+
+def test_diagnostics_are_bounded_but_total_counts_are_complete(tmp_path: Path) -> None:
+    routes = [f"guide/{index}" for index in range(5)]
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url == f"{BASE_URL}/":
+            return HttpResult(200, "<html><main>Healthy host preflight content.</main></html>", url)
+        return HttpResult(404, "<html><main>Not found</main></html>", url)
+
+    report = _run(tmp_path, fetcher, routes=routes, max_diagnostics=2)
+
+    assert report["diagnosticSummary"] == {
+        "total": 5,
+        "counts": {"route_missing": 5},
+        "truncated": True,
+    }
+    assert len(report["diagnostics"]) == 2
+
+
+def test_invalid_inventory_is_blocked(tmp_path: Path) -> None:
+    inventory = tmp_path / "inventory.json"
+    inventory.write_text(json.dumps({"schemaVersion": 1, "status": "failed", "routes": []}), encoding="utf-8")
+
+    report = check_hosted_routes(
+        inventory_path=inventory,
+        repository_root=tmp_path,
+        base_url=BASE_URL,
+        expected_source_sha=SHA,
+        deployed_source_sha=SHA,
+        deployment_state="success",
+        expected_environment="staging - docs-vnext",
+        deployment_environment="staging - docs-vnext",
+        observed_base_url=BASE_URL,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["diagnosticSummary"]["counts"] == {"source_inventory_invalid": 1}
+
+
+def test_duplicate_navigation_entries_probe_a_route_once(tmp_path: Path) -> None:
+    inventory = _write_inventory(tmp_path, ["guide/one"])
+    data = json.loads(inventory.read_text(encoding="utf-8"))
+    duplicate = dict(data["routes"][0])
+    duplicate["sourceNavigationEntry"] = "navigation.groups[1].pages[0]"
+    data["routes"].append(duplicate)
+    inventory.write_text(json.dumps(data), encoding="utf-8")
+    route_calls: list[str] = []
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url != f"{BASE_URL}/":
+            route_calls.append(url)
+        return HttpResult(200, _html(0), url)
+
+    report = check_hosted_routes(
+        inventory_path=inventory,
+        repository_root=tmp_path,
+        base_url=BASE_URL,
+        expected_source_sha=SHA,
+        deployed_source_sha=SHA,
+        deployment_state="success",
+        expected_environment="staging - docs-vnext",
+        deployment_environment="staging - docs-vnext",
+        observed_base_url=BASE_URL,
+        fetcher=fetcher,
+    )
+
+    assert report["status"] == "passed"
+    assert report["routeSummary"]["required"] == 1
+    assert route_calls == [f"{BASE_URL}/guide/one"]
+
+
+def test_initialize_output_is_uploadable_and_fails_closed(tmp_path: Path) -> None:
+    output = tmp_path / "report.json"
+    summary = tmp_path / "summary.md"
+
+    exit_code = main(
+        [
+            "--base-url",
+            BASE_URL,
+            "--output",
+            str(output),
+            "--summary-output",
+            str(summary),
+            "--initialize-output",
+        ]
+    )
+
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert exit_code == 1
+    assert report["status"] == "blocked"
+    assert report["diagnosticSummary"]["counts"] == {"workflow_incomplete": 1}
+    assert summary.is_file()
+
+
+def test_workflow_runs_after_deployment_and_on_schedule_with_retained_diagnostics() -> None:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    triggers = workflow.get("on") or workflow.get(True)
+    assert "deployment_status" in triggers
+    assert triggers["schedule"]
+    assert "workflow_dispatch" in triggers
+    assert workflow["permissions"] == {"contents": "read", "deployments": "read"}
+
+    job = workflow["jobs"]["hosted-route-readiness"]
+    assert "staging - docs-vnext" in job["if"]
+    assert "staging - docs" in job["if"]
+    assert "success" in job["if"]
+    assert "failure" in job["if"]
+    checkout = next(step for step in job["steps"] if step.get("uses", "").startswith("actions/checkout@"))
+    assert "github.event.deployment.sha" in checkout["with"]["ref"]
+    assert "staging - docs-vnext" in checkout["with"]["ref"]
+    assert checkout["with"]["fetch-depth"] == 0
+    by_name = {step.get("name"): step for step in job["steps"] if "name" in step}
+    assert "Initialize blocked diagnostics" in by_name
+    assert "Generate validated route inventory" in by_name
+    assert "Resolve hosted deployment" in by_name
+    assert "Check every hosted route" in by_name
+    assert by_name["Upload hosted route diagnostics"]["if"] == "always()"
+    assert by_name["Upload hosted route diagnostics"]["with"]["retention-days"] == 30
+    assert by_name["Publish hosted readiness summary"]["if"] == "always()"
+
+    resolver = by_name["Resolve hosted deployment"]["run"]
+    assert "repos/$GITHUB_REPOSITORY/deployments" in resolver
+    assert "deployment_status" in resolver
+    assert "HEAD:docs-vnext" in resolver
+    assert "$deployed_commit_sha:docs-vnext" in resolver
+    checker = by_name["Check every hosted route"]["run"]
+    assert "docs-vnext-route-inventory.json" in checker
+    assert "--expected-source-sha" in checker
+    assert "--deployed-source-sha" in checker
+    assert "--conflicting-base-url" in checker

--- a/tests/test_check_hosted_docs_routes.py
+++ b/tests/test_check_hosted_docs_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from http.client import BadStatusLine, IncompleteRead
 import json
 import os
 import shutil
@@ -11,6 +12,7 @@ import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
+import check_hosted_docs_routes as hosted_routes  # noqa: E402
 from check_hosted_docs_routes import HttpResult, check_hosted_routes, load_targets, main  # noqa: E402
 from validate_docs_vnext_navigation import validate_navigation  # noqa: E402
 
@@ -337,6 +339,96 @@ def test_host_unavailability_is_blocked_without_false_route_success(tmp_path: Pa
     assert report["diagnosticSummary"]["counts"] == {"host_unavailable": 1}
 
 
+class _FakeHeaders:
+    def __init__(self, charset: str | None = "utf-8") -> None:
+        self.charset = charset
+
+    def get_content_charset(self) -> str | None:
+        return self.charset
+
+
+class _FakeResponse:
+    status = 200
+
+    def __init__(self, *, body: bytes = b"", read_error: Exception | None = None, charset: str = "utf-8") -> None:
+        self.body = body
+        self.read_error = read_error
+        self.headers = _FakeHeaders(charset)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+    def read(self, _size: int) -> bytes:
+        if self.read_error:
+            raise self.read_error
+        return self.body
+
+    def geturl(self) -> str:
+        return BASE_URL
+
+
+def test_fetch_url_converts_incomplete_read_to_structured_error(monkeypatch) -> None:
+    response = _FakeResponse(read_error=IncompleteRead(b"partial", 10))
+    monkeypatch.setattr(hosted_routes, "urlopen", lambda *_args, **_kwargs: response)
+
+    result = hosted_routes.fetch_url(BASE_URL, 1.0, 1024)
+
+    assert result.status_code == 200
+    assert result.body == ""
+    assert result.error and result.error.startswith("IncompleteRead:")
+
+
+def test_fetch_url_converts_unknown_charset_to_structured_error(monkeypatch) -> None:
+    response = _FakeResponse(body=b"content", charset="unknown-test-charset")
+    monkeypatch.setattr(hosted_routes, "urlopen", lambda *_args, **_kwargs: response)
+
+    result = hosted_routes.fetch_url(BASE_URL, 1.0, 1024)
+
+    assert result.status_code == 200
+    assert result.body == ""
+    assert result.error and result.error.startswith("LookupError:")
+
+
+def test_fetch_url_converts_pre_response_protocol_error(monkeypatch) -> None:
+    def raise_protocol_error(*_args, **_kwargs):
+        raise BadStatusLine("invalid status")
+
+    monkeypatch.setattr(hosted_routes, "urlopen", raise_protocol_error)
+
+    result = hosted_routes.fetch_url(BASE_URL, 1.0, 1024)
+
+    assert result.status_code is None
+    assert result.body == ""
+    assert result.error and result.error.startswith("BadStatusLine:")
+
+
+def test_fetch_url_marks_oversized_response_invalid(monkeypatch) -> None:
+    response = _FakeResponse(body=b"01234567890")
+    monkeypatch.setattr(hosted_routes, "urlopen", lambda *_args, **_kwargs: response)
+
+    result = hosted_routes.fetch_url(BASE_URL, 1.0, 10)
+
+    assert result.status_code == 200
+    assert result.body == "0123456789"
+    assert result.error == "response exceeded maximum inspection size (10 bytes)"
+
+
+def test_route_read_failures_complete_as_bounded_diagnostics(tmp_path: Path) -> None:
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url == f"{BASE_URL}/":
+            return HttpResult(200, "<html><main>Healthy host preflight content.</main></html>", url)
+        return HttpResult(200, "", url, "IncompleteRead: partial response")
+
+    report = _run(tmp_path, fetcher)
+
+    assert report["status"] == "failed"
+    assert report["routeSummary"] == {"required": 2, "checked": 2, "passed": 0, "failed": 2}
+    assert report["diagnosticSummary"]["counts"] == {"route_response_invalid": 2}
+
+
 def test_uniform_infrastructure_4xx_is_host_unavailable(tmp_path: Path) -> None:
     def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
         if url == f"{BASE_URL}/":
@@ -615,6 +707,7 @@ def test_workflow_runs_after_deployment_and_on_schedule_with_retained_diagnostic
     assert "deployment_status" in resolver
     assert "HEAD:docs-vnext" in resolver
     assert "$deployed_commit_sha:docs-vnext" in resolver
+    assert resolver.count("-f ref=main") == 2
     checker = by_name["Check every hosted route"]["run"]
     assert "docs-vnext-route-inventory.json" in checker
     assert "--expected-source-sha" in checker
@@ -622,7 +715,7 @@ def test_workflow_runs_after_deployment_and_on_schedule_with_retained_diagnostic
     assert "--conflicting-base-url" in checker
 
 
-def test_intended_deployment_status_path_resolves_deployed_docs_tree(tmp_path: Path) -> None:
+def _bash_executable() -> Path:
     git = shutil.which("git")
     bash_candidates = (
         [
@@ -636,7 +729,10 @@ def test_intended_deployment_status_path_resolves_deployed_docs_tree(tmp_path: P
     bash = next((candidate for candidate in bash_candidates if candidate.is_file()), None)
     if bash is None:
         raise AssertionError("bash is required to execute the workflow resolver")
+    return bash
 
+
+def _resolver_fixture_repo(tmp_path: Path) -> tuple[Path, str, str]:
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
@@ -661,12 +757,44 @@ def test_intended_deployment_status_path_resolves_deployed_docs_tree(tmp_path: P
         capture_output=True,
         text=True,
     ).stdout.strip()
+    return repo, commit_sha, tree_sha
+
+
+def _run_workflow_resolver(
+    tmp_path: Path,
+    repo: Path,
+    *,
+    gh_function: str,
+    event_name: str,
+    event_environment: str,
+    event_sha: str,
+    event_state: str,
+    event_url: str,
+) -> dict[str, str]:
+    bash = _bash_executable()
 
     workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
     steps = workflow["jobs"]["hosted-route-readiness"]["steps"]
     resolver = next(step for step in steps if step.get("name") == "Resolve hosted deployment")["run"]
     script = repo / "resolver.sh"
-    script.write_text("#!/usr/bin/env bash\ngh() { return 0; }\n" + resolver, encoding="utf-8", newline="\n")
+    jq_function = r"""
+jq() {
+  if [[ "$1" == "-r" ]]; then shift; fi
+  python -c 'import json, sys
+data = json.load(sys.stdin)
+expression = sys.argv[1]
+key = expression.split()[0].lstrip(".")
+value = data.get(key)
+if value is None:
+    value = "missing" if "\"missing\"" in expression else ""
+print(value)' "$1"
+}
+"""
+    script.write_text(
+        "#!/usr/bin/env bash\n" + jq_function + "\n" + gh_function + "\n" + resolver,
+        encoding="utf-8",
+        newline="\n",
+    )
     output_path = tmp_path / "github-output"
     env = {
         **os.environ,
@@ -675,23 +803,121 @@ def test_intended_deployment_status_path_resolves_deployed_docs_tree(tmp_path: P
         "GITHUB_OUTPUT": output_path.as_posix(),
         "DOCS_VNEXT_ENVIRONMENT": "staging - docs-vnext",
         "DOCS_PRIMARY_ENVIRONMENT": "staging - docs",
-        "EVENT_NAME": "deployment_status",
-        "EVENT_ENVIRONMENT": "staging - docs-vnext",
-        "EVENT_SHA": commit_sha,
-        "EVENT_STATE": "success",
-        "EVENT_URL": BASE_URL,
+        "EVENT_NAME": event_name,
+        "EVENT_ENVIRONMENT": event_environment,
+        "EVENT_SHA": event_sha,
+        "EVENT_STATE": event_state,
+        "EVENT_URL": event_url,
     }
 
-    subprocess.run([str(bash), script.as_posix()], cwd=repo, env=env, check=True, capture_output=True, text=True)
+    result = subprocess.run(
+        [str(bash), script.as_posix()],
+        cwd=repo,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
-    outputs = dict(
+    return dict(
         line.split("=", 1)
         for line in output_path.read_text(encoding="utf-8").splitlines()
         if "=" in line
     )
+
+
+def test_intended_deployment_status_path_resolves_deployed_docs_tree(tmp_path: Path) -> None:
+    repo, commit_sha, tree_sha = _resolver_fixture_repo(tmp_path)
+    outputs = _run_workflow_resolver(
+        tmp_path,
+        repo,
+        gh_function="gh() { return 0; }",
+        event_name="deployment_status",
+        event_environment="staging - docs-vnext",
+        event_sha=commit_sha,
+        event_state="success",
+        event_url=BASE_URL,
+    )
+
     assert outputs["expected_sha"] == tree_sha
     assert outputs["deployed_commit_sha"] == commit_sha
     assert outputs["deployed_sha"] == tree_sha
     assert outputs["environment"] == "staging - docs-vnext"
     assert outputs["state"] == "success"
     assert outputs["observed_url"] == BASE_URL
+
+
+def test_main_deployments_detect_collision_despite_newer_distinct_preview(tmp_path: Path) -> None:
+    repo, commit_sha, tree_sha = _resolver_fixture_repo(tmp_path)
+    distinct_preview_url = "https://preview.example.test"
+    gh_function = f"""
+gh() {{
+  args="$*"
+  case "$args" in
+    *"deployments/101/statuses"*)
+      printf '%s\\n' '{{"state":"success","environment_url":"{BASE_URL}"}}'
+      ;;
+    *"deployments/202/statuses"*)
+      printf '%s\\n' '{{"state":"success","environment_url":"{BASE_URL}"}}'
+      ;;
+    *"environment=staging - docs-vnext"*)
+      if [[ "$args" == *"ref=main"* ]]; then
+        printf '%s\\n' '{{"id":101,"environment":"staging - docs-vnext","sha":"{commit_sha}"}}'
+      else
+        printf '%s\\n' '{{"id":901,"environment":"staging - docs-vnext","sha":"{'b' * 40}","url":"{distinct_preview_url}"}}'
+      fi
+      ;;
+    *"environment=staging - docs"*)
+      if [[ "$args" == *"ref=main"* ]]; then
+        printf '%s\\n' '{{"id":202,"environment":"staging - docs","sha":"{commit_sha}"}}'
+      else
+        printf '%s\\n' '{{"id":902,"environment":"staging - docs","sha":"{'c' * 40}","url":"{distinct_preview_url}"}}'
+      fi
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}}
+"""
+    outputs = _run_workflow_resolver(
+        tmp_path,
+        repo,
+        gh_function=gh_function,
+        event_name="schedule",
+        event_environment="",
+        event_sha="",
+        event_state="",
+        event_url="",
+    )
+
+    assert outputs["expected_sha"] == tree_sha
+    assert outputs["deployed_sha"] == tree_sha
+    assert outputs["observed_url"] == BASE_URL
+    assert outputs["conflicting_url"] == BASE_URL
+    assert distinct_preview_url not in outputs.values()
+
+    inventory = _write_inventory(tmp_path, ["guide/one"])
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        raise AssertionError(f"collision must block before HTTP: {url}")
+
+    report = check_hosted_routes(
+        inventory_path=inventory,
+        repository_root=tmp_path,
+        base_url=BASE_URL,
+        expected_source_sha=outputs["expected_sha"],
+        deployed_source_sha=outputs["deployed_sha"],
+        deployment_state=outputs["state"],
+        expected_environment="staging - docs-vnext",
+        deployment_environment=outputs["environment"],
+        observed_base_url=outputs["observed_url"],
+        conflicting_environment=outputs["conflicting_environment"],
+        conflicting_source_sha=outputs["conflicting_sha"],
+        conflicting_base_url=outputs["conflicting_url"],
+        fetcher=fetcher,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["diagnosticSummary"]["counts"] == {"deployment_host_collision": 1}

--- a/tests/test_check_hosted_docs_routes.py
+++ b/tests/test_check_hosted_docs_routes.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -9,7 +11,8 @@ import yaml
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
-from check_hosted_docs_routes import HttpResult, check_hosted_routes, main  # noqa: E402
+from check_hosted_docs_routes import HttpResult, check_hosted_routes, load_targets, main  # noqa: E402
+from validate_docs_vnext_navigation import validate_navigation  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "docs-vnext-hosted-routes.yml"
@@ -45,10 +48,49 @@ def _write_inventory(tmp_path: Path, routes: list[str]) -> Path:
         "status": "passed",
         "navigationSource": "docs-vnext/docs.json",
         "routes": entries,
+        "openapi": [],
     }
     path = tmp_path / "inventory.json"
     path.write_text(json.dumps(inventory), encoding="utf-8")
     return path
+
+
+def _write_openapi_inventory(tmp_path: Path, *, include_page_collision: bool = False) -> tuple[Path, dict]:
+    page_routes = ["api/widgets/widgets/list-widgets"] if include_page_collision else ["guide/one"]
+    inventory_path = _write_inventory(tmp_path, page_routes)
+    specification = {
+        "openapi": "3.1.0",
+        "info": {"title": "Widgets", "version": "1.0.0"},
+        "paths": {
+            "/widgets": {
+                "get": {
+                    "operationId": "listWidgets",
+                    "summary": "List widgets",
+                    "tags": ["Widgets"],
+                    "responses": {"200": {"description": "OK"}},
+                },
+                "post": {
+                    "operationId": "createWidget",
+                    "tags": ["Widgets"],
+                    "responses": {"201": {"description": "Created"}},
+                },
+            }
+        },
+    }
+    source_path = tmp_path / "docs-vnext" / "openapi" / "widgets.json"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    source_path.write_text(json.dumps(specification), encoding="utf-8")
+    inventory = json.loads(inventory_path.read_text(encoding="utf-8"))
+    inventory["openapi"] = [
+        {
+            "kind": "openapi",
+            "sourceNavigationEntry": "navigation.tabs[1].groups[0].openapi",
+            "route": "/api/widgets",
+            "candidateSourcePath": "docs-vnext/openapi/widgets.json",
+        }
+    ]
+    inventory_path.write_text(json.dumps(inventory), encoding="utf-8")
+    return inventory_path, specification
 
 
 def _html(index: int, body: str | None = None) -> str:
@@ -105,6 +147,122 @@ def test_all_inventory_routes_are_checked(tmp_path: Path) -> None:
     assert report["status"] == "passed"
     assert report["routeSummary"] == {"required": 2, "checked": 2, "passed": 2, "failed": 0}
     assert sorted(calls) == sorted([f"{BASE_URL}/", f"{BASE_URL}/guide/one", f"{BASE_URL}/guide/two"])
+
+
+def test_openapi_sources_and_operations_are_expanded_and_deduped_with_pages(tmp_path: Path) -> None:
+    inventory, specification = _write_openapi_inventory(tmp_path, include_page_collision=True)
+    calls: list[str] = []
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        calls.append(url)
+        if url.endswith("/openapi/widgets.json"):
+            return HttpResult(200, json.dumps(specification), url)
+        if url.endswith("/api/widgets/widgets/post-widgets"):
+            return HttpResult(
+                200,
+                "<html><body><main><h1>POST /widgets</h1><p>"
+                + ("Create a widget through this operation. " * 6)
+                + "</p></main></body></html>",
+                url,
+            )
+        return HttpResult(200, _html(0), url)
+
+    report = check_hosted_routes(
+        inventory_path=inventory,
+        repository_root=tmp_path,
+        base_url=BASE_URL,
+        expected_source_sha=SHA,
+        deployed_source_sha=SHA,
+        deployment_state="success",
+        expected_environment="staging - docs-vnext",
+        deployment_environment="staging - docs-vnext",
+        observed_base_url=BASE_URL,
+        fetcher=fetcher,
+    )
+
+    assert report["status"] == "passed"
+    assert report["targetSummary"] == {
+        "pageEntries": 1,
+        "uniquePageRoutes": 1,
+        "openapiSources": 1,
+        "openapiOperations": 2,
+        "requiredTargets": 3,
+    }
+    assert report["routeSummary"] == {"required": 3, "checked": 3, "passed": 3, "failed": 0}
+    assert calls.count(f"{BASE_URL}/api/widgets/widgets/list-widgets") == 1
+    assert sorted(calls) == sorted(
+        [
+            f"{BASE_URL}/",
+            f"{BASE_URL}/api/widgets/widgets/list-widgets",
+            f"{BASE_URL}/openapi/widgets.json",
+            f"{BASE_URL}/api/widgets/widgets/post-widgets",
+        ]
+    )
+
+
+def test_stale_hosted_openapi_source_fails_readiness(tmp_path: Path) -> None:
+    inventory, _specification = _write_openapi_inventory(tmp_path)
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        if url.endswith("/openapi/widgets.json"):
+            return HttpResult(200, json.dumps({"openapi": "3.1.0", "paths": {}}), url)
+        if url.endswith("/api/widgets/widgets/list-widgets"):
+            return HttpResult(
+                200,
+                "<html><body><main><h1>List widgets</h1><p>GET /widgets</p>"
+                + ("Current API operation content. " * 6)
+                + "</main></body></html>",
+                url,
+            )
+        if url.endswith("/api/widgets/widgets/post-widgets"):
+            return HttpResult(
+                200,
+                "<html><body><main><h1>POST /widgets</h1><p>"
+                + ("Current API operation content. " * 6)
+                + "</p></main></body></html>",
+                url,
+            )
+        return HttpResult(200, _html(0), url)
+
+    report = check_hosted_routes(
+        inventory_path=inventory,
+        repository_root=tmp_path,
+        base_url=BASE_URL,
+        expected_source_sha=SHA,
+        deployed_source_sha=SHA,
+        deployment_state="success",
+        expected_environment="staging - docs-vnext",
+        deployment_environment="staging - docs-vnext",
+        observed_base_url=BASE_URL,
+        fetcher=fetcher,
+    )
+
+    assert report["status"] == "failed"
+    assert report["diagnosticSummary"]["counts"] == {"stale_openapi_source": 1}
+    assert report["diagnostics"][0]["route"] == "/openapi/widgets.json"
+
+
+def test_repository_inventory_expands_expected_pages_and_openapi_operations(tmp_path: Path) -> None:
+    docs_dir = REPO_ROOT / "docs-vnext"
+    inventory = validate_navigation(docs_dir, docs_dir / "docs.json", base_docs_dir=docs_dir)
+    inventory_path = tmp_path / "inventory.json"
+    inventory_path.write_text(json.dumps(inventory), encoding="utf-8")
+
+    _inventory, targets, summary = load_targets(inventory_path, REPO_ROOT)
+
+    assert summary == {
+        "pageEntries": 527,
+        "uniquePageRoutes": 526,
+        "openapiSources": 2,
+        "openapiOperations": 123,
+        "requiredTargets": 651,
+    }
+    assert len(targets) == 651
+    routes = {target.route for target in targets}
+    assert "/openapi/openai-v1-stable.json" in routes
+    assert "/openapi/projects-stable.json" in routes
+    assert "/api-reference/openai-v1/batch/creates-and-executes-a-batch-from-an-uploaded-file-of-requests" in routes
+    assert "/api-reference/projects/datasets/patch-datasets-versions" in routes
 
 
 def test_route_failure_preserves_inventory_evidence(tmp_path: Path) -> None:
@@ -218,6 +376,78 @@ def test_cross_origin_route_redirect_fails_that_route(tmp_path: Path) -> None:
     assert report["status"] == "failed"
     assert report["diagnosticSummary"]["counts"] == {"cross_origin_redirect": 1}
     assert report["diagnostics"][0]["route"] == "/guide/two"
+
+
+def test_missing_host_configuration_blocks_before_inventory_or_http(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        calls.append(url)
+        raise AssertionError("HTTP must not run without hosted configuration")
+
+    report = check_hosted_routes(
+        inventory_path=tmp_path / "missing.json",
+        repository_root=tmp_path,
+        base_url="",
+        expected_source_sha=SHA,
+        deployed_source_sha=SHA,
+        deployment_state="success",
+        expected_environment="staging - docs-vnext",
+        deployment_environment="staging - docs-vnext",
+        observed_base_url="",
+        fetcher=fetcher,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["diagnosticSummary"]["counts"] == {"host_configuration_missing": 1}
+    assert calls == []
+
+
+def test_invalid_host_configuration_with_path_blocks(tmp_path: Path) -> None:
+    report = _run(tmp_path, lambda url, _timeout, _max_bytes: HttpResult(200, _html(0), url), base_url=f"{BASE_URL}/docs")
+
+    assert report["status"] == "blocked"
+    assert report["diagnosticSummary"]["counts"] == {"host_configuration_invalid": 1}
+
+
+def test_missing_deployment_environment_url_blocks_before_http(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        calls.append(url)
+        raise AssertionError("HTTP must not run without deployment environment_url")
+
+    report = _run(
+        tmp_path,
+        fetcher,
+        observed_base_url="",
+    )
+
+    assert report["status"] == "blocked"
+    assert report["diagnosticSummary"]["counts"] == {"deployment_url_missing": 1}
+    assert calls == []
+
+
+def test_normalized_deployment_origin_must_match_configured_origin(tmp_path: Path) -> None:
+    def fetcher(url: str, _timeout: float, _max_bytes: int) -> HttpResult:
+        index = 0 if url.endswith("/guide/one") else 1
+        return HttpResult(200, _html(index), url)
+
+    passed = _run(
+        tmp_path,
+        fetcher,
+        base_url="https://DOCS.example.test/",
+        observed_base_url="https://docs.example.test:443/deployment/status",
+    )
+    mismatched = _run(
+        tmp_path,
+        fetcher,
+        observed_base_url="https://other.example.test/",
+    )
+
+    assert passed["status"] == "passed"
+    assert mismatched["status"] == "blocked"
+    assert mismatched["diagnosticSummary"]["counts"] == {"deployment_url_mismatch": 1}
 
 
 def test_stale_deployment_blocks_before_route_requests(tmp_path: Path) -> None:
@@ -361,6 +591,7 @@ def test_workflow_runs_after_deployment_and_on_schedule_with_retained_diagnostic
     assert triggers["schedule"]
     assert "workflow_dispatch" in triggers
     assert workflow["permissions"] == {"contents": "read", "deployments": "read"}
+    assert workflow["env"]["DOCS_VNEXT_BASE_URL"] == "${{ vars.DOCS_VNEXT_BASE_URL }}"
 
     job = workflow["jobs"]["hosted-route-readiness"]
     assert "staging - docs-vnext" in job["if"]
@@ -389,3 +620,78 @@ def test_workflow_runs_after_deployment_and_on_schedule_with_retained_diagnostic
     assert "--expected-source-sha" in checker
     assert "--deployed-source-sha" in checker
     assert "--conflicting-base-url" in checker
+
+
+def test_intended_deployment_status_path_resolves_deployed_docs_tree(tmp_path: Path) -> None:
+    git = shutil.which("git")
+    bash_candidates = (
+        [
+            Path(os.environ.get("ProgramFiles", "")) / "Git" / "bin" / "bash.exe",
+            Path(git).parent.parent / "bin" / "bash.exe",
+        ]
+        if git and os.name == "nt"
+        else []
+    )
+    bash_candidates.append(Path(shutil.which("bash") or ""))
+    bash = next((candidate for candidate in bash_candidates if candidate.is_file()), None)
+    if bash is None:
+        raise AssertionError("bash is required to execute the workflow resolver")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    docs_dir = repo / "docs-vnext"
+    docs_dir.mkdir()
+    (docs_dir / "docs.json").write_text('{"navigation": {"groups": []}}\n', encoding="utf-8")
+    subprocess.run(["git", "add", "docs-vnext/docs.json"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "fixture"], cwd=repo, check=True, capture_output=True)
+    commit_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    tree_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD:docs-vnext"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["hosted-route-readiness"]["steps"]
+    resolver = next(step for step in steps if step.get("name") == "Resolve hosted deployment")["run"]
+    script = repo / "resolver.sh"
+    script.write_text("#!/usr/bin/env bash\ngh() { return 0; }\n" + resolver, encoding="utf-8", newline="\n")
+    output_path = tmp_path / "github-output"
+    env = {
+        **os.environ,
+        "GH_TOKEN": "test-token",
+        "GITHUB_REPOSITORY": "owner/repo",
+        "GITHUB_OUTPUT": output_path.as_posix(),
+        "DOCS_VNEXT_ENVIRONMENT": "staging - docs-vnext",
+        "DOCS_PRIMARY_ENVIRONMENT": "staging - docs",
+        "EVENT_NAME": "deployment_status",
+        "EVENT_ENVIRONMENT": "staging - docs-vnext",
+        "EVENT_SHA": commit_sha,
+        "EVENT_STATE": "success",
+        "EVENT_URL": BASE_URL,
+    }
+
+    subprocess.run([str(bash), script.as_posix()], cwd=repo, env=env, check=True, capture_output=True, text=True)
+
+    outputs = dict(
+        line.split("=", 1)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+    assert outputs["expected_sha"] == tree_sha
+    assert outputs["deployed_commit_sha"] == commit_sha
+    assert outputs["deployed_sha"] == tree_sha
+    assert outputs["environment"] == "staging - docs-vnext"
+    assert outputs["state"] == "success"
+    assert outputs["observed_url"] == BASE_URL


### PR DESCRIPTION
## Summary

- consume the complete validated docs-vnext inventory: 527 page entries / 526 unique page routes, 2 OpenAPI source files, and 123 generated OpenAPI operation pages
- probe 651 unique hosted targets after deduplication across page and OpenAPI routes
- fail closed for missing/invalid hosted configuration, absent/stale/failed deployment provenance, missing or mismatched deployment `environment_url`, shared-host overwrite, host outages, non-2xx/404 responses, empty pages, stale page/OpenAPI content, cross-origin redirects, oversized responses, and protocol/read/decode errors
- run on terminal `deployment_status` events from both the canonical and intended docs-vnext environments, plus daily schedule and manual dispatch
- select only `ref=main` deployment records for both environments, so newer previews cannot mask stale or shared-origin main deployments
- compare deployed and current source at the `docs-vnext` Git tree level
- retain bounded JSON/Markdown diagnostics and the consumed route inventory for 30 days

## Deployment-boundary evidence

GitHub Deployments shows two Mintlify main environments targeting the same origin, `https://hobbyist-e43fa225.mintlify.app`:

- `staging - docs-vnext`: last successful main deployment `a95a92ae787dc46e912b7fdfe3ab166da4ea54f2` on 2026-03-30; deployed docs-vnext tree `de5bc582a6f51f4d0824bc20d11d07156526fbc9`
- `staging - docs`: continued deploying canonical `docs/`; observed main deployment `cb8bb6fdeee90d47c6ffe943ddfc02d3c2af0689` on 2026-07-28 to the same origin
- current `main` docs-vnext tree: `c34c324b245a9f85afd468c8ac696ff6e04db1ed`

The first docs-vnext commit after the last successful deployment, `c16ae9f8e78c855418ec89135006b00e58a260db`, received `No eligible deployments found for changes`. Canonical docs deployments then continued overwriting the shared host.

The workflow reacts to both environments. Queries explicitly request `ref=main`; an executable fixture proves a newer preview with a distinct URL is ignored and the older colliding main deployments still block.

## Live evidence

A forced-current provenance run, used only to enumerate hosted behavior, consumed the validated inventory and checked all 651 unique targets:

- 566 `route_missing`
- 70 `route_unavailable`
- 11 `stale_content`
- 1 `route_response_invalid`
- 3 passed

With actual provenance, readiness stops before HTTP with `stale_deployment` and `deployment_host_collision`. With `DOCS_VNEXT_BASE_URL` unset, it stops with `host_configuration_missing`.

## Validation

- `python -m pytest tests/test_check_hosted_docs_routes.py tests/test_validate_docs_vnext_navigation.py -q` — 63 passed
- executable resolver fixtures run the exact workflow shell for direct docs-vnext events and preview-vs-main collision selection
- transport tests cover `IncompleteRead`, pre-response `BadStatusLine`, unknown charset `LookupError`, response overflow, and bounded executor diagnostics
- `ruff check scripts/check_hosted_docs_routes.py tests/test_check_hosted_docs_routes.py`
- `python -m py_compile scripts/check_hosted_docs_routes.py`
- scoped `git diff --check`
- independent final diff review: no significant issues

## External Mintlify owner action

No documented repository/API deployment path is available without adding credentials. This repository has no Mintlify deploy secret or variable, and the documented Mintlify CLI has no deployment command. This PR does not guess credentials or alter Mintlify settings.

An authenticated Mintlify owner must set the docs-vnext project Git Settings to:

1. Repository `nicholasdbrady/foundry-docs`
2. Deployment branch `main`
3. **docs.json is in a subdirectory** enabled
4. Content directory `/docs-vnext` (no trailing slash)
5. A domain/origin distinct from canonical `staging - docs`

Then set repository variable `DOCS_VNEXT_BASE_URL` to that exact HTTPS origin with no path, query, or fragment. All trigger paths consume this variable and require the deployment `environment_url` to correlate to the same normalized origin.

Saving Git Settings is the required genuinely new deployment trigger. If save does not deploy, use a fresh `docs-vnext/**` push to `main` or an authenticated dashboard manual deployment; never rerun an old deployment.

## Post-merge proof required

The new terminal docs-vnext deployment must trigger `docs-vnext hosted route readiness`. Its retained artifact must show current docs-vnext tree provenance, exact distinct origin, no collision, inventory counts of 527 / 526 / 2 / 123, and all 651 unique targets passed.

Refs #634