### PR TITLE
Bound Copilot evaluation process output capture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "azure-monitor-opentelemetry-exporter>=1.0.0b48",
     "opentelemetry-sdk>=1.39.0,<1.40",
     "opentelemetry-api>=1.39.0,<1.40",
+    "psutil>=7.0.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -21,9 +21,11 @@ import json
 import math
 import os
 import re
+import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -105,11 +107,15 @@ MAX_STDERR_EXCERPT = 4_000
 MAX_STDOUT_PARSE_BYTES = 4_000_000
 MAX_STDOUT_PARSE_LINES = 500
 MAX_STDOUT_LINE_BYTES = 64_000
+MAX_STDOUT_CAPTURE_BYTES = MAX_STDOUT_PARSE_BYTES + MAX_STDOUT_LINE_BYTES + 1
+MAX_STDERR_CAPTURE_BYTES = 64_000
+MAX_PIPE_DRAIN_SECONDS = 0.5
 MAX_IDENTIFIER_TEXT = 256
 MAX_USAGE_METRIC = 10**15
 MAX_ENCODED_TOKEN_BYTES = 8_192
 MAX_ENCODED_DECODE_ITERATIONS = 8
 MAX_ENCODED_DECODE_SECONDS = 0.02
+_ORIGINAL_SUBPROCESS_RUN = subprocess.run
 _SECRET_KEY_PATTERN = re.compile(r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I)
 _AUTHORIZATION_HEADER_PATTERN = re.compile(
     r"(?im)(authorization\s*:\s*)[^\r\n]+(?:\r?\n[ \t]+[^\r\n]*)*"
@@ -784,6 +790,272 @@ def _bounded_stdout_excerpt(value: str | bytes | None) -> tuple[str, bool]:
     return excerpt, per_line_truncated or final_truncated
 
 
+def _drain_bounded_pipe(fd: int, sink: bytearray, max_bytes: int) -> None:
+    """Drain a process pipe while retaining only a bounded byte projection."""
+    try:
+        while chunk := os.read(fd, 64 * 1024):
+            remaining = max_bytes - len(sink)
+            if remaining > 0:
+                sink.extend(chunk[:remaining])
+    except OSError:
+        pass
+
+
+def _drain_bounded_stream(stream: object, sink: bytearray, max_bytes: int) -> None:
+    """Drain a process stream while retaining only a bounded byte projection."""
+    while chunk := stream.read(64 * 1024):
+        remaining = max_bytes - len(sink)
+        if remaining > 0:
+            sink.extend(chunk[:remaining])
+
+
+def _run_process_with_injected_runner(
+    cmd: list[str],
+    *,
+    timeout: int,
+    cwd: str,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess:
+    """Exercise the bounded stream contract through an injected test runner."""
+    stdout_read_fd, stdout_write_fd = os.pipe()
+    stderr_read_fd, stderr_write_fd = os.pipe()
+    stdout_projection = bytearray()
+    stderr_projection = bytearray()
+
+    with (
+        os.fdopen(stdout_write_fd, "wb", buffering=0) as stdout_writer,
+        os.fdopen(stderr_write_fd, "wb", buffering=0) as stderr_writer,
+    ):
+        stdout_thread = threading.Thread(
+            target=_drain_bounded_pipe,
+            args=(stdout_read_fd, stdout_projection, MAX_STDOUT_CAPTURE_BYTES),
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            target=_drain_bounded_pipe,
+            args=(stderr_read_fd, stderr_projection, MAX_STDERR_CAPTURE_BYTES),
+            daemon=True,
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+        timeout_error: subprocess.TimeoutExpired | None = None
+        try:
+            proc = subprocess.run(
+                cmd,
+                stdout=stdout_writer,
+                stderr=stderr_writer,
+                timeout=timeout,
+                cwd=cwd,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            timeout_error = exc
+        finally:
+            stdout_writer.close()
+            stderr_writer.close()
+            for thread in (stdout_thread, stderr_thread):
+                thread.join()
+            for fd in (stdout_read_fd, stderr_read_fd):
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+        if timeout_error is not None:
+            if timeout_error.stdout is None:
+                timeout_error.stdout = bytes(stdout_projection)
+            if timeout_error.stderr is None:
+                timeout_error.stderr = bytes(stderr_projection)
+            raise timeout_error
+
+    if proc.stdout is None:
+        proc.stdout = bytes(stdout_projection)
+    if proc.stderr is None:
+        proc.stderr = bytes(stderr_projection)
+    return proc
+
+
+def _terminate_process_tree(proc: subprocess.Popen) -> None:
+    """Terminate the process and descendants that can retain output pipes."""
+    if os.name == "nt":
+        completed = _ORIGINAL_SUBPROCESS_RUN(
+            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if completed.returncode != 0 and proc.poll() is None:
+            proc.kill()
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        if proc.poll() is None:
+            proc.kill()
+
+
+def _assign_windows_kill_on_close_job(proc: subprocess.Popen) -> int | None:
+    """Own the Windows process tree so closing the job terminates descendants."""
+    if os.name != "nt":
+        return None
+
+    import ctypes
+    from ctypes import wintypes
+
+    class IO_COUNTERS(ctypes.Structure):
+        _fields_ = [
+            ("ReadOperationCount", ctypes.c_ulonglong),
+            ("WriteOperationCount", ctypes.c_ulonglong),
+            ("OtherOperationCount", ctypes.c_ulonglong),
+            ("ReadTransferCount", ctypes.c_ulonglong),
+            ("WriteTransferCount", ctypes.c_ulonglong),
+            ("OtherTransferCount", ctypes.c_ulonglong),
+        ]
+
+    class JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("PerProcessUserTimeLimit", ctypes.c_longlong),
+            ("PerJobUserTimeLimit", ctypes.c_longlong),
+            ("LimitFlags", wintypes.DWORD),
+            ("MinimumWorkingSetSize", ctypes.c_size_t),
+            ("MaximumWorkingSetSize", ctypes.c_size_t),
+            ("ActiveProcessLimit", wintypes.DWORD),
+            ("Affinity", ctypes.c_size_t),
+            ("PriorityClass", wintypes.DWORD),
+            ("SchedulingClass", wintypes.DWORD),
+        ]
+
+    class JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+        _fields_ = [
+            ("BasicLimitInformation", JOBOBJECT_BASIC_LIMIT_INFORMATION),
+            ("IoInfo", IO_COUNTERS),
+            ("ProcessMemoryLimit", ctypes.c_size_t),
+            ("JobMemoryLimit", ctypes.c_size_t),
+            ("PeakProcessMemoryUsed", ctypes.c_size_t),
+            ("PeakJobMemoryUsed", ctypes.c_size_t),
+        ]
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+    kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+    kernel32.SetInformationJobObject.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    kernel32.SetInformationJobObject.restype = wintypes.BOOL
+    kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+    kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    job = kernel32.CreateJobObjectW(None, None)
+    if not job:
+        raise ctypes.WinError(ctypes.get_last_error())
+    limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+    limits.BasicLimitInformation.LimitFlags = 0x00002000
+    if not kernel32.SetInformationJobObject(
+        job,
+        9,
+        ctypes.byref(limits),
+        ctypes.sizeof(limits),
+    ):
+        error = ctypes.WinError(ctypes.get_last_error())
+        kernel32.CloseHandle(job)
+        raise error
+    if not kernel32.AssignProcessToJobObject(job, wintypes.HANDLE(proc._handle)):
+        error = ctypes.WinError(ctypes.get_last_error())
+        kernel32.CloseHandle(job)
+        raise error
+    return int(job)
+
+
+def _close_windows_job(job: int | None) -> None:
+    if job is None:
+        return
+    import ctypes
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    if not kernel32.CloseHandle(wintypes.HANDLE(job)):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _run_process_bounded(
+    cmd: list[str],
+    *,
+    timeout: int,
+    cwd: str,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess:
+    """Run a process while bounding retained stdout and stderr in memory."""
+    if subprocess.run is not _ORIGINAL_SUBPROCESS_RUN:
+        return _run_process_with_injected_runner(cmd, timeout=timeout, cwd=cwd, env=env)
+
+    creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=cwd,
+        env=env,
+        start_new_session=os.name != "nt",
+        creationflags=creationflags,
+    )
+    try:
+        windows_job = _assign_windows_kill_on_close_job(proc)
+    except OSError:
+        proc.kill()
+        proc.wait()
+        proc.stdout.close()
+        proc.stderr.close()
+        raise
+    stdout_projection = bytearray()
+    stderr_projection = bytearray()
+    stdout_thread = threading.Thread(
+        target=_drain_bounded_stream,
+        args=(proc.stdout, stdout_projection, MAX_STDOUT_CAPTURE_BYTES),
+        daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=_drain_bounded_stream,
+        args=(proc.stderr, stderr_projection, MAX_STDERR_CAPTURE_BYTES),
+        daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+    timed_out = False
+    try:
+        returncode = proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        if windows_job is not None:
+            _close_windows_job(windows_job)
+            windows_job = None
+        else:
+            _terminate_process_tree(proc)
+        returncode = proc.wait()
+    finally:
+        if windows_job is not None:
+            _close_windows_job(windows_job)
+        elif os.name != "nt" and not timed_out:
+            _terminate_process_tree(proc)
+        deadline = time.monotonic() + MAX_PIPE_DRAIN_SECONDS
+        for thread in (stdout_thread, stderr_thread):
+            thread.join(max(0.0, deadline - time.monotonic()))
+        proc.stdout.close()
+        proc.stderr.close()
+
+    stdout = bytes(stdout_projection)
+    stderr = bytes(stderr_projection)
+    if timed_out:
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout, output=stdout, stderr=stderr)
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
 def _bounded_event_lines(value: str | bytes | None) -> tuple[list[tuple[int, str]], list[str], bool]:
     """Bound bytes, lines, and per-line size before any JSON parsing."""
     is_bytes = isinstance(value, bytes)
@@ -1271,19 +1543,17 @@ def run_single_eval(
             process_env = os.environ.copy()
             process_env["COPILOT_HOME"] = isolated_home
 
-            proc = subprocess.run(
+            proc = _run_process_bounded(
                 cmd,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
                 timeout=timeout,
                 cwd=isolated_home,
                 env=process_env,
             )
+            proc_stdout = proc.stdout
+            proc_stderr = proc.stderr
 
         elapsed = time.monotonic() - start_time
-        parsed = parse_event_stream(_coerce_process_text(proc.stdout))
+        parsed = parse_event_stream(proc_stdout)
         response = parsed["response"]
         evidence_valid, failure_reason, azure_live_query_proven = validate_row_evidence(
             parsed,
@@ -1307,7 +1577,7 @@ def run_single_eval(
 
         result.update({
             "response": response,
-            "stderr": _bounded_excerpt(proc.stderr, MAX_STDERR_EXCERPT)[0],
+            "stderr": _bounded_excerpt(proc_stderr, MAX_STDERR_EXCERPT)[0],
             "exit_code": proc.returncode,
             "response_time_seconds": round(elapsed, 2),
             "status": status,
@@ -1328,8 +1598,8 @@ def run_single_eval(
             "event_parse_error": parsed["parse_error"],
             "diagnostics": _build_diagnostics(
                 parsed,
-                proc.stdout,
-                proc.stderr,
+                proc_stdout,
+                proc_stderr,
                 preserve_stdout=status != "success",
             ),
         })

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -31,6 +31,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import unquote_plus, urlsplit, urlunsplit
 
+import psutil
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SCENARIOS_FILE = PROJECT_ROOT / "tests" / "docs_eval_scenarios.json"
 RESULTS_DIR = PROJECT_ROOT / "tests" / "eval_results"
@@ -109,13 +111,14 @@ MAX_STDOUT_PARSE_LINES = 500
 MAX_STDOUT_LINE_BYTES = 64_000
 MAX_STDOUT_CAPTURE_BYTES = MAX_STDOUT_PARSE_BYTES + MAX_STDOUT_LINE_BYTES + 1
 MAX_STDERR_CAPTURE_BYTES = 64_000
-MAX_PIPE_DRAIN_SECONDS = 0.5
+MAX_PROCESS_CLEANUP_SECONDS = 2.0
+DESCENDANT_POLL_SECONDS = 0.01
 MAX_IDENTIFIER_TEXT = 256
 MAX_USAGE_METRIC = 10**15
 MAX_ENCODED_TOKEN_BYTES = 8_192
 MAX_ENCODED_DECODE_ITERATIONS = 8
 MAX_ENCODED_DECODE_SECONDS = 0.02
-_ORIGINAL_SUBPROCESS_RUN = subprocess.run
+_PROCESS_FACTORY = subprocess.Popen
 _SECRET_KEY_PATTERN = re.compile(r"(?:api[_-]?key|authorization|credential|password|secret|token)", re.I)
 _AUTHORIZATION_HEADER_PATTERN = re.compile(
     r"(?im)(authorization\s*:\s*)[^\r\n]+(?:\r?\n[ \t]+[^\r\n]*)*"
@@ -219,6 +222,7 @@ def build_mcp_config(server_config: dict, require_azure: bool = False) -> tuple[
         mcp_server = {
             "type": "http",
             "url": config["url"],
+            "deferTools": "never",
             "tools": ["*"],
         }
     elif server_config["type"] == "stdio":
@@ -226,6 +230,7 @@ def build_mcp_config(server_config: dict, require_azure: bool = False) -> tuple[
             "type": "local",
             "command": config["command"],
             "args": list(config.get("args", [])),
+            "deferTools": "never",
             "tools": ["*"],
         }
     else:
@@ -818,99 +823,106 @@ def _drain_bounded_pipe(fd: int, sink: bytearray, max_bytes: int) -> None:
                 sink.extend(chunk[:remaining])
     except OSError:
         pass
-
-
-def _drain_bounded_stream(stream: object, sink: bytearray, max_bytes: int) -> None:
-    """Drain a process stream while retaining only a bounded byte projection."""
-    while chunk := stream.read(64 * 1024):
-        remaining = max_bytes - len(sink)
-        if remaining > 0:
-            sink.extend(chunk[:remaining])
-
-
-def _run_process_with_injected_runner(
-    cmd: list[str],
-    *,
-    timeout: int,
-    cwd: str,
-    env: dict[str, str],
-) -> subprocess.CompletedProcess:
-    """Exercise the bounded stream contract through an injected test runner."""
-    stdout_read_fd, stdout_write_fd = os.pipe()
-    stderr_read_fd, stderr_write_fd = os.pipe()
-    stdout_projection = bytearray()
-    stderr_projection = bytearray()
-
-    with (
-        os.fdopen(stdout_write_fd, "wb", buffering=0) as stdout_writer,
-        os.fdopen(stderr_write_fd, "wb", buffering=0) as stderr_writer,
-    ):
-        stdout_thread = threading.Thread(
-            target=_drain_bounded_pipe,
-            args=(stdout_read_fd, stdout_projection, MAX_STDOUT_CAPTURE_BYTES),
-            daemon=True,
-        )
-        stderr_thread = threading.Thread(
-            target=_drain_bounded_pipe,
-            args=(stderr_read_fd, stderr_projection, MAX_STDERR_CAPTURE_BYTES),
-            daemon=True,
-        )
-        stdout_thread.start()
-        stderr_thread.start()
-        timeout_error: subprocess.TimeoutExpired | None = None
+    finally:
         try:
-            proc = subprocess.run(
-                cmd,
-                stdout=stdout_writer,
-                stderr=stderr_writer,
-                timeout=timeout,
-                cwd=cwd,
-                env=env,
-            )
-        except subprocess.TimeoutExpired as exc:
-            timeout_error = exc
-        finally:
-            stdout_writer.close()
-            stderr_writer.close()
-            for thread in (stdout_thread, stderr_thread):
-                thread.join()
-            for fd in (stdout_read_fd, stderr_read_fd):
-                try:
-                    os.close(fd)
-                except OSError:
-                    pass
-
-        if timeout_error is not None:
-            if timeout_error.stdout is None:
-                timeout_error.stdout = bytes(stdout_projection)
-            if timeout_error.stderr is None:
-                timeout_error.stderr = bytes(stderr_projection)
-            raise timeout_error
-
-    if proc.stdout is None:
-        proc.stdout = bytes(stdout_projection)
-    if proc.stderr is None:
-        proc.stderr = bytes(stderr_projection)
-    return proc
+            os.close(fd)
+        except OSError:
+            pass
 
 
-def _terminate_process_tree(proc: subprocess.Popen) -> None:
-    """Terminate the process and descendants that can retain output pipes."""
+def _track_descendants(
+    tracked: dict[int, float],
+    stop: threading.Event,
+) -> None:
+    """Track descendants before reparenting can detach them from the root."""
+    while not stop.wait(DESCENDANT_POLL_SECONDS):
+        for pid, create_time in tuple(tracked.items()):
+            try:
+                process = psutil.Process(pid)
+                if process.create_time() != create_time:
+                    continue
+                for child in process.children(recursive=True):
+                    tracked.setdefault(child.pid, child.create_time())
+            except (psutil.Error, OSError):
+                continue
+
+
+def _tracked_processes(tracked: dict[int, float]) -> list[psutil.Process]:
+    processes = []
+    for pid, create_time in tracked.items():
+        try:
+            process = psutil.Process(pid)
+            if process.create_time() == create_time:
+                processes.append(process)
+        except (psutil.Error, OSError):
+            continue
+    return processes
+
+
+def _process_identities(processes: list[psutil.Process]) -> dict[int, float]:
+    identities = {}
+    for process in processes:
+        try:
+            identities[process.pid] = process.create_time()
+        except (psutil.Error, OSError):
+            continue
+    return identities
+
+
+def _set_linux_child_subreaper(enabled: bool) -> bool | None:
+    """Set Linux child-subreaper ownership and return the previous state."""
+    if sys.platform != "linux":
+        return None
+    import ctypes
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    current = ctypes.c_int()
+    if libc.prctl(37, ctypes.byref(current), 0, 0, 0) != 0:
+        raise OSError(ctypes.get_errno(), "unable to read child subreaper state")
+    if libc.prctl(36, int(enabled), 0, 0, 0) != 0:
+        raise OSError(ctypes.get_errno(), "unable to set child subreaper state")
+    return bool(current.value)
+
+
+def _new_adopted_processes(baseline: dict[int, float]) -> dict[int, float]:
+    current = _process_identities(psutil.Process().children(recursive=True))
+    return {
+        pid: create_time
+        for pid, create_time in current.items()
+        if baseline.get(pid) != create_time
+    }
+
+
+def _terminate_tracked_processes(tracked: dict[int, float], deadline: float) -> None:
+    """Terminate every observed descendant within one absolute cleanup deadline."""
+    processes = _tracked_processes(tracked)
+    for process in sorted(processes, key=lambda item: item.pid, reverse=True):
+        try:
+            process.terminate()
+        except psutil.Error:
+            pass
+    graceful_deadline = min(deadline, time.monotonic() + 0.25)
+    _gone, alive = psutil.wait_procs(
+        processes,
+        timeout=max(0.0, graceful_deadline - time.monotonic()),
+    )
+    for process in alive:
+        try:
+            process.kill()
+        except psutil.Error:
+            pass
+    if alive:
+        forced_deadline = min(deadline, time.monotonic() + 0.5)
+        psutil.wait_procs(alive, timeout=max(0.0, forced_deadline - time.monotonic()))
+
+
+def _kill_process_group(proc: subprocess.Popen) -> None:
     if os.name == "nt":
-        completed = _ORIGINAL_SUBPROCESS_RUN(
-            ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=False,
-        )
-        if completed.returncode != 0 and proc.poll() is None:
-            proc.kill()
         return
     try:
         os.killpg(proc.pid, signal.SIGKILL)
     except ProcessLookupError:
-        if proc.poll() is None:
-            proc.kill()
+        pass
 
 
 def _assign_windows_kill_on_close_job(proc: subprocess.Popen) -> int | None:
@@ -1011,67 +1023,122 @@ def _run_process_bounded(
     env: dict[str, str],
 ) -> subprocess.CompletedProcess:
     """Run a process while bounding retained stdout and stderr in memory."""
-    if subprocess.run is not _ORIGINAL_SUBPROCESS_RUN:
-        return _run_process_with_injected_runner(cmd, timeout=timeout, cwd=cwd, env=env)
-
     creationflags = subprocess.CREATE_NEW_PROCESS_GROUP if os.name == "nt" else 0
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        cwd=cwd,
-        env=env,
-        start_new_session=os.name != "nt",
-        creationflags=creationflags,
-    )
+    baseline_children = _process_identities(psutil.Process().children(recursive=True))
+    previous_subreaper = _set_linux_child_subreaper(True)
+    try:
+        proc = _PROCESS_FACTORY(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+            start_new_session=os.name != "nt",
+            creationflags=creationflags,
+        )
+    except BaseException:
+        if previous_subreaper is not None:
+            _set_linux_child_subreaper(previous_subreaper)
+        raise
+    windows_job = None
+    stdout_read_fd = None
+    stderr_read_fd = None
+    started_threads: list[threading.Thread] = []
+    tracking_stop = threading.Event()
+    tracked: dict[int, float] = {}
     try:
         windows_job = _assign_windows_kill_on_close_job(proc)
-    except OSError:
-        proc.kill()
-        proc.wait()
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+        stdout_read_fd = os.dup(proc.stdout.fileno())
+        stderr_read_fd = os.dup(proc.stderr.fileno())
         proc.stdout.close()
         proc.stderr.close()
+        stdout_projection = bytearray()
+        stderr_projection = bytearray()
+        stdout_thread = threading.Thread(
+            target=_drain_bounded_pipe,
+            args=(stdout_read_fd, stdout_projection, MAX_STDOUT_CAPTURE_BYTES),
+            daemon=True,
+        )
+        stderr_thread = threading.Thread(
+            target=_drain_bounded_pipe,
+            args=(stderr_read_fd, stderr_projection, MAX_STDERR_CAPTURE_BYTES),
+            daemon=True,
+        )
+        tracked = {proc.pid: psutil.Process(proc.pid).create_time()}
+        tracking_thread = threading.Thread(
+            target=_track_descendants,
+            args=(tracked, tracking_stop),
+            daemon=True,
+        )
+        for thread in (stdout_thread, stderr_thread, tracking_thread):
+            thread.start()
+            started_threads.append(thread)
+    except BaseException:
+        cleanup_deadline = time.monotonic() + MAX_PROCESS_CLEANUP_SECONDS
+        tracking_stop.set()
+        if windows_job is not None:
+            _close_windows_job(windows_job)
+        _kill_process_group(proc)
+        if previous_subreaper is not None:
+            tracked.update(_new_adopted_processes(baseline_children))
+        _terminate_tracked_processes(tracked, cleanup_deadline)
+        if proc.poll() is None:
+            proc.kill()
+        try:
+            proc.wait(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            pass
+        for stream in (proc.stdout, proc.stderr):
+            if stream is not None and not stream.closed:
+                stream.close()
+        for fd in (stdout_read_fd, stderr_read_fd):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+        for thread in started_threads:
+            thread.join(max(0.0, cleanup_deadline - time.monotonic()))
+        if previous_subreaper is not None:
+            _set_linux_child_subreaper(previous_subreaper)
         raise
-    stdout_projection = bytearray()
-    stderr_projection = bytearray()
-    stdout_thread = threading.Thread(
-        target=_drain_bounded_stream,
-        args=(proc.stdout, stdout_projection, MAX_STDOUT_CAPTURE_BYTES),
-        daemon=True,
-    )
-    stderr_thread = threading.Thread(
-        target=_drain_bounded_stream,
-        args=(proc.stderr, stderr_projection, MAX_STDERR_CAPTURE_BYTES),
-        daemon=True,
-    )
-    stdout_thread.start()
-    stderr_thread.start()
     timed_out = False
     try:
         returncode = proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         timed_out = True
-        if windows_job is not None:
-            _close_windows_job(windows_job)
-            windows_job = None
-        else:
-            _terminate_process_tree(proc)
-        returncode = proc.wait()
+        returncode = -1
     finally:
+        cleanup_deadline = time.monotonic() + MAX_PROCESS_CLEANUP_SECONDS
+        if timed_out:
+            _kill_process_group(proc)
+        tracking_stop.set()
+        tracking_thread.join(max(0.0, cleanup_deadline - time.monotonic()))
+        if previous_subreaper is not None:
+            tracked.update(_new_adopted_processes(baseline_children))
         if windows_job is not None:
             _close_windows_job(windows_job)
-        elif os.name != "nt" and not timed_out:
-            _terminate_process_tree(proc)
-        deadline = time.monotonic() + MAX_PIPE_DRAIN_SECONDS
+        _terminate_tracked_processes(tracked, cleanup_deadline)
+        if proc.poll() is None:
+            proc.kill()
+        try:
+            returncode = proc.wait(timeout=max(0.0, cleanup_deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            returncode = -1
         for thread in (stdout_thread, stderr_thread):
-            thread.join(max(0.0, deadline - time.monotonic()))
-        proc.stdout.close()
-        proc.stderr.close()
+            thread.join(max(0.0, cleanup_deadline - time.monotonic()))
+        drain_incomplete = stdout_thread.is_alive() or stderr_thread.is_alive()
+        if previous_subreaper is not None:
+            _set_linux_child_subreaper(previous_subreaper)
 
     stdout = bytes(stdout_projection)
     stderr = bytes(stderr_projection)
     if timed_out:
         raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout, output=stdout, stderr=stderr)
+    if drain_incomplete:
+        raise OSError("process output drain did not complete within cleanup deadline")
     return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
 
 

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -191,6 +191,25 @@ def build_prompt(question: str, server_name: str) -> str:
     )
 
 
+def build_copilot_command(
+    model: str,
+    prompt: str,
+    config_path: Path,
+    source_name: str,
+) -> list[str]:
+    """Build an isolated Copilot command for one selected MCP server."""
+    return [
+        "copilot",
+        "--model", model,
+        "--prompt", prompt,
+        "--output-format", "json",
+        "--disable-builtin-mcps",
+        "--additional-mcp-config", f"@{config_path}",
+        f"--allow-tool={source_name}",
+        "--no-ask-user",
+    ]
+
+
 def build_mcp_config(server_config: dict, require_azure: bool = False) -> tuple[dict, dict]:
     """Build one isolated MCP configuration and its non-secret row descriptor."""
     config = server_config["config"]
@@ -1257,6 +1276,15 @@ def parse_event_stream(stdout: str | bytes) -> dict:
                     )
             else:
                 parse_errors.append(f"line {line_number}: output token count must be a non-negative integer")
+        elif (
+            etype == "session.info"
+            and data.get("infoType") == "configuration"
+            and isinstance(data.get("message"), str)
+            and "unknown tool name in the tool allowlist" in data["message"].lower()
+        ):
+            configuration_failure = _sanitize_text(data["message"], max_chars=MAX_DIAGNOSTIC_TEXT)[0]
+            metrics["session_failure"] = configuration_failure
+            add_diagnostic(etype, {"infoType": "configuration", "message": configuration_failure})
         elif etype == "tool.execution_start":
             tool_call_id = data.get("toolCallId")
             tool_name = data.get("toolName")
@@ -1529,17 +1557,7 @@ def run_single_eval(
             config_path.write_text(json.dumps(mcp_config), encoding="utf-8")
             config_path.chmod(0o600)
 
-            cmd = [
-                "copilot",
-                "--model", model,
-                "--prompt", prompt,
-                "--output-format", "json",
-                "--disable-builtin-mcps",
-                "--additional-mcp-config", f"@{config_path}",
-                f"--available-tools={source_name}",
-                f"--allow-tool={source_name}",
-                "--no-ask-user",
-            ]
+            cmd = build_copilot_command(model, prompt, config_path, source_name)
             process_env = os.environ.copy()
             process_env["COPILOT_HOME"] = isolated_home
 

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -224,7 +224,9 @@ def test_run_single_eval_passes_only_selected_config_across_process_boundary(mon
         captured["cmd"] = cmd
         captured["cwd"] = kwargs["cwd"]
         captured["copilot_home"] = kwargs["env"]["COPILOT_HOME"]
-        return subprocess.CompletedProcess(cmd, 0, stdout=_event_stream(), stderr="")
+        captured["streamed"] = "capture_output" not in kwargs
+        kwargs["stdout"].write(_event_stream().encode())
+        return subprocess.CompletedProcess(cmd, 0, stdout=None, stderr=None)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -239,6 +241,7 @@ def test_run_single_eval_passes_only_selected_config_across_process_boundary(mon
     assert "--disable-builtin-mcps" in captured["cmd"]
     assert "--available-tools=foundry_docs" in captured["cmd"]
     assert "--allow-tool=foundry_docs" in captured["cmd"]
+    assert captured["streamed"] is True
     assert captured["cwd"] == captured["copilot_home"]
     assert result["selected_source"] == "foundry-docs"
     assert result["source_config_count"] == 1
@@ -917,6 +920,79 @@ def test_timeout_is_preserved_as_invalid_row_diagnostics(monkeypatch):
         models=["model-1"],
     )
     assert publication["allowed"] is False
+
+
+def test_timeout_projects_partial_stream_output_when_exception_has_no_payload(monkeypatch):
+    partial_event = json.dumps({
+        "type": "session.mcp_server_status_changed",
+        "data": {
+            "serverName": "foundry_docs",
+            "status": "failed",
+            "error": "initialization failed",
+        },
+    })
+
+    def time_out(cmd, **kwargs):
+        kwargs["stdout"].write(partial_event.encode())
+        kwargs["stderr"].write(b"streamed timeout diagnostic")
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(subprocess, "run", time_out)
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+        timeout=3,
+    )
+
+    assert result["status"] == "timeout"
+    assert result["diagnostics"]["events"][0]["event_type"] == "session.mcp_server_status_changed"
+    assert result["diagnostics"]["stderr_excerpt"] == "streamed timeout diagnostic"
+
+
+def test_bounded_process_timeout_does_not_wait_for_inheriting_descendant(tmp_path):
+    script = (
+        "import subprocess, sys, time; "
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(2)']); "
+        "print(child.pid, flush=True); "
+        "time.sleep(2)"
+    )
+    started = time.monotonic()
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        run_docs_eval._run_process_bounded(
+            [sys.executable, "-c", script],
+            timeout=0.2,
+            cwd=str(tmp_path),
+            env=os.environ.copy(),
+        )
+    elapsed = time.monotonic() - started
+
+    assert int(exc_info.value.stdout.decode().strip()) > 0
+    assert elapsed < 2.0
+
+
+def test_bounded_process_success_terminates_inheriting_descendant(tmp_path):
+    script = (
+        "import subprocess, sys; "
+        "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(10)']); "
+        "print(child.pid, flush=True)"
+    )
+    started = time.monotonic()
+
+    completed = run_docs_eval._run_process_bounded(
+        [sys.executable, "-c", script],
+        timeout=5,
+        cwd=str(tmp_path),
+        env=os.environ.copy(),
+    )
+    elapsed = time.monotonic() - started
+
+    assert completed.returncode == 0
+    assert int(completed.stdout.decode().strip()) > 0
+    assert elapsed < 2.0
 
 
 def test_process_launch_error_sanitizes_every_persisted_field(monkeypatch):
@@ -1927,6 +2003,36 @@ def test_total_stdout_budget_still_fails_closed():
     assert parsed["stdout_input_truncated"] is True
     assert f"stdout exceeds {run_docs_eval.MAX_STDOUT_PARSE_BYTES} byte pre-parse limit" in parsed["parse_error"]
     assert parsed["response"] == ""
+
+
+def test_process_stream_projection_discards_output_beyond_capture_budget(monkeypatch):
+    event = json.dumps({
+        "type": "session.mcp_servers_loaded",
+        "data": {"message": "x" * 63_000},
+    }, separators=(",", ":"))
+    stdout = ((event + "\n") * 100).encode()
+    assert len(stdout) > run_docs_eval.MAX_STDOUT_CAPTURE_BYTES
+
+    def emit_excess_output(cmd, **kwargs):
+        kwargs["stdout"].write(stdout)
+        return subprocess.CompletedProcess(cmd, 0, stdout=None, stderr=None)
+
+    monkeypatch.setattr(subprocess, "run", emit_excess_output)
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "invalid"
+    assert f"stdout exceeds {run_docs_eval.MAX_STDOUT_PARSE_BYTES} byte pre-parse limit" in result[
+        "event_parse_error"
+    ]
+    assert len(result["diagnostics"]["stdout_excerpt"]) <= run_docs_eval.MAX_STDOUT_EXCERPT + len(
+        "...[truncated]"
+    )
 
 
 def test_deeply_nested_bounded_json_fails_closed_without_recursion_crash():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -32,6 +32,7 @@ from run_docs_eval import (  # noqa: E402
     MCP_SERVERS,
     _sanitize_response_text,
     _sanitize_text,
+    build_copilot_command,
     build_mcp_config,
     compare_results,
     parse_event_stream,
@@ -239,7 +240,7 @@ def test_run_single_eval_passes_only_selected_config_across_process_boundary(mon
 
     assert list(captured["config"]["mcpServers"]) == ["foundry_docs"]
     assert "--disable-builtin-mcps" in captured["cmd"]
-    assert "--available-tools=foundry_docs" in captured["cmd"]
+    assert not any(arg.startswith("--available-tools") for arg in captured["cmd"])
     assert "--allow-tool=foundry_docs" in captured["cmd"]
     assert captured["streamed"] is True
     assert captured["cwd"] == captured["copilot_home"]
@@ -251,6 +252,68 @@ def test_run_single_eval_passes_only_selected_config_across_process_boundary(mon
     assert result["response_present"] is True
     assert result["status"] == "success"
     assert result["failure_reason"] is None
+
+
+@pytest.mark.parametrize(
+    ("server_name", "source_name"),
+    [
+        ("microsoft-learn", "MicrosoftDocs"),
+        ("mintlify-hosted", "mintlify"),
+        ("foundry-docs", "foundry_docs"),
+        ("foundry-docs-vnext", "foundry_docs_vnext"),
+    ],
+)
+def test_copilot_command_isolates_all_selected_mcp_servers_without_broken_availability_filter(
+    tmp_path,
+    server_name,
+    source_name,
+):
+    config_path = tmp_path / "selected-source.json"
+    config, descriptor = build_mcp_config(MCP_SERVERS[server_name])
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    cmd = build_copilot_command("model-1", "prompt", config_path, source_name)
+
+    assert list(config["mcpServers"]) == [source_name]
+    assert descriptor["tool_prefix"] == MCP_SERVERS[server_name]["config"]["tool_prefix"]
+    assert "--disable-builtin-mcps" in cmd
+    assert cmd[cmd.index("--additional-mcp-config") + 1] == f"@{config_path}"
+    assert f"--allow-tool={source_name}" in cmd
+    assert not any(arg.startswith("--available-tools") for arg in cmd)
+    for other_server in MCP_SERVERS.values():
+        other_name = other_server["config"]["name"]
+        if other_name != source_name:
+            assert f"--allow-tool={other_name}" not in cmd
+
+
+def test_unknown_tool_allowlist_warning_is_retained_and_fails_closed():
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.info",
+            "data": {
+                "infoType": "configuration",
+                "message": 'Unknown tool name in the tool allowlist: "foundry_docs_vnext"',
+            },
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+    valid, failure_reason, _azure_proven = run_docs_eval.validate_row_evidence(
+        parsed,
+        "foundry_docs_vnext",
+        False,
+    )
+
+    assert valid is False
+    assert failure_reason.startswith("session_error:")
+    assert parsed["diagnostic_events"] == [{
+        "event_type": "session.info",
+        "data": {
+            "infoType": "configuration",
+            "message": 'Unknown tool name in the tool allowlist: "foundry_docs_vnext"',
+        },
+    }]
 
 
 def test_success_response_is_sanitized_in_raw_and_scored_rows(monkeypatch):

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -13,6 +13,7 @@ import urllib.parse
 from pathlib import Path
 
 import pytest
+import psutil
 from fastmcp import Client
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
@@ -225,11 +226,9 @@ def test_run_single_eval_passes_only_selected_config_across_process_boundary(mon
         captured["cmd"] = cmd
         captured["cwd"] = kwargs["cwd"]
         captured["copilot_home"] = kwargs["env"]["COPILOT_HOME"]
-        captured["streamed"] = "capture_output" not in kwargs
-        kwargs["stdout"].write(_event_stream().encode())
-        return subprocess.CompletedProcess(cmd, 0, stdout=None, stderr=None)
+        return subprocess.CompletedProcess(cmd, 0, stdout=_event_stream(), stderr="")
 
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(run_docs_eval, "_run_process_bounded", fake_run)
 
     result = run_single_eval(
         SCENARIO,
@@ -242,7 +241,6 @@ def test_run_single_eval_passes_only_selected_config_across_process_boundary(mon
     assert "--disable-builtin-mcps" in captured["cmd"]
     assert not any(arg.startswith("--available-tools") for arg in captured["cmd"])
     assert "--allow-tool=foundry_docs" in captured["cmd"]
-    assert captured["streamed"] is True
     assert captured["cwd"] == captured["copilot_home"]
     assert result["selected_source"] == "foundry-docs"
     assert result["source_config_count"] == 1
@@ -275,6 +273,7 @@ def test_copilot_command_isolates_all_selected_mcp_servers_without_broken_availa
     cmd = build_copilot_command("model-1", "prompt", config_path, source_name)
 
     assert list(config["mcpServers"]) == [source_name]
+    assert config["mcpServers"][source_name]["deferTools"] == "never"
     assert descriptor["tool_prefix"] == MCP_SERVERS[server_name]["config"]["tool_prefix"]
     assert "--disable-builtin-mcps" in cmd
     assert cmd[cmd.index("--additional-mcp-config") + 1] == f"@{config_path}"
@@ -316,11 +315,58 @@ def test_unknown_tool_allowlist_warning_is_retained_and_fails_closed():
     }]
 
 
+def test_live_selected_mcp_fixture_loads_and_calls_search_without_allowlist_warning():
+    stdout = "\n".join([
+        json.dumps({
+            "type": "session.mcp_servers_loaded",
+            "data": {
+                "servers": [{
+                    "name": "foundry_docs_vnext",
+                    "status": "connected",
+                    "tools": ["search_docs"],
+                }],
+            },
+        }),
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {
+                "toolCallId": "call-live-1",
+                "toolName": "foundry_docs_vnext-search_docs",
+            },
+        }),
+        json.dumps({
+            "type": "tool.execution_complete",
+            "data": {
+                "toolCallId": "call-live-1",
+                "success": True,
+                "result": {"content": "selected source result"},
+            },
+        }),
+        json.dumps({
+            "type": "assistant.message",
+            "data": {"content": "trusted answer"},
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+    valid, failure_reason, _azure_proven = run_docs_eval.validate_row_evidence(
+        parsed,
+        "foundry_docs_vnext",
+        False,
+    )
+
+    assert valid is True
+    assert failure_reason is None
+    assert parsed["successful_tools"] == ["foundry_docs_vnext-search_docs"]
+    assert "unknown tool name" not in (parsed["parse_error"] or "").lower()
+
+
 def test_success_response_is_sanitized_in_raw_and_scored_rows(monkeypatch):
     response = r"Useful answer. token=LEAKME See C:\Users\Alice\private for details."
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -381,8 +427,8 @@ def test_success_response_preserves_root_relative_documentation_link(monkeypatch
         "Then configure managed identity."
     )
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -586,8 +632,8 @@ def test_success_response_redacts_common_unix_roots_and_bare_oauth_sas_assignmen
 def test_signed_url_response_remains_valid_after_runner_and_scorer(monkeypatch):
     response = "Use https://host/path?sig=SECRET&view=foundry."
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -794,8 +840,8 @@ def test_folded_encoded_authorization_redacts_logical_header_block(response):
 def test_encoded_credentials_and_paths_are_redacted_in_diagnostic_channels(monkeypatch):
     leaked = "token%3DSECRETVALUE %252Fhome%252Falice%252Fsecret.txt"
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             1,
@@ -885,8 +931,8 @@ def test_cli_plural_server_selection_fails_nonzero_before_execution(tmp_path, ex
 )
 def test_invalid_event_evidence_fails_closed(monkeypatch, stdout, failure_prefix):
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -906,8 +952,8 @@ def test_azure_required_row_needs_successful_selected_search(monkeypatch):
     monkeypatch.setenv("AZURE_SEARCH_ENDPOINT", "https://search.example")
     monkeypatch.setenv("AZURE_AI_PROJECT_ENDPOINT", "https://project.example")
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -953,7 +999,7 @@ def test_timeout_is_preserved_as_invalid_row_diagnostics(monkeypatch):
             stderr=b"Bearer abc.def.ghi from C:\\Users\\someone\\repo",
         )
 
-    monkeypatch.setattr(subprocess, "run", time_out)
+    monkeypatch.setattr(run_docs_eval, "_run_process_bounded", time_out)
 
     result = run_single_eval(
         SCENARIO,
@@ -985,7 +1031,7 @@ def test_timeout_is_preserved_as_invalid_row_diagnostics(monkeypatch):
     assert publication["allowed"] is False
 
 
-def test_timeout_projects_partial_stream_output_when_exception_has_no_payload(monkeypatch):
+def test_timeout_projects_partial_stream_output(monkeypatch):
     partial_event = json.dumps({
         "type": "session.mcp_server_status_changed",
         "data": {
@@ -996,11 +1042,14 @@ def test_timeout_projects_partial_stream_output_when_exception_has_no_payload(mo
     })
 
     def time_out(cmd, **kwargs):
-        kwargs["stdout"].write(partial_event.encode())
-        kwargs["stderr"].write(b"streamed timeout diagnostic")
-        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+        raise subprocess.TimeoutExpired(
+            cmd=cmd,
+            timeout=kwargs["timeout"],
+            output=partial_event.encode(),
+            stderr=b"streamed timeout diagnostic",
+        )
 
-    monkeypatch.setattr(subprocess, "run", time_out)
+    monkeypatch.setattr(run_docs_eval, "_run_process_bounded", time_out)
 
     result = run_single_eval(
         SCENARIO,
@@ -1037,6 +1086,32 @@ def test_bounded_process_timeout_does_not_wait_for_inheriting_descendant(tmp_pat
     assert elapsed < 2.0
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX detached-session regression")
+def test_bounded_process_timeout_terminates_detached_descendant(tmp_path):
+    script = (
+        "import subprocess, sys, time; "
+        "child = subprocess.Popen("
+        "[sys.executable, '-c', 'import time; time.sleep(10)'], start_new_session=True"
+        "); "
+        "print(child.pid, flush=True); "
+        "time.sleep(10)"
+    )
+    started = time.monotonic()
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+        run_docs_eval._run_process_bounded(
+            [sys.executable, "-c", script],
+            timeout=0.5,
+            cwd=str(tmp_path),
+            env=os.environ.copy(),
+        )
+    elapsed = time.monotonic() - started
+    descendant_pid = int(exc_info.value.stdout.decode().strip())
+
+    assert elapsed < 3.0
+    assert not psutil.pid_exists(descendant_pid)
+
+
 def test_bounded_process_success_terminates_inheriting_descendant(tmp_path):
     script = (
         "import subprocess, sys; "
@@ -1058,6 +1133,62 @@ def test_bounded_process_success_terminates_inheriting_descendant(tmp_path):
     assert elapsed < 2.0
 
 
+@pytest.mark.skipif(os.name == "nt", reason="Linux child-subreaper regression")
+def test_bounded_process_success_owns_immediately_detached_descendant(tmp_path):
+    script = (
+        "import subprocess, sys; "
+        "child = subprocess.Popen("
+        "[sys.executable, '-c', 'import time; time.sleep(10)'], start_new_session=True"
+        "); "
+        "print(child.pid, flush=True)"
+    )
+    started = time.monotonic()
+
+    completed = run_docs_eval._run_process_bounded(
+        [sys.executable, "-c", script],
+        timeout=5,
+        cwd=str(tmp_path),
+        env=os.environ.copy(),
+    )
+    elapsed = time.monotonic() - started
+    descendant_pid = int(completed.stdout.decode().strip())
+
+    assert elapsed < 3.0
+    assert not psutil.pid_exists(descendant_pid)
+
+
+def test_bounded_process_setup_failure_terminates_child_and_restores_subreaper(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+    original_factory = run_docs_eval._PROCESS_FACTORY
+    previous_subreaper = run_docs_eval._set_linux_child_subreaper(False)
+    if previous_subreaper is not None:
+        run_docs_eval._set_linux_child_subreaper(previous_subreaper)
+
+    def capture_factory(*args, **kwargs):
+        captured["proc"] = original_factory(*args, **kwargs)
+        return captured["proc"]
+
+    monkeypatch.setattr(run_docs_eval, "_PROCESS_FACTORY", capture_factory)
+    monkeypatch.setattr(run_docs_eval.os, "dup", lambda _fd: (_ for _ in ()).throw(OSError("EMFILE")))
+
+    with pytest.raises(OSError, match="EMFILE"):
+        run_docs_eval._run_process_bounded(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+            timeout=5,
+            cwd=str(tmp_path),
+            env=os.environ.copy(),
+        )
+
+    assert captured["proc"].poll() is not None
+    current_subreaper = run_docs_eval._set_linux_child_subreaper(False)
+    if current_subreaper is not None:
+        run_docs_eval._set_linux_child_subreaper(current_subreaper)
+        assert current_subreaper is previous_subreaper
+
+
 def test_process_launch_error_sanitizes_every_persisted_field(monkeypatch):
     leaked = (
         "failed to launch with GITHUB_TOKEN=github_pat_launchsecret "
@@ -1065,8 +1196,8 @@ def test_process_launch_error_sanitizes_every_persisted_field(monkeypatch):
         "failed at C:/Users/Jane Doe/private/copilot.exe"
     )
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: (_ for _ in ()).throw(OSError(leaked)),
     )
 
@@ -1094,8 +1225,8 @@ def test_process_launch_error_sanitizes_every_persisted_field(monkeypatch):
 def test_exact_process_launch_error_leaks_neither_token_nor_path_in_raw_or_scored_row(monkeypatch):
     leaked = r"token=LEAKME at C:\Users\Alice\private"
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: (_ for _ in ()).throw(OSError(leaked)),
     )
 
@@ -1130,8 +1261,8 @@ def test_mcp_initialization_failure_preserves_sanitized_lifecycle_diagnostics(mo
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -1180,8 +1311,8 @@ def test_real_mcp_servers_loaded_schema_preserves_statuses_and_selected_failure(
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -1231,8 +1362,8 @@ def test_canonical_mcp_servers_loaded_diagnostic_scores_as_valid(monkeypatch):
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -1269,8 +1400,8 @@ def test_real_session_error_schema_preserves_diagnostics_and_invalidates_answer(
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -1302,8 +1433,8 @@ def test_diagnostic_output_is_bounded(monkeypatch):
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=long_error),
     )
 
@@ -1326,8 +1457,8 @@ def test_sanitizer_redacts_prefixed_secrets_and_windows_paths(monkeypatch):
         "at C:\\Users\\Jane Doe\\repo and \\\\server\\share\\private"
     )
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -1423,8 +1554,8 @@ def test_escaped_authorization_does_not_leak_in_stdout_or_stderr(monkeypatch):
         r'response=\\\"digest-secret\\\"\"}'
     )
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -1458,8 +1589,8 @@ def test_escaped_authorization_does_not_leak_in_stdout_or_stderr(monkeypatch):
 )
 def test_deeply_escaped_authorization_is_clean_in_valid_raw_and_scored_rows(monkeypatch, response):
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -1488,8 +1619,8 @@ def test_deeply_escaped_authorization_is_clean_in_valid_raw_and_scored_rows(monk
 def test_exact_custom_scheme_escaped_authorization_does_not_leak_in_excerpts(monkeypatch):
     leaked = r'upstream={\"Authorization\":\"CustomScheme opaque-value\"}'
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -1517,8 +1648,8 @@ def test_truncated_escaped_authorization_value_fails_closed(monkeypatch):
         r'response=\\\"digest-secret\\\"' + ("x" * 20_000)
     )
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(
             cmd,
             0,
@@ -1574,8 +1705,8 @@ def test_sanitizer_redacts_json_style_secret_keys(monkeypatch):
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -1603,8 +1734,8 @@ def test_sanitizer_redacts_escaped_nested_json_secrets(monkeypatch):
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -1627,8 +1758,8 @@ def test_process_exit_preserves_specific_mcp_failure_reason(monkeypatch):
         json.dumps({"type": "result", "exitCode": 1}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr=""),
     )
 
@@ -1646,8 +1777,8 @@ def test_process_exit_preserves_specific_mcp_failure_reason(monkeypatch):
 def test_non_success_preserves_stdout_even_when_tool_evidence_was_valid(monkeypatch):
     stdout = _event_stream(response="untrusted answer")
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr=""),
     )
 
@@ -1667,8 +1798,8 @@ def test_non_success_preserves_stdout_even_when_tool_evidence_was_valid(monkeypa
 def test_failed_tool_clears_untrusted_answer_and_preserves_diagnostics(monkeypatch):
     stdout = _event_stream(tool_success=False, response="untrusted answer")
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -1732,8 +1863,8 @@ def test_mcp_failure_server_name_is_sanitized_and_bounded(monkeypatch):
         json.dumps({"type": "result", "exitCode": 1}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 1, stdout=stdout, stderr=""),
     )
 
@@ -1987,8 +2118,8 @@ def test_real_size_57kb_tool_result_parses_and_validates_selected_source(monkeyp
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -2034,8 +2165,8 @@ def test_multiple_real_size_tool_results_over_128kb_remain_valid(monkeypatch):
     stdout = "\n".join(json.dumps(event, separators=(",", ":")) for event in events)
     assert 128_000 < len(stdout.encode()) < run_docs_eval.MAX_STDOUT_PARSE_BYTES
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -2068,34 +2199,19 @@ def test_total_stdout_budget_still_fails_closed():
     assert parsed["response"] == ""
 
 
-def test_process_stream_projection_discards_output_beyond_capture_budget(monkeypatch):
-    event = json.dumps({
-        "type": "session.mcp_servers_loaded",
-        "data": {"message": "x" * 63_000},
-    }, separators=(",", ":"))
-    stdout = ((event + "\n") * 100).encode()
-    assert len(stdout) > run_docs_eval.MAX_STDOUT_CAPTURE_BYTES
-
-    def emit_excess_output(cmd, **kwargs):
-        kwargs["stdout"].write(stdout)
-        return subprocess.CompletedProcess(cmd, 0, stdout=None, stderr=None)
-
-    monkeypatch.setattr(subprocess, "run", emit_excess_output)
-
-    result = run_single_eval(
-        SCENARIO,
-        "foundry-docs",
-        MCP_SERVERS["foundry-docs"],
-        "model-1",
+def test_process_stream_projection_discards_output_beyond_capture_budget(tmp_path):
+    output_bytes = run_docs_eval.MAX_STDOUT_CAPTURE_BYTES + 1_000_000
+    completed = run_docs_eval._run_process_bounded(
+        [sys.executable, "-c", f"import sys; sys.stdout.buffer.write(b'x' * {output_bytes})"],
+        timeout=10,
+        cwd=str(tmp_path),
+        env=os.environ.copy(),
     )
 
-    assert result["status"] == "invalid"
-    assert f"stdout exceeds {run_docs_eval.MAX_STDOUT_PARSE_BYTES} byte pre-parse limit" in result[
-        "event_parse_error"
-    ]
-    assert len(result["diagnostics"]["stdout_excerpt"]) <= run_docs_eval.MAX_STDOUT_EXCERPT + len(
-        "...[truncated]"
-    )
+    assert len(completed.stdout) == run_docs_eval.MAX_STDOUT_CAPTURE_BYTES
+    parsed = parse_event_stream(completed.stdout)
+    assert parsed["stdout_input_truncated"] is True
+    assert parsed["response"] == ""
 
 
 def test_deeply_nested_bounded_json_fails_closed_without_recursion_crash():
@@ -2126,8 +2242,8 @@ def test_diagnostic_path_keys_are_sanitized(monkeypatch):
         json.dumps({"type": "result", "exitCode": 0}),
     ])
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -2147,8 +2263,8 @@ def test_tool_name_is_validated_raw_but_persisted_sanitized(monkeypatch):
     tool_name = r"foundry_docs-search_docs token=LEAKME C:\Users\Alice\private"
     stdout = _event_stream(tool_name=tool_name, response="trusted answer")
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 
@@ -2174,8 +2290,8 @@ def test_cross_source_failure_reason_sanitizes_tool_identifier(monkeypatch):
     tool_name = r"evil-search token=LEAKME C:\Users\Alice\private"
     stdout = _event_stream(tool_name=tool_name, response="untrusted answer")
     monkeypatch.setattr(
-        subprocess,
-        "run",
+        run_docs_eval,
+        "_run_process_bounded",
         lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
     )
 


### PR DESCRIPTION
## Summary

- configure the one selected MCP server with `deferTools: "never"` so its tools remain loaded under Copilot tool search
- remove the broken `--available-tools=<server>` filter; retain empty per-row `COPILOT_HOME`, built-in MCPs disabled, exactly one additional MCP config, and `--allow-tool=<selected server>`
- fail closed and retain bounded diagnostics if Copilot emits an unknown-tool allowlist warning or any non-selected tool is observed
- stream Copilot stdout/stderr into bounded raw-FD projections without unbounded `capture_output`, temporary-file growth, or buffered-reader close hangs
- terminate complete descendant trees under one cleanup deadline: Windows kill-on-close Job Object; POSIX process group while leader is unreaped; Linux child subreaper plus psutil identity tracking for detached/reparented descendants
- remove the injected `subprocess.run` production bypass; evidence unit tests mock the bounded helper, while resource/teardown tests execute the production Popen path

Follow-up to #631, externally merged #671, and live run `30484377602`.

## Copilot CLI contract evidence

- The live run proved bare `--available-tools=foundry_docs_vnext` is rejected and disables the selected MCP tools.
- A checksum-verified `v1.0.65` release asset (currently self-reporting `1.0.76-1`) isolated one FastMCP server. `--available-tools=probe(*)` emitted `Unknown tool name in the tool allowlist: "probe(*)"` and made no tool request.
- Removing only the availability filter, under an empty `COPILOT_HOME` with built-ins disabled, one `probe` config using `deferTools: "never"`, and `--allow-tool=probe`, connected `probe`, executed `probe-search_docs`, and returned `PROBE_OK:contract-check` with exit code 0.

## Validation

- `python -m pytest tests\test_docs_eval_evidence.py -q` — 250 passed, 2 POSIX-specific tests skipped on Windows
- `python -m ruff check scripts\run_docs_eval.py tests\test_docs_eval_evidence.py pyproject.toml` — passed
- deterministic live-event fixture proves the selected search tool loads/calls without an unknown-tool warning
- command/config tests cover all four canonical server names and `deferTools: "never"`
- real production-path tests cover oversized output, inherited writers, timeout/success descendants, partial setup failure, and subreaper restoration; POSIX tests cover detached `start_new_session` descendants including immediate parent exit
- independent final code review — no significant issues

Do not merge until reviewed. Do not rerun the matrix for this PR.