### PR TITLE
Fix docs-vnext sync credential preflight

### DIFF
--- a/.github/workflows/docs-vnext-sync-batches.yml
+++ b/.github/workflows/docs-vnext-sync-batches.yml
@@ -14,8 +14,8 @@ on:
 
 permissions:
   actions: read
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: docs-vnext-bounded-baseline-sync
@@ -28,20 +28,85 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Initialize failure checkpoint
+        env:
+          CHECKPOINT_PATH: ${{ runner.temp }}/docs-vnext-sync/checkpoint.json
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$CHECKPOINT_PATH")"
+          python3 - "$CHECKPOINT_PATH" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          checkpoint = {
+              "schemaVersion": 1,
+              "status": "failed",
+              "manifest": {"sha256": None, "runId": None},
+              "limits": {"maxFiles": 50, "maxPayloadBytes": 41943040},
+              "summary": {"completed": 0, "failed": 0, "pending": 0},
+              "diagnostics": ["Workflow failed before the batch runner initialized."],
+              "batches": [],
+          }
+          path.write_text(json.dumps(checkpoint, indent=2, sort_keys=True) + "\n")
+          PY
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.AZURE_AI_DOCS_PR_TOKEN || github.token }}
+          persist-credentials: false
+          token: ${{ github.token }}
 
-      - name: Require pull-request automation token
+      - name: Preflight pull-request automation token
         env:
+          CHECKPOINT_PATH: ${{ runner.temp }}/docs-vnext-sync/checkpoint.json
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EXPECTED_OWNER: ${{ github.repository_owner }}
+          REPOSITORY: ${{ github.repository }}
           SYNC_TOKEN: ${{ secrets.AZURE_AI_DOCS_PR_TOKEN }}
         run: |
           set -euo pipefail
-          if [[ -z "$SYNC_TOKEN" ]]; then
-            echo "::error::AZURE_AI_DOCS_PR_TOKEN is required so automation-created PRs trigger checks."
+          fail_preflight() {
+            local message="$1"
+            python3 - "$CHECKPOINT_PATH" "$message" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          checkpoint = json.loads(path.read_text())
+          checkpoint["diagnostics"] = [sys.argv[2]]
+          path.write_text(json.dumps(checkpoint, indent=2, sort_keys=True) + "\n")
+          PY
+            echo "::error::$message"
             exit 1
+          }
+          if [[ -z "$SYNC_TOKEN" ]]; then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN is absent. Rotate it to a token owned by $EXPECTED_OWNER with repository contents and pull-request write access."
+          fi
+          if ! token_owner=$(GH_TOKEN="$SYNC_TOKEN" gh api user --jq .login 2>/dev/null); then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN is invalid or expired. Rotate the $EXPECTED_OWNER-owned secret."
+          fi
+          if [[ "$token_owner" != "$EXPECTED_OWNER" ]]; then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN authenticates as $token_owner; rotate it to a token owned by $EXPECTED_OWNER."
+          fi
+          if ! push_permission=$(GH_TOKEN="$SYNC_TOKEN" gh api "repos/$REPOSITORY" \
+            --jq '.permissions.push' 2>/dev/null); then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN cannot read permission metadata for $REPOSITORY."
+          fi
+          if [[ "$push_permission" != "true" ]]; then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN does not grant push access to $REPOSITORY."
+          fi
+          if ! GH_TOKEN="$SYNC_TOKEN" gh api --method GET \
+            "repos/$REPOSITORY/pulls?state=open&per_page=1" >/dev/null; then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN cannot access pull requests in $REPOSITORY."
+          fi
+          GH_TOKEN="$SYNC_TOKEN" gh auth setup-git
+          if ! GH_TOKEN="$SYNC_TOKEN" git ls-remote --exit-code origin \
+            "refs/heads/$DEFAULT_BRANCH" >/dev/null; then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN is not usable for Git access to $REPOSITORY. Rotate the $EXPECTED_OWNER-owned secret."
           fi
 
       - name: Resolve retained manifest run
@@ -50,7 +115,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_RUN_ID: ${{ inputs.manifest_run_id }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
-          GH_TOKEN: ${{ secrets.AZURE_AI_DOCS_PR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           run_id="$INPUT_RUN_ID"
@@ -73,7 +138,7 @@ jobs:
 
       - name: Download retained schema-v2 manifest
         env:
-          GH_TOKEN: ${{ secrets.AZURE_AI_DOCS_PR_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           MANIFEST_RUN_ID: ${{ steps.manifest.outputs.run-id }}
         run: |
           set -euo pipefail

--- a/.github/workflows/docs-vnext-sync-batches.yml
+++ b/.github/workflows/docs-vnext-sync-batches.yml
@@ -108,6 +108,41 @@ jobs:
             "refs/heads/$DEFAULT_BRANCH" >/dev/null; then
             fail_preflight "AZURE_AI_DOCS_PR_TOKEN is not usable for Git access to $REPOSITORY. Rotate the $EXPECTED_OWNER-owned secret."
           fi
+          preflight_ref="refs/heads/automation/docs-vnext-sync/preflight-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          if ! GH_TOKEN="$SYNC_TOKEN" git push --dry-run origin \
+            "HEAD:$preflight_ref" >/dev/null 2>&1; then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN cannot push branches to $REPOSITORY. Grant repository contents write access."
+          fi
+          pr_probe="$RUNNER_TEMP/docs-vnext-sync/pr-write-probe.json"
+          pr_response="$RUNNER_TEMP/docs-vnext-sync/pr-write-response.txt"
+          python3 - "$pr_probe" "$EXPECTED_OWNER" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          path = pathlib.Path(sys.argv[1])
+          suffix = f"{sys.argv[3]}-{sys.argv[4]}"
+          probe = {
+              "title": f"docs-vnext sync permission probe {suffix}",
+              "head": f"{sys.argv[2]}:automation/docs-vnext-sync/nonexistent-{suffix}",
+              "base": f"docs-vnext-sync-nonexistent-base-{suffix}",
+              "body": "This request must fail validation and must not create a pull request.",
+          }
+          path.write_text(json.dumps(probe))
+          PY
+          set +e
+          GH_TOKEN="$SYNC_TOKEN" gh api --method POST "repos/$REPOSITORY/pulls" \
+            --input "$pr_probe" --include >"$pr_response" 2>/dev/null
+          pr_probe_exit=$?
+          set -e
+          pr_probe_status=$(awk '
+            toupper($1) ~ /^HTTP\// { status=$2 }
+            END { print status }
+          ' "$pr_response")
+          rm -f "$pr_probe" "$pr_response"
+          if [[ "$pr_probe_exit" -eq 0 || "$pr_probe_status" != "422" ]]; then
+            fail_preflight "AZURE_AI_DOCS_PR_TOKEN pull-request write probe failed with HTTP ${pr_probe_status:-unknown}. Grant pull-request write access."
+          fi
 
       - name: Resolve retained manifest run
         id: manifest

--- a/.github/workflows/docs-vnext-sync-batches.yml
+++ b/.github/workflows/docs-vnext-sync-batches.yml
@@ -68,6 +68,7 @@ jobs:
           SYNC_TOKEN: ${{ secrets.AZURE_AI_DOCS_PR_TOKEN }}
         run: |
           set -euo pipefail
+          umask 077
           fail_preflight() {
             local message="$1"
             python3 - "$CHECKPOINT_PATH" "$message" <<'PY'

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -1964,6 +1964,7 @@ def test_workflow_consumes_retained_manifest_and_always_retains_checkpoint():
     assert checkout["token"] == "${{ github.token }}"
     assert checkout["persist-credentials"] == "false"
     preflight = steps["Preflight pull-request automation token"]["run"]
+    assert "umask 077" in preflight
     assert "gh api user --jq .login" in preflight
     assert "--jq '.permissions.push'" in preflight
     assert '[[ "$push_permission" != "true" ]]' in preflight
@@ -1976,7 +1977,9 @@ def test_workflow_consumes_retained_manifest_and_always_retains_checkpoint():
     assert 'gh api --method POST "repos/$REPOSITORY/pulls"' in preflight
     assert '--input "$pr_probe" --include' in preflight
     assert '"$pr_probe_status" != "422"' in preflight
+    assert '"$pr_probe_exit" -eq 0' in preflight
     assert 'rm -f "$pr_probe" "$pr_response"' in preflight
+    assert 'echo "$SYNC_TOKEN"' not in preflight
     assert "checkpoint[\"diagnostics\"] = [sys.argv[2]]" in preflight
     assert steps["Resolve retained manifest run"]["env"]["GH_TOKEN"] == "${{ github.token }}"
     assert steps["Download retained schema-v2 manifest"]["env"]["GH_TOKEN"] == "${{ github.token }}"

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -1947,9 +1947,36 @@ def test_workflow_consumes_retained_manifest_and_always_retains_checkpoint():
     ]
     assert workflow["permissions"] == {
         "actions": "read",
-        "contents": "write",
-        "pull-requests": "write",
+        "contents": "read",
+        "pull-requests": "read",
     }
+    step_names = [step["name"] for step in job["steps"]]
+    assert step_names[:3] == [
+        "Initialize failure checkpoint",
+        "Checkout repository",
+        "Preflight pull-request automation token",
+    ]
+    initialize_step = steps["Initialize failure checkpoint"]["run"]
+    assert '"status": "failed"' in initialize_step
+    assert '"maxFiles": 50' in initialize_step
+    checkout = steps["Checkout repository"]["with"]
+    assert checkout["token"] == "${{ github.token }}"
+    assert checkout["persist-credentials"] == "false"
+    preflight = steps["Preflight pull-request automation token"]["run"]
+    assert "gh api user --jq .login" in preflight
+    assert "--jq '.permissions.push'" in preflight
+    assert '[[ "$push_permission" != "true" ]]' in preflight
+    assert "--jq -e" not in preflight
+    assert "pulls?state=open&per_page=1" in preflight
+    assert "gh auth setup-git" in preflight
+    assert "git ls-remote --exit-code origin" in preflight
+    assert "checkpoint[\"diagnostics\"] = [sys.argv[2]]" in preflight
+    assert steps["Resolve retained manifest run"]["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert steps["Download retained schema-v2 manifest"]["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert (
+        steps["Apply resumable bounded batches"]["env"]["GH_TOKEN"]
+        == "${{ secrets.AZURE_AI_DOCS_PR_TOKEN }}"
+    )
     assert "docs-vnext-sync-manifest-$MANIFEST_RUN_ID" in steps[
         "Download retained schema-v2 manifest"
     ]["run"]

--- a/tests/test_docs_vnext_sync_batches.py
+++ b/tests/test_docs_vnext_sync_batches.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -1970,6 +1971,12 @@ def test_workflow_consumes_retained_manifest_and_always_retains_checkpoint():
     assert "pulls?state=open&per_page=1" in preflight
     assert "gh auth setup-git" in preflight
     assert "git ls-remote --exit-code origin" in preflight
+    assert "git push --dry-run origin" in preflight
+    assert "HEAD:$preflight_ref" in preflight
+    assert 'gh api --method POST "repos/$REPOSITORY/pulls"' in preflight
+    assert '--input "$pr_probe" --include' in preflight
+    assert '"$pr_probe_status" != "422"' in preflight
+    assert 'rm -f "$pr_probe" "$pr_response"' in preflight
     assert "checkpoint[\"diagnostics\"] = [sys.argv[2]]" in preflight
     assert steps["Resolve retained manifest run"]["env"]["GH_TOKEN"] == "${{ github.token }}"
     assert steps["Download retained schema-v2 manifest"]["env"]["GH_TOKEN"] == "${{ github.token }}"
@@ -1996,3 +2003,113 @@ def test_workflow_consumes_retained_manifest_and_always_retains_checkpoint():
     )
     producer_upload = producer["jobs"]["manifest"]["steps"][-1]
     assert producer_upload["with"]["retention-days"] == "90"
+
+
+@pytest.mark.skipif(
+    os.name == "nt" or shutil.which("bash") is None,
+    reason="Executable workflow shell contract requires POSIX bash",
+)
+def test_preflight_write_probes_are_non_mutating_and_accept_expected_422(tmp_path):
+    workflow = yaml.load(
+        (REPO_ROOT / ".github" / "workflows" / "docs-vnext-sync-batches.yml").read_text(
+            encoding="utf-8"
+        ),
+        Loader=yaml.BaseLoader,
+    )
+    steps = {step["name"]: step for step in workflow["jobs"]["apply-batches"]["steps"]}
+    script = tmp_path / "preflight.sh"
+    script.write_text(
+        steps["Preflight pull-request automation token"]["run"],
+        encoding="utf-8",
+        newline="\n",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log = tmp_path / "probe.log"
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'gh %s\\n' "$*" >> "$PROBE_LOG"
+if [[ "$1" == "api" && "$2" == "user" ]]; then
+  printf '%s\\n' "$EXPECTED_OWNER"
+elif [[ "$1" == "api" && "$2" == "repos/$REPOSITORY" ]]; then
+  printf 'true\\n'
+elif [[ "$1" == "api" && "$2" == "--method" && "$3" == "POST" ]]; then
+  printf 'HTTP/2 422 Unprocessable Entity\\r\\ncontent-type: application/json\\r\\n\\r\\n{}\\n'
+  exit 1
+elif [[ "$1" == "api" ]]; then
+  printf '[]\\n'
+elif [[ "$1" == "auth" && "$2" == "setup-git" ]]; then
+  exit 0
+else
+  exit 2
+fi
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf 'git %s\\n' "$*" >> "$PROBE_LOG"
+if [[ "$1" == "ls-remote" ]]; then
+  printf '%040d\\trefs/heads/main\\n' 1
+elif [[ "$1" == "push" && "$2" == "--dry-run" ]]; then
+  [[ "$4" == HEAD:refs/heads/automation/docs-vnext-sync/preflight-* ]]
+else
+  exit 2
+fi
+""",
+        encoding="utf-8",
+        newline="\n",
+    )
+    fake_gh.chmod(0o755)
+    fake_git.chmod(0o755)
+    checkpoint = tmp_path / "docs-vnext-sync" / "checkpoint.json"
+    checkpoint.parent.mkdir()
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "status": "failed",
+                "diagnostics": ["initial"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "CHECKPOINT_PATH": str(checkpoint),
+            "DEFAULT_BRANCH": "main",
+            "EXPECTED_OWNER": "nicholasdbrady",
+            "GITHUB_RUN_ATTEMPT": "1",
+            "GITHUB_RUN_ID": "12345",
+            "PATH": f"{fake_bin}{os.pathsep}{env['PATH']}",
+            "PROBE_LOG": str(log),
+            "REPOSITORY": "nicholasdbrady/foundry-docs",
+            "RUNNER_TEMP": str(tmp_path),
+            "SYNC_TOKEN": "test-token-not-logged",
+        }
+    )
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+    probe_log = log.read_text(encoding="utf-8")
+    assert "git push --dry-run origin HEAD:refs/heads/automation/docs-vnext-sync/preflight-12345-1" in probe_log
+    assert "gh api --method POST repos/nicholasdbrady/foundry-docs/pulls" in probe_log
+    assert "test-token-not-logged" not in probe_log
+    assert not (tmp_path / "docs-vnext-sync" / "pr-write-probe.json").exists()
+    assert not (tmp_path / "docs-vnext-sync" / "pr-write-response.txt").exists()


### PR DESCRIPTION
## Summary

Corrective follow-up to #635 after real-run evidence from parent `30417319787` / consumer `30417333048`.

- initialize a bounded schema-v1 failure checkpoint before checkout
- use `${{ github.token }}` with non-persistent credentials for checkout and manifest reads
- preflight owner-scoped `AZURE_AI_DOCS_PR_TOKEN` after checkout without logging it
- prove Git write via `git push --dry-run` to a unique nonexistent automation preflight ref
- prove PR write via an impossible unique create-PR request that must fail with HTTP 422 validation; all other statuses fail closed
- remove probe files/responses, retain sanitized checkpoint diagnostics, and configure the PAT only for deterministic mutation

## Validation

- focused pytest — 80 passed, 2 platform-specific skipped on Windows
- targeted Ruff — passed
- executable fake-command test proves dry-run ref push, expected 422 PR probe, no token output, no probe files, and no mutation
- independent final review — no findings
- traditional YAML only; gh-aw compilation is not applicable

## Current blocker

Rotate `AZURE_AI_DOCS_PR_TOKEN` to a token owned by `nicholasdbrady` with contents and pull-request write access. After merge and rotation, trigger a genuinely new first manifest run; do not start the second proof run until its consumer completes and is verified.

Related to #635.