### PR TITLE
Accept bounded live Copilot JSONL event shapes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "opentelemetry-sdk>=1.39.0,<1.40",
     "opentelemetry-api>=1.39.0,<1.40",
     "psutil>=7.0.0",
+    "ijson>=3.4.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -107,12 +107,13 @@ MAX_RESPONSE_TEXT = 50_000
 MAX_STDOUT_EXCERPT = 12_000
 MAX_STDERR_EXCERPT = 4_000
 MAX_STDOUT_PARSE_BYTES = 4_000_000
-MAX_STDOUT_PARSE_LINES = 500
-MAX_STDOUT_LINE_BYTES = 64_000
-MAX_STDOUT_CAPTURE_BYTES = MAX_STDOUT_PARSE_BYTES + MAX_STDOUT_LINE_BYTES + 1
+MAX_STDOUT_PARSE_LINES = 5_000
+MAX_STDOUT_LINE_BYTES = 512_000
+MAX_STDOUT_CAPTURE_BYTES = MAX_STDOUT_PARSE_BYTES + 1
 MAX_STDERR_CAPTURE_BYTES = 64_000
 MAX_PROCESS_CLEANUP_SECONDS = 2.0
 DESCENDANT_POLL_SECONDS = 0.01
+MAX_SANITIZE_CANONICAL_ITERATIONS = 4
 MAX_IDENTIFIER_TEXT = 256
 MAX_USAGE_METRIC = 10**15
 MAX_ENCODED_TOKEN_BYTES = 8_192
@@ -793,7 +794,20 @@ def select_servers(server: str | None, servers: list[str] | None) -> dict:
 
 
 def _bounded_excerpt(value: str | bytes | None, max_chars: int) -> tuple[str, bool]:
-    return _sanitize_text(_coerce_process_text(value), max_chars=max_chars)
+    return _canonicalize_sanitized_text(_coerce_process_text(value), max_chars=max_chars)
+
+
+def _canonicalize_sanitized_text(value: str, *, max_chars: int) -> tuple[str, bool]:
+    """Sanitize until stable under a strict iteration and output-size bound."""
+    current = value
+    truncated = False
+    for _ in range(MAX_SANITIZE_CANONICAL_ITERATIONS):
+        sanitized, pass_truncated = _sanitize_text(current, max_chars=max_chars)
+        truncated = truncated or pass_truncated
+        if sanitized == current:
+            return sanitized, truncated
+        current = sanitized
+    return "[REDACTED]", True
 
 
 def _bounded_stdout_excerpt(value: str | bytes | None) -> tuple[str, bool]:
@@ -810,7 +824,10 @@ def _bounded_stdout_excerpt(value: str | bytes | None) -> tuple[str, bool]:
         else:
             per_line_truncated = per_line_truncated or _contains_oversized_diagnostic_value(parsed_line)
             sanitized_lines.append(json.dumps(_sanitize_diagnostic_value(parsed_line), ensure_ascii=True))
-    excerpt, final_truncated = _sanitize_text("\n".join(sanitized_lines), max_chars=MAX_STDOUT_EXCERPT)
+    excerpt, final_truncated = _canonicalize_sanitized_text(
+        "\n".join(sanitized_lines),
+        max_chars=MAX_STDOUT_EXCERPT,
+    )
     return excerpt, per_line_truncated or final_truncated
 
 

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -27,11 +27,13 @@ import sys
 import tempfile
 import threading
 import time
+from decimal import Decimal, DecimalException
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import unquote_plus, urlsplit, urlunsplit
 
 import psutil
+import ijson
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SCENARIOS_FILE = PROJECT_ROOT / "tests" / "docs_eval_scenarios.json"
@@ -108,12 +110,15 @@ MAX_STDOUT_EXCERPT = 12_000
 MAX_STDERR_EXCERPT = 4_000
 MAX_STDOUT_PARSE_BYTES = 4_000_000
 MAX_STDOUT_PARSE_LINES = 5_000
-MAX_STDOUT_LINE_BYTES = 512_000
+MAX_STDOUT_LINE_BYTES = MAX_STDOUT_PARSE_BYTES
+MAX_EAGER_JSON_EVENT_BYTES = 512_000
 MAX_STDOUT_CAPTURE_BYTES = MAX_STDOUT_PARSE_BYTES + 1
 MAX_STDERR_CAPTURE_BYTES = 64_000
 MAX_PROCESS_CLEANUP_SECONDS = 2.0
 DESCENDANT_POLL_SECONDS = 0.01
 MAX_SANITIZE_CANONICAL_ITERATIONS = 4
+MAX_STREAM_JSON_DEPTH = 64
+MAX_STREAM_JSON_MAP_KEYS = 10_000
 MAX_IDENTIFIER_TEXT = 256
 MAX_USAGE_METRIC = 10**15
 MAX_ENCODED_TOKEN_BYTES = 8_192
@@ -170,6 +175,40 @@ _ABSOLUTE_PATH_PATTERNS = (
     re.compile(r"(?i)\b[A-Z]:[\\/][^,\r\n;\"']+"),
     re.compile(r"(?<![:/\w])/(?!/)[^,\r\n;\"']+"),
 )
+
+_LARGE_EVENT_SCALAR_PATHS = {
+    ("type",),
+    ("exitCode",),
+    ("usage", "premiumRequests"),
+    ("usage", "totalApiDurationMs"),
+    ("usage", "sessionDurationMs"),
+    ("data", "turnId"),
+    ("data", "content"),
+    ("data", "outputTokens"),
+    ("data", "infoType"),
+    ("data", "message"),
+    ("data", "errorType"),
+    ("data", "toolCallId"),
+    ("data", "toolName"),
+    ("data", "success"),
+    ("data", "serverName"),
+    ("data", "server"),
+    ("data", "name"),
+    ("data", "status"),
+    ("data", "state"),
+    ("data", "error"),
+    ("data", "error", "message"),
+    ("data", "error", "code"),
+}
+_LARGE_EVENT_MAP_PATHS = {
+    (),
+    ("data",),
+    ("usage",),
+    ("data", "servers", "item"),
+}
+_LARGE_EVENT_ARRAY_PATHS = {("data", "servers")}
+_SERVER_ITEM_PATH = ("data", "servers", "item")
+_SERVER_SCALAR_FIELDS = {"name", "status", "error", "source", "transport"}
 
 
 def load_scenarios(path: Path) -> list[dict]:
@@ -816,13 +855,17 @@ def _bounded_stdout_excerpt(value: str | bytes | None) -> tuple[str, bool]:
     per_line_truncated = boundary_truncated
     for _line_number, line in lines:
         try:
-            parsed_line = json.loads(line)
+            parsed_line, projected_truncated = _parse_json_event(line)
         except (json.JSONDecodeError, ValueError, RecursionError):
             sanitized_line, truncated = _sanitize_text(line)
             sanitized_lines.append(sanitized_line)
             per_line_truncated = per_line_truncated or truncated
         else:
-            per_line_truncated = per_line_truncated or _contains_oversized_diagnostic_value(parsed_line)
+            per_line_truncated = (
+                per_line_truncated
+                or projected_truncated
+                or _contains_oversized_diagnostic_value(parsed_line)
+            )
             sanitized_lines.append(json.dumps(_sanitize_diagnostic_value(parsed_line), ensure_ascii=True))
     excerpt, final_truncated = _canonicalize_sanitized_text(
         "\n".join(sanitized_lines),
@@ -1259,6 +1302,145 @@ def _build_diagnostics(
     return diagnostics
 
 
+def _set_projected_value(target: dict, path: tuple[str, ...], value: object) -> None:
+    current = target
+    for part in path[:-1]:
+        current = current.setdefault(part, {})
+    if isinstance(value, str):
+        if path == ("data", "content"):
+            value = _sanitize_response_text(value)
+    elif isinstance(value, Decimal):
+        value = float(value)
+    current[path[-1]] = value
+
+
+def _consume_projected_path(stack: list[dict]) -> tuple[str, ...]:
+    if not stack:
+        raise ValueError("streamed JSON event has multiple roots")
+    parent = stack[-1]
+    if parent["kind"] == "map":
+        key = parent["pending_key"]
+        if key is None:
+            raise ValueError("streamed JSON map value is missing a key")
+        parent["pending_key"] = None
+        return (*parent["path"], key)
+    return (*parent["path"], "item")
+
+
+def _validate_projected_container(path: tuple[str, ...], kind: str) -> None:
+    if path == ("data", "error"):
+        if kind != "map":
+            raise ValueError("streamed JSON error field has an invalid container type")
+        return
+    if path in _LARGE_EVENT_SCALAR_PATHS:
+        raise ValueError("streamed JSON evidence field has an invalid container type")
+    if path in _LARGE_EVENT_MAP_PATHS and kind != "map":
+        raise ValueError("streamed JSON evidence field must be an object")
+    if path in _LARGE_EVENT_ARRAY_PATHS and kind != "array":
+        raise ValueError("streamed JSON evidence field must be an array")
+    if path[:3] == _SERVER_ITEM_PATH and len(path) == 4 and path[-1] in _SERVER_SCALAR_FIELDS:
+        if path[-1] != "error":
+            raise ValueError("streamed MCP server field has an invalid container type")
+    if path == (*_SERVER_ITEM_PATH, "error") and kind != "map":
+        raise ValueError("streamed MCP server error has an invalid container type")
+
+
+def _project_large_json_event(line: str) -> tuple[dict, bool]:
+    """Stream-project required evidence from one aggregate-sized JSON event."""
+    projected: dict = {"data": {}}
+    servers: list[dict] = []
+    servers_array_seen = False
+    current_server: dict | None = None
+    stack: list[dict] = []
+    root_complete = False
+    try:
+        for event_type, value in ijson.basic_parse(
+            io.BytesIO(line.encode("utf-8", errors="replace")),
+        ):
+            if root_complete:
+                raise ValueError("streamed JSON event contains trailing data")
+            if event_type == "map_key":
+                if not stack or stack[-1]["kind"] != "map":
+                    raise ValueError("streamed JSON map key is outside an object")
+                frame = stack[-1]
+                if value in frame["keys"]:
+                    raise ValueError("streamed JSON event contains a duplicate key")
+                frame["keys"].add(value)
+                if len(frame["keys"]) > MAX_STREAM_JSON_MAP_KEYS:
+                    raise ValueError("streamed JSON object exceeds its key limit")
+                frame["pending_key"] = value
+                continue
+            if event_type in {"start_map", "start_array"}:
+                if len(stack) >= MAX_STREAM_JSON_DEPTH:
+                    raise ValueError("streamed JSON event exceeds its depth limit")
+                path = () if not stack else _consume_projected_path(stack)
+                kind = "map" if event_type == "start_map" else "array"
+                _validate_projected_container(path, kind)
+                stack.append({
+                    "kind": kind,
+                    "path": path,
+                    "keys": set(),
+                    "pending_key": None,
+                })
+                if path == ("data", "servers") and kind == "array":
+                    servers_array_seen = True
+                if path == _SERVER_ITEM_PATH:
+                    if kind != "map":
+                        raise ValueError("streamed MCP server summary must be an object")
+                    current_server = {}
+                continue
+            if event_type in {"end_map", "end_array"}:
+                if not stack:
+                    raise ValueError("streamed JSON container ended without a start")
+                frame = stack.pop()
+                expected = "map" if event_type == "end_map" else "array"
+                if frame["kind"] != expected or frame["pending_key"] is not None:
+                    raise ValueError("streamed JSON container shape is invalid")
+                if frame["path"] == _SERVER_ITEM_PATH:
+                    if current_server is not None and len(servers) < MAX_DIAGNOSTIC_EVENTS:
+                        servers.append(current_server)
+                    current_server = None
+                if not stack:
+                    root_complete = True
+                continue
+            path = _consume_projected_path(stack)
+            if path in _LARGE_EVENT_MAP_PATHS or path in _LARGE_EVENT_ARRAY_PATHS:
+                raise ValueError("streamed JSON evidence field has an invalid scalar type")
+            if path == _SERVER_ITEM_PATH:
+                raise ValueError("streamed MCP server summary must be an object")
+            if path[:3] == _SERVER_ITEM_PATH and len(path) == 4:
+                field = path[-1]
+                if field in _SERVER_SCALAR_FIELDS and current_server is not None:
+                    current_server[field] = value
+                continue
+            if path[:4] == (*_SERVER_ITEM_PATH, "error") and len(path) == 5:
+                if current_server is not None and path[-1] in {"message", "code"}:
+                    error = current_server.setdefault("error", {})
+                    error[path[-1]] = value
+                continue
+            if path in _LARGE_EVENT_SCALAR_PATHS:
+                _set_projected_value(projected, path, value)
+    except (
+        ijson.JSONError,
+        DecimalException,
+        OverflowError,
+        ValueError,
+        RecursionError,
+    ) as exc:
+        raise ValueError("invalid streamed JSON event") from exc
+    if not root_complete or stack:
+        raise ValueError("streamed JSON event is incomplete")
+    if servers_array_seen:
+        projected["data"]["servers"] = servers
+    return projected, True
+
+
+def _parse_json_event(line: str) -> tuple[dict, bool]:
+    if len(line.encode("utf-8", errors="replace")) <= MAX_EAGER_JSON_EVENT_BYTES:
+        return json.loads(line), False
+    return _project_large_json_event(line)
+
+
 def parse_event_stream(stdout: str | bytes) -> dict:
     """Parse `copilot --output-format json` JSONL output into operational metrics.
 
@@ -1320,7 +1502,7 @@ def parse_event_stream(stdout: str | bytes) -> dict:
 
     for line_number, line in lines:
         try:
-            event = json.loads(line)
+            event, _projected_truncated = _parse_json_event(line)
         except (json.JSONDecodeError, ValueError, RecursionError):
             parse_errors.append(f"line {line_number}: invalid JSON event")
             continue

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -112,7 +112,11 @@ MAX_STDOUT_PARSE_BYTES = 4_000_000
 MAX_STDOUT_PARSE_LINES = 5_000
 MAX_STDOUT_LINE_BYTES = MAX_STDOUT_PARSE_BYTES
 MAX_EAGER_JSON_EVENT_BYTES = 512_000
-MAX_STDOUT_CAPTURE_BYTES = MAX_STDOUT_PARSE_BYTES + 1
+MAX_STDOUT_CAPTURE_BYTES = (
+    MAX_STDOUT_PARSE_BYTES
+    + (MAX_STDOUT_PARSE_LINES * 2)
+    + 1
+)
 MAX_STDERR_CAPTURE_BYTES = 64_000
 MAX_PROCESS_CLEANUP_SECONDS = 2.0
 DESCENDANT_POLL_SECONDS = 0.01
@@ -1212,29 +1216,33 @@ def _bounded_event_lines(value: str | bytes | None) -> tuple[list[tuple[int, str
     truncated = False
 
     for line_number in range(1, MAX_STDOUT_PARSE_LINES + 1):
-        line = reader.readline(MAX_STDOUT_LINE_BYTES + 1)
+        line = reader.readline(MAX_STDOUT_LINE_BYTES + 3)
         if not line:
             break
-        newline_markers = (b"\n", b"\r") if is_bytes else ("\n", "\r")
-        if len(line) > MAX_STDOUT_LINE_BYTES and not line.endswith(newline_markers):
+        lf = b"\n" if is_bytes else "\n"
+        cr = b"\r" if is_bytes else "\r"
+        payload = line
+        if payload.endswith(lf):
+            payload = payload[:-1]
+            if payload.endswith(cr):
+                payload = payload[:-1]
+        payload_bytes = (
+            len(payload)
+            if is_bytes
+            else len(payload.encode("utf-8", errors="replace"))
+        )
+        if payload_bytes > MAX_STDOUT_LINE_BYTES:
             errors.append(
                 f"line {line_number}: event exceeds {MAX_STDOUT_LINE_BYTES} byte pre-parse limit"
             )
             truncated = True
             break
-        line_bytes = len(line) if is_bytes else len(line.encode("utf-8", errors="replace"))
-        if line_bytes > MAX_STDOUT_LINE_BYTES:
-            errors.append(
-                f"line {line_number}: event exceeds {MAX_STDOUT_LINE_BYTES} byte pre-parse limit"
-            )
-            truncated = True
-            break
-        if total_bytes + line_bytes > MAX_STDOUT_PARSE_BYTES:
+        if total_bytes + payload_bytes > MAX_STDOUT_PARSE_BYTES:
             errors.append(f"stdout exceeds {MAX_STDOUT_PARSE_BYTES} byte pre-parse limit")
             truncated = True
             break
-        total_bytes += line_bytes
-        text_line = line.decode("utf-8", errors="replace") if is_bytes else line
+        total_bytes += payload_bytes
+        text_line = payload.decode("utf-8", errors="replace") if is_bytes else payload
         stripped = text_line.strip()
         if stripped:
             accepted.append((line_number, stripped))
@@ -1312,6 +1320,19 @@ def _set_projected_value(target: dict, path: tuple[str, ...], value: object) -> 
     elif isinstance(value, Decimal):
         value = float(value)
     current[path[-1]] = value
+
+
+def _reject_duplicate_json_pairs(pairs: list[tuple[str, object]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("JSON event contains a duplicate key")
+        result[key] = value
+    return result
+
+
+def _reject_nonstandard_json_constant(value: str) -> object:
+    raise ValueError(f"JSON event contains non-standard constant {value}")
 
 
 def _consume_projected_path(stack: list[dict]) -> tuple[str, ...]:
@@ -1437,7 +1458,11 @@ def _project_large_json_event(line: str) -> tuple[dict, bool]:
 
 def _parse_json_event(line: str) -> tuple[dict, bool]:
     if len(line.encode("utf-8", errors="replace")) <= MAX_EAGER_JSON_EVENT_BYTES:
-        return json.loads(line), False
+        return json.loads(
+            line,
+            object_pairs_hook=_reject_duplicate_json_pairs,
+            parse_constant=_reject_nonstandard_json_constant,
+        ), False
     return _project_large_json_event(line)
 
 

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -1592,10 +1592,11 @@ def parse_event_stream(stdout: str | bytes) -> dict:
                     metrics["observed_tools"].append(_sanitize_identifier(tool_name))
                 if type(data.get("success")) is not bool:
                     parse_errors.append(f"line {line_number}: tool completion missing Boolean success")
-                elif data["success"] is True and tool_name not in metrics["_successful_tools_raw"]:
-                    metrics["_successful_tools_raw"].append(tool_name)
-                    metrics["successful_tools"].append(_sanitize_identifier(tool_name))
+                elif data["success"] is True:
                     last_successful_tool_line = line_number
+                    if tool_name not in metrics["_successful_tools_raw"]:
+                        metrics["_successful_tools_raw"].append(tool_name)
+                        metrics["successful_tools"].append(_sanitize_identifier(tool_name))
             if data.get("success") is False:
                 metrics["tool_errors"] += 1
                 add_diagnostic(

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -1076,7 +1076,7 @@ def test_bounded_process_timeout_does_not_wait_for_inheriting_descendant(tmp_pat
     with pytest.raises(subprocess.TimeoutExpired) as exc_info:
         run_docs_eval._run_process_bounded(
             [sys.executable, "-c", script],
-            timeout=0.2,
+            timeout=0.75,
             cwd=str(tmp_path),
             env=os.environ.copy(),
         )
@@ -2094,7 +2094,26 @@ def test_large_event_is_stopped_before_json_parse_and_remains_bounded():
     assert parsed["response"] == ""
 
 
-def test_real_size_57kb_tool_result_parses_and_validates_selected_source(monkeypatch):
+def test_600kb_event_is_stopped_by_per_event_limit_before_json_parse():
+    oversized_event = (
+        b'{"type":"tool.execution_complete","data":{"toolCallId":"call-1","success":true,'
+        b'"result":{"content":"'
+        + (b"x" * 600_000)
+        + b'"}}}'
+    )
+    assert len(oversized_event) < run_docs_eval.MAX_STDOUT_PARSE_BYTES
+
+    parsed = parse_event_stream(oversized_event)
+
+    assert parsed["stdout_input_truncated"] is True
+    assert f"event exceeds {run_docs_eval.MAX_STDOUT_LINE_BYTES} byte pre-parse limit" in parsed[
+        "parse_error"
+    ]
+    assert parsed["diagnostic_events"] == []
+    assert parsed["response"] == ""
+
+
+def test_real_size_256kb_tool_result_parses_and_validates_selected_source(monkeypatch):
     completion = {
         "type": "tool.execution_complete",
         "data": {
@@ -2104,9 +2123,9 @@ def test_real_size_57kb_tool_result_parses_and_validates_selected_source(monkeyp
         },
     }
     base_size = len(json.dumps(completion, separators=(",", ":")).encode())
-    completion["data"]["result"]["content"][0]["text"] = "x" * (57_000 - base_size)
+    completion["data"]["result"]["content"][0]["text"] = "x" * (256_000 - base_size)
     completion_line = json.dumps(completion, separators=(",", ":"))
-    assert len(completion_line.encode()) == 57_000
+    assert len(completion_line.encode()) == 256_000
 
     stdout = "\n".join([
         json.dumps({
@@ -2134,6 +2153,73 @@ def test_real_size_57kb_tool_result_parses_and_validates_selected_source(monkeyp
     assert result["source_validated"] is True
     assert result["response"] == "trusted answer"
     assert result["event_parse_error"] is None
+
+
+def test_real_stream_with_750_delta_events_parses_and_validates_selected_source(monkeypatch):
+    events = [
+        {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+        },
+        *[
+            {
+                "type": "assistant.tool_call_delta",
+                "data": {
+                    "toolCallId": "call-1",
+                    "toolName": "foundry_docs-search_docs",
+                    "inputDelta": "x",
+                },
+            }
+            for _ in range(750)
+        ],
+        {
+            "type": "tool.execution_complete",
+            "data": {"toolCallId": "call-1", "success": True, "result": {"content": "docs"}},
+        },
+        {"type": "assistant.message", "data": {"content": "trusted answer"}},
+        {"type": "result", "exitCode": 0},
+    ]
+    stdout = "\n".join(json.dumps(event, separators=(",", ":")) for event in events)
+    assert len(events) > 500
+    assert len(stdout.encode()) < run_docs_eval.MAX_STDOUT_PARSE_BYTES
+    monkeypatch.setattr(
+        run_docs_eval,
+        "_run_process_bounded",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "success"
+    assert result["source_validated"] is True
+    assert result["response"] == "trusted answer"
+    assert result["event_parse_error"] is None
+
+
+def test_stdout_excerpt_is_sanitized_to_a_stable_canonical_form():
+    observed_fragment = (
+        r'# Function calling ```bash curl -X POST https:<PATH>\"api-key: [REDACTED] '
+        r'\\<PATH>"Content-Type: application/json\<PATH>\'{ .'
+    )
+    stdout = json.dumps({
+        "type": "session.error",
+        "data": {"message": observed_fragment},
+    })
+
+    excerpt, truncated = run_docs_eval._bounded_stdout_excerpt(stdout)
+    canonical, canonical_truncated = run_docs_eval._sanitize_text(
+        excerpt,
+        max_chars=run_docs_eval.MAX_STDOUT_EXCERPT,
+    )
+
+    assert excerpt == canonical
+    assert truncated is False
+    assert canonical_truncated is False
 
 
 def test_multiple_real_size_tool_results_over_128kb_remain_valid(monkeypatch):

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import math
 import os
 import subprocess
 import sys
@@ -2116,6 +2117,20 @@ def test_event_at_exact_4mb_aggregate_boundary_is_stream_projected():
     assert parsed["result_exit_code"] == 0
 
 
+@pytest.mark.parametrize("terminator", ["\n", "\r\n"])
+def test_exact_4mb_json_event_accepts_normal_line_terminator(terminator):
+    result_line = _json_event_at_size(
+        {"type": "result", "exitCode": 0},
+        run_docs_eval.MAX_STDOUT_PARSE_BYTES,
+    )
+
+    parsed = parse_event_stream(result_line + terminator)
+
+    assert parsed["stdout_input_truncated"] is False
+    assert parsed["parse_error"] is None
+    assert parsed["result_exit_code"] == 0
+
+
 def test_event_one_byte_over_4mb_aggregate_boundary_fails_before_json_parse():
     oversized_line = _json_event_at_size(
         {"type": "result", "exitCode": 0},
@@ -2129,6 +2144,62 @@ def test_event_one_byte_over_4mb_aggregate_boundary_fails_before_json_parse():
         "parse_error"
     ]
     assert parsed["response"] == ""
+
+
+@pytest.mark.parametrize("terminator", ["\n", "\r\n"])
+def test_4mb_plus_one_json_payload_fails_with_line_terminator(terminator):
+    oversized_line = _json_event_at_size(
+        {"type": "result", "exitCode": 0},
+        run_docs_eval.MAX_STDOUT_PARSE_BYTES + 1,
+    )
+
+    parsed = parse_event_stream(oversized_line + terminator)
+
+    assert parsed["stdout_input_truncated"] is True
+    assert f"event exceeds {run_docs_eval.MAX_STDOUT_LINE_BYTES} byte pre-parse limit" in parsed[
+        "parse_error"
+    ]
+    assert parsed["response"] == ""
+
+
+@pytest.mark.parametrize("padding_size", [0, 600_000])
+def test_duplicate_type_cannot_suppress_session_error_in_eager_or_streaming_parser(
+    padding_size,
+):
+    padding = "x" * padding_size
+    duplicate_type = (
+        '{"type":"session.error",'
+        '"data":{"errorType":"fatal","message":"must fail"},'
+        '"type":"result","exitCode":0,'
+        f'"padding":"{padding}"'
+        "}"
+    )
+
+    parsed = parse_event_stream(duplicate_type)
+
+    assert "invalid JSON event" in parsed["parse_error"]
+    assert parsed["result_exit_code"] is None
+    assert parsed["response"] == ""
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+@pytest.mark.parametrize("padding_size", [0, 600_000])
+def test_nonstandard_numeric_constants_fail_in_eager_and_streaming_parser(
+    constant,
+    padding_size,
+):
+    padding = "x" * padding_size
+    nonstandard = (
+        '{"type":"result","exitCode":0,'
+        f'"usage":{{"premiumRequests":{constant}}},'
+        f'"padding":"{padding}"'
+        "}"
+    )
+
+    parsed = parse_event_stream(nonstandard)
+
+    assert "invalid JSON event" in parsed["parse_error"]
+    assert parsed["result_exit_code"] is None
 
 
 def test_real_size_256kb_tool_result_parses_and_validates_selected_source(monkeypatch):
@@ -2845,7 +2916,10 @@ def test_usage_metrics_discard_invalid_values_and_remain_strict_json(invalid_val
     assert parsed["premium_requests"] is None
     assert parsed["api_duration_ms"] is None
     assert parsed["session_duration_ms"] is None
-    assert "must be a finite non-negative number" in parsed["parse_error"]
+    if isinstance(invalid_value, float) and not math.isfinite(invalid_value):
+        assert "invalid JSON event" in parsed["parse_error"]
+    else:
+        assert "must be a finite non-negative number" in parsed["parse_error"]
     assert "LEAKME" not in parsed["parse_error"]
     assert "Alice" not in parsed["parse_error"]
     json.dumps(parsed, allow_nan=False)
@@ -2925,7 +2999,7 @@ def test_usage_metrics_reject_integer_beyond_aggregation_bound():
     assert "must be a finite non-negative number" in parsed["parse_error"]
 
 
-def test_nonfinite_nested_diagnostic_value_is_normalized_for_strict_json():
+def test_nonfinite_nested_diagnostic_value_is_rejected_as_invalid_json():
     stdout = "\n".join([
         json.dumps({
             "type": "session.error",
@@ -2936,7 +3010,8 @@ def test_nonfinite_nested_diagnostic_value_is_normalized_for_strict_json():
 
     parsed = parse_event_stream(stdout)
 
-    assert parsed["diagnostic_events"][0]["data"]["extra"] is None
+    assert parsed["diagnostic_events"] == []
+    assert "invalid JSON event" in parsed["parse_error"]
     json.dumps(parsed, allow_nan=False)
 
 

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -2214,6 +2214,37 @@ def test_aggregate_sized_tool_result_is_projected_without_materializing_result(m
     assert result["event_parse_error"] is None
 
 
+def test_response_before_later_repeated_tool_success_fails_closed():
+    stdout = "\n".join([
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+        }),
+        json.dumps({
+            "type": "tool.execution_complete",
+            "data": {"toolCallId": "call-1", "success": True},
+        }),
+        json.dumps({
+            "type": "assistant.message",
+            "data": {"content": "premature answer"},
+        }),
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-2", "toolName": "foundry_docs-search_docs"},
+        }),
+        json.dumps({
+            "type": "tool.execution_complete",
+            "data": {"toolCallId": "call-2", "success": True},
+        }),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["successful_tools"] == ["foundry_docs-search_docs"]
+    assert "assistant response preceded the final successful documentation tool" in parsed["parse_error"]
+
+
 def test_large_event_dotted_keys_cannot_forge_nested_tool_evidence():
     forged = {
         "type": "tool.execution_start",

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -2094,22 +2094,40 @@ def test_large_event_is_stopped_before_json_parse_and_remains_bounded():
     assert parsed["response"] == ""
 
 
-def test_600kb_event_is_stopped_by_per_event_limit_before_json_parse():
-    oversized_event = (
-        b'{"type":"tool.execution_complete","data":{"toolCallId":"call-1","success":true,'
-        b'"result":{"content":"'
-        + (b"x" * 600_000)
-        + b'"}}}'
-    )
-    assert len(oversized_event) < run_docs_eval.MAX_STDOUT_PARSE_BYTES
+def _json_event_at_size(event: dict, target_size: int, field: str = "padding") -> str:
+    event[field] = ""
+    base_size = len(json.dumps(event, separators=(",", ":")).encode())
+    event[field] = "x" * (target_size - base_size)
+    serialized = json.dumps(event, separators=(",", ":"))
+    assert len(serialized.encode()) == target_size
+    return serialized
 
-    parsed = parse_event_stream(oversized_event)
+
+def test_event_at_exact_4mb_aggregate_boundary_is_stream_projected():
+    result_line = _json_event_at_size(
+        {"type": "result", "exitCode": 0},
+        run_docs_eval.MAX_STDOUT_PARSE_BYTES,
+    )
+
+    parsed = parse_event_stream(result_line)
+
+    assert parsed["stdout_input_truncated"] is False
+    assert parsed["parse_error"] is None
+    assert parsed["result_exit_code"] == 0
+
+
+def test_event_one_byte_over_4mb_aggregate_boundary_fails_before_json_parse():
+    oversized_line = _json_event_at_size(
+        {"type": "result", "exitCode": 0},
+        run_docs_eval.MAX_STDOUT_PARSE_BYTES + 1,
+    )
+
+    parsed = parse_event_stream(oversized_line)
 
     assert parsed["stdout_input_truncated"] is True
     assert f"event exceeds {run_docs_eval.MAX_STDOUT_LINE_BYTES} byte pre-parse limit" in parsed[
         "parse_error"
     ]
-    assert parsed["diagnostic_events"] == []
     assert parsed["response"] == ""
 
 
@@ -2153,6 +2171,245 @@ def test_real_size_256kb_tool_result_parses_and_validates_selected_source(monkey
     assert result["source_validated"] is True
     assert result["response"] == "trusted answer"
     assert result["event_parse_error"] is None
+
+
+def test_aggregate_sized_tool_result_is_projected_without_materializing_result(monkeypatch):
+    completion_line = _json_event_at_size(
+        {
+            "type": "tool.execution_complete",
+            "data": {
+                "toolCallId": "call-1",
+                "success": True,
+                "result": {"content": ""},
+            },
+        },
+        3_900_000,
+        field="padding",
+    )
+    stdout = "\n".join([
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+        }),
+        completion_line,
+        json.dumps({"type": "assistant.message", "data": {"content": "trusted answer"}}),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    monkeypatch.setattr(
+        run_docs_eval,
+        "_run_process_bounded",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr=""),
+    )
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+    )
+
+    assert result["status"] == "success"
+    assert result["source_validated"] is True
+    assert result["response"] == "trusted answer"
+    assert result["event_parse_error"] is None
+
+
+def test_large_event_dotted_keys_cannot_forge_nested_tool_evidence():
+    forged = {
+        "type": "tool.execution_start",
+        "data.toolCallId": "call-forged",
+        "data.toolName": "foundry_docs-search_docs",
+    }
+    forged_line = _json_event_at_size(forged, 600_000)
+    stdout = "\n".join([
+        forged_line,
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["observed_tools"] == []
+    assert "tool start missing identity" in parsed["parse_error"]
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {
+            "type": "assistant.message",
+            "data": {"content": "answer", "outputTokens": {}},
+        },
+        {
+            "type": "result",
+            "exitCode": 0,
+            "usage": [],
+        },
+    ],
+)
+def test_large_event_wrong_typed_evidence_fields_fail_closed(event):
+    oversized_line = _json_event_at_size(event, 600_000)
+
+    parsed = parse_event_stream(oversized_line)
+
+    assert "invalid JSON event" in parsed["parse_error"]
+    assert parsed["response"] == ""
+
+
+def test_large_event_duplicate_data_members_fail_closed():
+    padding = "x" * 600_000
+    duplicate_data = (
+        '{"type":"tool.execution_start",'
+        '"data":{"toolCallId":"call-forged","toolName":"foundry_docs-search_docs"},'
+        f'"data":{{"padding":"{padding}"}}'
+        "}"
+    )
+    assert len(duplicate_data.encode()) > run_docs_eval.MAX_EAGER_JSON_EVENT_BYTES
+
+    parsed = parse_event_stream(duplicate_data)
+
+    assert "invalid JSON event" in parsed["parse_error"]
+    assert parsed["observed_tools"] == []
+
+
+def test_large_event_preserves_empty_mcp_servers_array():
+    loaded_line = _json_event_at_size(
+        {
+            "type": "session.mcp_servers_loaded",
+            "data": {"servers": []},
+        },
+        600_000,
+    )
+    stdout = "\n".join([
+        loaded_line,
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert parsed["parse_error"] is None
+    assert parsed["mcp_statuses"] == {}
+
+
+def test_large_event_ignores_lossless_integer_in_unprojected_payload():
+    result_line = _json_event_at_size(
+        {
+            "type": "result",
+            "exitCode": 0,
+            "unknown": 18_446_744_073_709_551_616,
+        },
+        600_000,
+    )
+
+    parsed = parse_event_stream(result_line)
+
+    assert parsed["parse_error"] is None
+    assert parsed["result_exit_code"] == 0
+
+
+def test_large_projected_response_retains_truncation_signal():
+    message_line = _json_event_at_size(
+        {
+            "type": "assistant.message",
+            "data": {"content": "x" * (run_docs_eval.MAX_RESPONSE_TEXT + 100)},
+        },
+        600_000,
+    )
+    stdout = "\n".join([
+        message_line,
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+    sanitized = run_docs_eval._sanitize_response_text(parsed["response"])
+
+    assert len(parsed["response"]) == (
+        run_docs_eval.MAX_RESPONSE_TEXT + len("...[truncated]")
+    )
+    assert sanitized.endswith("...[truncated]")
+
+
+def test_large_projected_event_marks_stdout_excerpt_truncated():
+    failed_line = _json_event_at_size(
+        {
+            "type": "tool.execution_complete",
+            "data": {
+                "toolCallId": "call-1",
+                "success": False,
+                "result": {"content": "x" * 550_000},
+            },
+        },
+        600_000,
+    )
+
+    excerpt, truncated = run_docs_eval._bounded_stdout_excerpt(failed_line)
+
+    assert truncated is True
+    assert len(excerpt) <= run_docs_eval.MAX_STDOUT_EXCERPT + len("...[truncated]")
+
+
+def test_large_configuration_warning_after_diagnostic_limit_still_fails_closed():
+    warning = (
+        ("x" * (run_docs_eval.MAX_DIAGNOSTIC_TEXT + 100))
+        + ' Unknown tool name in the tool allowlist: "foundry_docs"'
+    )
+    info_line = _json_event_at_size(
+        {
+            "type": "session.info",
+            "data": {"infoType": "configuration", "message": warning},
+        },
+        600_000,
+    )
+    stdout = "\n".join([
+        info_line,
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+    valid, failure_reason, _azure_proven = run_docs_eval.validate_row_evidence(
+        parsed,
+        "foundry_docs",
+        False,
+    )
+
+    assert valid is False
+    assert failure_reason.startswith("session_error:")
+
+
+def test_large_extreme_decimal_fails_closed_without_crashing():
+    extreme_number = "1e" + ("9" * 600_000)
+    result_line = (
+        '{"type":"result","exitCode":0,"usage":{"premiumRequests":'
+        + extreme_number
+        + "}}"
+    )
+    assert len(result_line.encode()) > run_docs_eval.MAX_EAGER_JSON_EVENT_BYTES
+
+    parsed = parse_event_stream(result_line)
+
+    assert "invalid JSON event" in parsed["parse_error"]
+    assert parsed["response"] == ""
+
+
+def test_large_projected_response_redacts_secret_crossing_response_limit():
+    token = "headerheader.payloadpayload.signaturesignature"
+    content = ("x" * (run_docs_eval.MAX_RESPONSE_TEXT - 20)) + token + ("y" * 100)
+    message_line = _json_event_at_size(
+        {
+            "type": "assistant.message",
+            "data": {"content": content},
+        },
+        600_000,
+    )
+    stdout = "\n".join([
+        message_line,
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+
+    parsed = parse_event_stream(stdout)
+
+    assert token not in parsed["response"]
+    assert "headerheader" not in parsed["response"]
+    assert "[REDACTED]" in parsed["response"]
 
 
 def test_real_stream_with_750_delta_events_parses_and_validates_selected_source(monkeypatch):
@@ -2199,6 +2456,30 @@ def test_real_stream_with_750_delta_events_parses_and_validates_selected_source(
     assert result["source_validated"] is True
     assert result["response"] == "trusted answer"
     assert result["event_parse_error"] is None
+
+
+def test_exact_line_count_boundary_accepts_5000_and_rejects_5001_events():
+    ignored_event = json.dumps({"type": "assistant.tool_call_delta", "data": {}})
+    at_limit = "\n".join([
+        *([ignored_event] * (run_docs_eval.MAX_STDOUT_PARSE_LINES - 1)),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    over_limit = "\n".join([
+        *([ignored_event] * run_docs_eval.MAX_STDOUT_PARSE_LINES),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ])
+    assert len(at_limit.encode()) < run_docs_eval.MAX_STDOUT_PARSE_BYTES
+    assert len(over_limit.encode()) < run_docs_eval.MAX_STDOUT_PARSE_BYTES
+
+    accepted = parse_event_stream(at_limit)
+    rejected = parse_event_stream(over_limit)
+
+    assert accepted["parse_error"] is None
+    assert accepted["result_exit_code"] == 0
+    assert rejected["stdout_input_truncated"] is True
+    assert f"stdout exceeds {run_docs_eval.MAX_STDOUT_PARSE_LINES} line pre-parse limit" in rejected[
+        "parse_error"
+    ]
 
 
 def test_stdout_excerpt_is_sanitized_to_a_stable_canonical_form():

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -2162,6 +2162,37 @@ def test_4mb_plus_one_json_payload_fails_with_line_terminator(terminator):
     assert parsed["response"] == ""
 
 
+@pytest.mark.parametrize("terminator", ["\n", "\r\n"])
+def test_aggregate_payload_boundary_excludes_all_line_terminators(terminator):
+    result_line = json.dumps({"type": "result", "exitCode": 0}, separators=(",", ":"))
+    filler_size = (
+        run_docs_eval.MAX_STDOUT_PARSE_BYTES
+        - len(result_line.encode())
+    )
+    filler_line = _json_event_at_size(
+        {"type": "assistant.tool_call_delta", "data": {}},
+        filler_size,
+    )
+    at_limit = terminator.join([filler_line, result_line]) + terminator
+    over_limit = terminator.join([
+        _json_event_at_size(
+            {"type": "assistant.tool_call_delta", "data": {}},
+            filler_size + 1,
+        ),
+        result_line,
+    ]) + terminator
+
+    accepted = parse_event_stream(at_limit)
+    rejected = parse_event_stream(over_limit)
+
+    assert accepted["parse_error"] is None
+    assert accepted["result_exit_code"] == 0
+    assert rejected["stdout_input_truncated"] is True
+    assert f"stdout exceeds {run_docs_eval.MAX_STDOUT_PARSE_BYTES} byte pre-parse limit" in rejected[
+        "parse_error"
+    ]
+
+
 @pytest.mark.parametrize("padding_size", [0, 600_000])
 def test_duplicate_type_cannot_suppress_session_error_in_eager_or_streaming_parser(
     padding_size,
@@ -2180,6 +2211,22 @@ def test_duplicate_type_cannot_suppress_session_error_in_eager_or_streaming_pars
     assert "invalid JSON event" in parsed["parse_error"]
     assert parsed["result_exit_code"] is None
     assert parsed["response"] == ""
+
+
+@pytest.mark.parametrize("padding_size", [0, 600_000])
+def test_nested_duplicate_keys_fail_in_eager_and_streaming_parser(padding_size):
+    padding = "x" * padding_size
+    duplicate_usage = (
+        '{"type":"result","exitCode":0,'
+        '"usage":{"premiumRequests":1,"premiumRequests":2},'
+        f'"padding":"{padding}"'
+        "}"
+    )
+
+    parsed = parse_event_stream(duplicate_usage)
+
+    assert "invalid JSON event" in parsed["parse_error"]
+    assert parsed["result_exit_code"] is None
 
 
 @pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])


### PR DESCRIPTION
## Summary

- allow one canonical JSONL event to consume the strict 4 MB aggregate payload budget without materializing bulky tool results or opaque payloads
- use eager JSON only through 512 KB; stream-project required evidence above that threshold with explicit key-stack schema validation
- raise the event-count limit from 500 to 5,000 for normal tool-call delta streams
- exclude terminating LF/CRLF from per-event and aggregate JSON payload accounting; bound retained capture to 4 MB plus worst-case 5,000 CRLF delimiters plus one overflow-detection byte
- reject duplicate keys and non-standard NaN/Infinity in both eager and streaming parsing, preventing duplicate `type` from suppressing `session.error`
- retain lifecycle/tool/result-order fail-closed behavior, including every repeated successful completion advancing causal ordering
- preserve strict schema, depth/key, sanitizer, diagnostics, and result-order checks

Follow-up to #631 and post-merge run `30512368218`, where 117 rows hit the 64 KB per-event limit and 75 hit the 500-event limit.

## Separate deployment requirement

Repository secret `AZURE_SEARCH_VNEXT_INDEX_NAME` is configured as `foundry-docs-vnext`. This PR does not modify deployment configuration.

## Validation

- `python -m pytest tests\test_docs_eval_evidence.py -q` — 280 passed, 2 POSIX-specific tests skipped on Windows
- `python -m ruff check pyproject.toml scripts\run_docs_eval.py tests\test_docs_eval_evidence.py` — passed
- exact 4 MB JSON event with no terminator, LF, or CRLF accepted; 4 MB + 1 payload rejected with each terminator
- exact 5,000-event stream accepted; 5,001 rejected
- eager and streaming duplicate-key and NaN/Infinity parity tests fail closed
- aggregate-sized projection integrity tests cover dotted keys, wrong types, duplicates, extreme numbers, late configuration failures, boundary-crossing secrets, and truncation signaling
- repeated successful calls to the same tool correctly enforce response ordering while persisted names remain deduplicated
- independent review — no significant issues

Do not merge or rerun the full matrix until reviewed.