### PR TITLE
Isolate docs eval tools and retain final evidence

### DIFF
--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -271,10 +271,64 @@ def _canonical_post_result_events(value: object) -> object:
             "line": event.get("line") if type(event.get("line")) is int else 0,
             "event_type": _sanitize_identifier(event.get("event_type", "")),
             "ephemeral": event.get("ephemeral") if type(event.get("ephemeral")) is bool else False,
-            "status": (
-                _sanitize_identifier(event["status"])
-                if isinstance(event.get("status"), str)
+            "servers": _canonical_post_result_servers(event.get("servers", [])),
+            "server_count": (
+                event.get("server_count")
+                if type(event.get("server_count")) is int
+                else 0
+            ),
+            "servers_truncated": (
+                event.get("servers_truncated")
+                if type(event.get("servers_truncated")) is bool
+                else False
+            ),
+            "server_metadata_valid": (
+                event.get("server_metadata_valid")
+                if type(event.get("server_metadata_valid")) is bool
+                else False
+            ),
+        })
+    return canonical
+
+
+def _canonical_post_result_servers(value: object) -> object:
+    if not isinstance(value, list):
+        return _sanitize_diagnostic_value(value)
+    canonical = []
+    for server in value[:MAX_DIAGNOSTIC_EVENTS]:
+        if not isinstance(server, dict):
+            canonical.append(_sanitize_diagnostic_value(server))
+            continue
+        canonical.append({
+            "name": (
+                _sanitize_identifier(server["name"])
+                if isinstance(server.get("name"), str)
                 else None
+            ),
+            "status": (
+                _sanitize_identifier(server["status"])
+                if isinstance(server.get("status"), str)
+                else None
+            ),
+            "identity_aliases": (
+                [_sanitize_identifier(value) for value in server["identity_aliases"]]
+                if isinstance(server.get("identity_aliases"), list)
+                else []
+            ),
+            "status_aliases": (
+                [_sanitize_identifier(value) for value in server["status_aliases"]]
+                if isinstance(server.get("status_aliases"), list)
+                else []
+            ),
+            "error_fields": (
+                [_sanitize_identifier(value) for value in server["error_fields"]]
+                if isinstance(server.get("error_fields"), list)
+                else ["invalid-shape"]
+            ),
+            "error_present": (
+                server.get("error_present")
+                if type(server.get("error_present")) is bool
+                else True
             ),
         })
     return canonical
@@ -490,7 +544,10 @@ def validate_row_schema(result: object) -> list[str]:
                     "line",
                     "event_type",
                     "ephemeral",
-                    "status",
+                    "servers",
+                    "server_count",
+                    "servers_truncated",
+                    "server_metadata_valid",
                 }:
                     errors.append(f"{path} must contain exactly the required metadata fields")
                     continue
@@ -503,7 +560,10 @@ def validate_row_schema(result: object) -> list[str]:
                 if not _is_benign_post_result_metadata(
                     event["event_type"],
                     event["ephemeral"],
-                    event["status"],
+                    event["servers"],
+                    event["server_count"],
+                    event["servers_truncated"],
+                    event["server_metadata_valid"],
                     result.get("selected_source_config", {}).get("name")
                     if isinstance(result.get("selected_source_config"), dict)
                     else None,

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -20,16 +20,19 @@ from pathlib import Path
 from run_docs_eval import (
     MAX_DIAGNOSTIC_EVENTS,
     MAX_DIAGNOSTIC_EVENTS_CHARS,
+    MAX_POST_RESULT_EVENTS,
     MAX_STDERR_EXCERPT,
     MAX_STDOUT_EXCERPT,
+    MAX_STDOUT_PARSE_LINES,
     MAX_USAGE_METRIC,
     MCP_SERVERS,
     _is_search_tool,
+    _is_benign_post_result_metadata,
+    _configured_tools_for_prefix,
     _sanitize_diagnostic_value,
     _sanitize_identifier,
     _sanitize_response_text,
     _sanitize_text,
-    _source_for_tool,
     serialized_diagnostic_events_size,
 )
 
@@ -238,11 +241,43 @@ def _canonical_diagnostics(value: object) -> object:
     return {
         "events": _canonical_diagnostic_events(value.get("events", [])),
         "events_truncated": value.get("events_truncated") if type(value.get("events_truncated")) is bool else False,
+        "post_result_events": _canonical_post_result_events(value.get("post_result_events", [])),
+        "post_result_event_count": (
+            value.get("post_result_event_count")
+            if type(value.get("post_result_event_count")) is int
+            else 0
+        ),
+        "post_result_events_truncated": (
+            value.get("post_result_events_truncated")
+            if type(value.get("post_result_events_truncated")) is bool
+            else False
+        ),
         "stdout_excerpt": _sanitize_text(str(value.get("stdout_excerpt", "")), max_chars=MAX_STDOUT_EXCERPT)[0],
         "stdout_truncated": value.get("stdout_truncated") if type(value.get("stdout_truncated")) is bool else False,
         "stderr_excerpt": _sanitize_text(str(value.get("stderr_excerpt", "")), max_chars=MAX_STDERR_EXCERPT)[0],
         "stderr_truncated": value.get("stderr_truncated") if type(value.get("stderr_truncated")) is bool else False,
     }
+
+
+def _canonical_post_result_events(value: object) -> object:
+    if not isinstance(value, list):
+        return _sanitize_diagnostic_value(value)
+    canonical = []
+    for event in value[:MAX_DIAGNOSTIC_EVENTS]:
+        if not isinstance(event, dict):
+            canonical.append(_sanitize_diagnostic_value(event))
+            continue
+        canonical.append({
+            "line": event.get("line") if type(event.get("line")) is int else 0,
+            "event_type": _sanitize_identifier(event.get("event_type", "")),
+            "ephemeral": event.get("ephemeral") if type(event.get("ephemeral")) is bool else False,
+            "status": (
+                _sanitize_identifier(event["status"])
+                if isinstance(event.get("status"), str)
+                else None
+            ),
+        })
+    return canonical
 
 
 def _canonical_diagnostic_events(value: object) -> object:
@@ -396,6 +431,9 @@ def validate_row_schema(result: object) -> list[str]:
     required_diagnostic_fields = {
         "events",
         "events_truncated",
+        "post_result_events",
+        "post_result_event_count",
+        "post_result_events_truncated",
         "stdout_excerpt",
         "stdout_truncated",
         "stderr_excerpt",
@@ -413,6 +451,7 @@ def validate_row_schema(result: object) -> list[str]:
             for error in diagnostic_identifier_errors
         )
         events = diagnostics["events"]
+        post_result_events = diagnostics["post_result_events"]
         if not excessive_depth:
             try:
                 canonical_events = _canonical_diagnostic_events(events)
@@ -434,7 +473,66 @@ def validate_row_schema(result: object) -> list[str]:
             else:
                 if serialized_event_chars > MAX_DIAGNOSTIC_EVENTS_CHARS:
                     errors.append("diagnostics.events exceeds its total serialized size limit")
-        for field in ("events_truncated", "stdout_truncated", "stderr_truncated"):
+        if not isinstance(post_result_events, list):
+            errors.append("diagnostics.post_result_events must be a list")
+        elif len(post_result_events) > MAX_POST_RESULT_EVENTS:
+            errors.append(
+                f"diagnostics.post_result_events must contain at most {MAX_POST_RESULT_EVENTS} entries"
+            )
+        elif post_result_events != _canonical_post_result_events(post_result_events):
+            errors.append(
+                "diagnostics.post_result_events must equal its sanitized canonical form"
+            )
+        if isinstance(post_result_events, list):
+            for index, event in enumerate(post_result_events[:MAX_POST_RESULT_EVENTS]):
+                path = f"diagnostics.post_result_events[{index}]"
+                if not isinstance(event, dict) or set(event) != {
+                    "line",
+                    "event_type",
+                    "ephemeral",
+                    "status",
+                }:
+                    errors.append(f"{path} must contain exactly the required metadata fields")
+                    continue
+                if (
+                    type(event["line"]) is not int
+                    or event["line"] < 1
+                    or event["line"] > MAX_STDOUT_PARSE_LINES
+                ):
+                    errors.append(f"{path}.line must be a bounded positive line number")
+                if not _is_benign_post_result_metadata(
+                    event["event_type"],
+                    event["ephemeral"],
+                    event["status"],
+                ):
+                    errors.append(f"{path} is not a benign post-result event")
+        if diagnostics["post_result_events_truncated"] is True:
+            errors.append("diagnostics.post_result_events must not be truncated")
+        post_result_event_count = diagnostics["post_result_event_count"]
+        if (
+            type(post_result_event_count) is not int
+            or post_result_event_count < 0
+            or post_result_event_count > MAX_USAGE_METRIC
+        ):
+            errors.append("diagnostics.post_result_event_count must be a non-negative integer")
+        elif isinstance(post_result_events, list):
+            post_result_truncated = diagnostics["post_result_events_truncated"]
+            if post_result_event_count < len(post_result_events):
+                errors.append(
+                    "diagnostics.post_result_event_count must cover retained post-result events"
+                )
+            elif post_result_truncated is False and post_result_event_count != len(
+                post_result_events
+            ):
+                errors.append(
+                    "diagnostics.post_result_event_count must equal retained events when not truncated"
+                )
+        for field in (
+            "events_truncated",
+            "post_result_events_truncated",
+            "stdout_truncated",
+            "stderr_truncated",
+        ):
             if type(diagnostics[field]) is not bool:
                 errors.append(f"diagnostics.{field} must be a Boolean")
         excerpt_limits = {
@@ -717,6 +815,7 @@ def score_result(result: object, trusted_scenarios: dict[str, dict]) -> dict:
     selected_config = result.get("selected_source_config")
     observed_tools = result.get("observed_tools")
     successful_tools = result.get("successful_tools")
+    allowed_tools = _configured_tools_for_prefix(expected_config.get("tool_prefix", ""))
     response_time = result.get("response_time_seconds")
     expected_type = "local" if expected_server.get("type") == "stdio" else "http"
     source_schema_valid = (
@@ -735,8 +834,12 @@ def score_result(result: object, trusted_scenarios: dict[str, dict]) -> dict:
         and bool(successful_tools)
         and set(successful_tools).issubset(observed_tools)
         and all(
-            isinstance(tool_name, str) and _source_for_tool(tool_name) == expected_config.get("tool_prefix")
+            isinstance(tool_name, str) and tool_name in allowed_tools
             for tool_name in observed_tools
+        )
+        and all(
+            isinstance(tool_name, str) and tool_name in allowed_tools
+            for tool_name in successful_tools
         )
         and result.get("response_present") is True
         and bool(response)
@@ -752,7 +855,7 @@ def score_result(result: object, trusted_scenarios: dict[str, dict]) -> dict:
         result.get("azure_live_query_proven") is True
         and isinstance(successful_tools, list)
         and any(
-            _source_for_tool(tool_name) == expected_config.get("tool_prefix") and _is_search_tool(tool_name)
+            tool_name in allowed_tools and _is_search_tool(tool_name)
             for tool_name in successful_tools
         )
     )

--- a/scripts/eval_scorer.py
+++ b/scripts/eval_scorer.py
@@ -504,6 +504,9 @@ def validate_row_schema(result: object) -> list[str]:
                     event["event_type"],
                     event["ephemeral"],
                     event["status"],
+                    result.get("selected_source_config", {}).get("name")
+                    if isinstance(result.get("selected_source_config"), dict)
+                    else None,
                 ):
                     errors.append(f"{path} is not a benign post-result event")
         if diagnostics["post_result_events_truncated"] is True:

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -50,6 +50,11 @@ MCP_SERVERS = {
             "name": "MicrosoftDocs",
             "url": "https://learn.microsoft.com/api/mcp",
             "tool_prefix": "MicrosoftDocs",
+            "available_tools": (
+                "MicrosoftDocs-microsoft_docs_search",
+                "MicrosoftDocs-microsoft_docs_fetch",
+                "MicrosoftDocs-microsoft_code_sample_search",
+            ),
         },
     },
     "mintlify-hosted": {
@@ -59,6 +64,10 @@ MCP_SERVERS = {
             "name": "mintlify",
             "url": "https://hobbyist-e43fa225.mintlify.app/mcp",
             "tool_prefix": "mintlify",
+            "available_tools": (
+                "mintlify-search_microsoft_foundry_docs",
+                "mintlify-query_docs_filesystem_microsoft_foundry_docs",
+            ),
         },
     },
     "foundry-docs": {
@@ -69,6 +78,12 @@ MCP_SERVERS = {
             "command": "foundry-docs",
             "tool_prefix": "foundry_docs",
             "supports_azure": True,
+            "available_tools": (
+                "foundry_docs-search_docs",
+                "foundry_docs-get_doc",
+                "foundry_docs-get_section",
+                "foundry_docs-list_sections",
+            ),
         },
     },
     "foundry-docs-vnext": {
@@ -79,6 +94,12 @@ MCP_SERVERS = {
             "command": "foundry-docs-vnext",
             "tool_prefix": "foundry_docs_vnext",
             "supports_azure": True,
+            "available_tools": (
+                "foundry_docs_vnext-search_docs",
+                "foundry_docs_vnext-get_doc",
+                "foundry_docs_vnext-get_section",
+                "foundry_docs_vnext-list_sections",
+            ),
         },
     },
 }
@@ -103,6 +124,7 @@ KNOWN_TOOL_PREFIXES = tuple(
     )
 )
 MAX_DIAGNOSTIC_EVENTS = 20
+MAX_POST_RESULT_EVENTS = 20
 MAX_DIAGNOSTIC_EVENTS_CHARS = 50_000
 MAX_DIAGNOSTIC_TEXT = 2_000
 MAX_RESPONSE_TEXT = 50_000
@@ -123,6 +145,12 @@ DESCENDANT_POLL_SECONDS = 0.01
 MAX_SANITIZE_CANONICAL_ITERATIONS = 4
 MAX_STREAM_JSON_DEPTH = 64
 MAX_STREAM_JSON_MAP_KEYS = 10_000
+BENIGN_EPHEMERAL_POST_RESULT_EVENTS = {
+    "session.tools_updated",
+    "session.skills_loaded",
+    "mcp.tools.list_changed",
+}
+BENIGN_POST_RESULT_MCP_STATUSES = {"connected", "disabled"}
 MAX_IDENTIFIER_TEXT = 256
 MAX_USAGE_METRIC = 10**15
 MAX_ENCODED_TOKEN_BYTES = 8_192
@@ -243,6 +271,7 @@ def build_copilot_command(
     prompt: str,
     config_path: Path,
     source_name: str,
+    available_tools: tuple[str, ...],
 ) -> list[str]:
     """Build an isolated Copilot command for one selected MCP server."""
     return [
@@ -252,6 +281,7 @@ def build_copilot_command(
         "--output-format", "json",
         "--disable-builtin-mcps",
         "--additional-mcp-config", f"@{config_path}",
+        *(f"--available-tools={tool}" for tool in available_tools),
         f"--allow-tool={source_name}",
         "--no-ask-user",
     ]
@@ -324,6 +354,15 @@ def _source_for_tool(tool_name: str) -> str | None:
 def _is_search_tool(tool_name: str) -> bool:
     normalized = tool_name.casefold().replace("-", "_").replace(".", "_").replace("/", "_").replace(":", "_")
     return "search_docs" in normalized or normalized.endswith("_search")
+
+
+def _configured_tools_for_prefix(tool_prefix: str) -> set[str]:
+    return {
+        tool
+        for server in MCP_SERVERS.values()
+        if server["config"]["tool_prefix"] == tool_prefix
+        for tool in server["config"]["available_tools"]
+    }
 
 
 def _coerce_process_text(value: str | bytes | None) -> str:
@@ -1283,6 +1322,9 @@ def _empty_diagnostics() -> dict:
     return {
         "events": [],
         "events_truncated": False,
+        "post_result_events": [],
+        "post_result_event_count": 0,
+        "post_result_events_truncated": False,
         "stdout_excerpt": "",
         "stdout_truncated": False,
         "stderr_excerpt": "",
@@ -1301,6 +1343,9 @@ def _build_diagnostics(
     if parsed is not None:
         diagnostics["events"] = parsed["diagnostic_events"]
         diagnostics["events_truncated"] = parsed["diagnostic_events_truncated"]
+        diagnostics["post_result_events"] = parsed["post_result_events"]
+        diagnostics["post_result_event_count"] = parsed["post_result_event_count"]
+        diagnostics["post_result_events_truncated"] = parsed["post_result_events_truncated"]
     if preserve_stdout:
         diagnostics["stdout_excerpt"], diagnostics["stdout_truncated"] = _bounded_stdout_excerpt(stdout)
     diagnostics["stderr_excerpt"], diagnostics["stderr_truncated"] = _bounded_excerpt(
@@ -1308,6 +1353,76 @@ def _build_diagnostics(
         MAX_STDERR_EXCERPT,
     )
     return diagnostics
+
+
+def _post_result_status(event_type: object, data: dict) -> str | None:
+    if event_type == "session.mcp_server_status_changed":
+        status = data.get("status") or data.get("state")
+        return _sanitize_identifier(status) if isinstance(status, str) else None
+    if event_type == "session.mcp_servers_loaded":
+        servers = data.get("servers")
+        if not isinstance(servers, list):
+            return None
+        statuses = sorted({
+            str(server.get("status")).casefold()
+            for server in servers
+            if isinstance(server, dict) and isinstance(server.get("status"), str)
+        })
+        return _sanitize_identifier(",".join(statuses)) if statuses else None
+    return None
+
+
+def _is_benign_post_result_metadata(
+    event_type: object,
+    ephemeral: object,
+    status: object,
+) -> bool:
+    if ephemeral is not True or not isinstance(event_type, str):
+        return False
+    if event_type in BENIGN_EPHEMERAL_POST_RESULT_EVENTS:
+        return status is None
+    if event_type == "session.mcp_server_status_changed":
+        return status in BENIGN_POST_RESULT_MCP_STATUSES
+    if event_type == "session.mcp_servers_loaded" and isinstance(status, str):
+        statuses = status.split(",")
+        return bool(statuses) and all(
+            value in BENIGN_POST_RESULT_MCP_STATUSES
+            for value in statuses
+        )
+    return False
+
+
+def _is_benign_post_result_event(event: dict, data: dict) -> bool:
+    if event.get("ephemeral") is not True:
+        return False
+    event_type = event.get("type")
+    if event_type in BENIGN_EPHEMERAL_POST_RESULT_EVENTS:
+        return True
+    if event_type == "session.mcp_server_status_changed":
+        status = str(data.get("status") or data.get("state") or "").casefold()
+        return (
+            not (data.get("error") or data.get("message"))
+            and _is_benign_post_result_metadata(event_type, True, status)
+        )
+    if event_type == "session.mcp_servers_loaded":
+        servers = data.get("servers")
+        benign = (
+            isinstance(servers, list)
+            and bool(servers)
+            and all(
+                isinstance(server, dict)
+                and str(server.get("status") or "").casefold()
+                in BENIGN_POST_RESULT_MCP_STATUSES
+                and not server.get("error")
+                for server in servers
+            )
+        )
+        return benign and _is_benign_post_result_metadata(
+            event_type,
+            True,
+            _post_result_status(event_type, data),
+        )
+    return False
 
 
 def _set_projected_value(target: dict, path: tuple[str, ...], value: object) -> None:
@@ -1490,6 +1605,9 @@ def parse_event_stream(stdout: str | bytes) -> dict:
         "_successful_tools_raw": [],
         "diagnostic_events": [],
         "diagnostic_events_truncated": False,
+        "post_result_events": [],
+        "post_result_event_count": 0,
+        "post_result_events_truncated": False,
         "mcp_failure": None,
         "mcp_statuses": {},
         "session_failure": None,
@@ -1534,12 +1652,25 @@ def parse_event_stream(stdout: str | bytes) -> dict:
         if not isinstance(event, dict):
             parse_errors.append(f"line {line_number}: event must be a JSON object")
             continue
-        if result_seen:
-            parse_errors.append(f"line {line_number}: event occurred after terminal result")
-
         parsed_any = True
         etype = event.get("type")
         data = event.get("data", {})
+        if result_seen:
+            metrics["post_result_event_count"] += 1
+            if len(metrics["post_result_events"]) < MAX_POST_RESULT_EVENTS:
+                metrics["post_result_events"].append({
+                    "line": line_number,
+                    "event_type": _sanitize_identifier(etype),
+                    "ephemeral": event.get("ephemeral") is True,
+                    "status": _post_result_status(etype, data if isinstance(data, dict) else {}),
+                })
+            else:
+                if not metrics["post_result_events_truncated"]:
+                    parse_errors.append("post-result event evidence exceeds retained limit")
+                metrics["post_result_events_truncated"] = True
+            if not isinstance(data, dict) or not _is_benign_post_result_event(event, data):
+                parse_errors.append(f"line {line_number}: event occurred after terminal result")
+            continue
         if not isinstance(data, dict):
             parse_errors.append(f"line {line_number}: event data must be a JSON object")
             continue
@@ -1735,10 +1866,22 @@ def parse_event_stream(stdout: str | bytes) -> dict:
     return {"response": last_message_content, **metrics}
 
 
+def _azure_search_proven(parsed: dict, tool_prefix: str, azure_required: bool) -> bool:
+    allowed_tools = _configured_tools_for_prefix(tool_prefix)
+    return (
+        azure_required
+        and any(
+            name in allowed_tools and _is_search_tool(name)
+            for name in parsed["_successful_tools_raw"]
+        )
+    )
+
+
 def validate_row_evidence(parsed: dict, tool_prefix: str, azure_required: bool) -> tuple[bool, str | None, bool]:
     """Validate selected-source and optional Azure evidence for one row."""
+    azure_live_query_proven = _azure_search_proven(parsed, tool_prefix, azure_required)
     if parsed["session_failure"]:
-        return False, f"session_error: {parsed['session_failure']}", False
+        return False, f"session_error: {parsed['session_failure']}", azure_live_query_proven
     selected_mcp_status = next(
         (
             status
@@ -1749,31 +1892,28 @@ def validate_row_evidence(parsed: dict, tool_prefix: str, azure_required: bool) 
     )
     if selected_mcp_status and selected_mcp_status["status"] != "connected":
         detail = selected_mcp_status["error"] or f"status is {selected_mcp_status['status'] or 'unknown'}"
-        return False, f"mcp_initialization_failure: {tool_prefix}: {detail}", False
+        return False, f"mcp_initialization_failure: {tool_prefix}: {detail}", azure_live_query_proven
     if parsed["parse_error"]:
-        return False, f"event_parse_failure: {parsed['parse_error']}", False
+        return False, f"event_parse_failure: {parsed['parse_error']}", azure_live_query_proven
     if parsed["tool_errors"]:
-        return False, f"tool_error: {parsed['tool_errors']} tool execution(s) failed", False
+        return False, f"tool_error: {parsed['tool_errors']} tool execution(s) failed", azure_live_query_proven
 
     observed_tools = parsed["_observed_tools_raw"]
-    cross_source_tools = [name for name in observed_tools if _source_for_tool(name) != tool_prefix]
+    allowed_tools = _configured_tools_for_prefix(tool_prefix)
+    cross_source_tools = [name for name in observed_tools if name not in allowed_tools]
     if cross_source_tools:
         sanitized_tools = [_sanitize_identifier(name) for name in cross_source_tools]
-        return False, f"cross_source_tool_call: {', '.join(sanitized_tools)}", False
+        return False, f"cross_source_tool_call: {', '.join(sanitized_tools)}", azure_live_query_proven
     if not observed_tools:
-        return False, "source_selection_unproven: no documentation tool calls observed", False
-    if not any(_source_for_tool(name) == tool_prefix for name in parsed["_successful_tools_raw"]):
-        return False, "source_selection_unproven: no selected-source tool completed successfully", False
-    if not parsed["response"]:
-        return False, "missing_response: no assistant response event contained content", False
-
-    azure_live_query_proven = (
-        azure_required
-        and any(
-            _tool_matches_source(name, tool_prefix) and _is_search_tool(name)
-            for name in parsed["_successful_tools_raw"]
+        return False, "source_selection_unproven: no documentation tool calls observed", azure_live_query_proven
+    if not any(name in allowed_tools for name in parsed["_successful_tools_raw"]):
+        return (
+            False,
+            "source_selection_unproven: no selected-source tool completed successfully",
+            azure_live_query_proven,
         )
-    )
+    if not parsed["response"]:
+        return False, "missing_response: no assistant response event contained content", azure_live_query_proven
     if azure_required and not azure_live_query_proven:
         return False, "azure_live_query_unproven: selected search tool did not complete successfully", False
 
@@ -1849,7 +1989,13 @@ def run_single_eval(
             config_path.write_text(json.dumps(mcp_config), encoding="utf-8")
             config_path.chmod(0o600)
 
-            cmd = build_copilot_command(model, prompt, config_path, source_name)
+            cmd = build_copilot_command(
+                model,
+                prompt,
+                config_path,
+                source_name,
+                tuple(server_config["config"]["available_tools"]),
+            )
             process_env = os.environ.copy()
             process_env["COPILOT_HOME"] = isolated_home
 
@@ -1919,6 +2065,15 @@ def run_single_eval(
         partial_stdout = exc.stdout
         partial_stderr = exc.stderr
         parsed = parse_event_stream(partial_stdout) if partial_stdout else None
+        azure_live_query_proven = (
+            _azure_search_proven(
+                parsed,
+                server_config["config"]["tool_prefix"],
+                result["azure_required"],
+            )
+            if parsed
+            else False
+        )
         result.update({
             "response": "",
             "stderr": _bounded_excerpt(
@@ -1931,6 +2086,7 @@ def run_single_eval(
             "passed": False,
             "response_present": False,
             "failure_reason": f"timeout: exceeded {timeout}s",
+            "azure_live_query_proven": azure_live_query_proven,
             "observed_tools": parsed["observed_tools"] if parsed else [],
             "successful_tools": parsed["successful_tools"] if parsed else [],
             "turns": parsed["turns"] if parsed else 0,

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -151,6 +151,7 @@ BENIGN_EPHEMERAL_POST_RESULT_EVENTS = {
     "mcp.tools.list_changed",
 }
 BENIGN_POST_RESULT_MCP_STATUSES = {"connected", "disabled"}
+BUILTIN_MCP_SERVER_NAME = "github-mcp-server"
 MAX_IDENTIFIER_TEXT = 256
 MAX_USAGE_METRIC = 10**15
 MAX_ENCODED_TOKEN_BYTES = 8_192
@@ -1357,16 +1358,25 @@ def _build_diagnostics(
 
 def _post_result_status(event_type: object, data: dict) -> str | None:
     if event_type == "session.mcp_server_status_changed":
+        server = data.get("serverName") or data.get("server") or data.get("name")
         status = data.get("status") or data.get("state")
-        return _sanitize_identifier(status) if isinstance(status, str) else None
+        return (
+            _sanitize_identifier(f"{server}={status.casefold()}")
+            if isinstance(server, str) and isinstance(status, str)
+            else None
+        )
     if event_type == "session.mcp_servers_loaded":
         servers = data.get("servers")
         if not isinstance(servers, list):
             return None
         statuses = sorted({
-            str(server.get("status")).casefold()
+            f"{server.get('name')}={str(server.get('status')).casefold()}"
             for server in servers
-            if isinstance(server, dict) and isinstance(server.get("status"), str)
+            if (
+                isinstance(server, dict)
+                and isinstance(server.get("name"), str)
+                and isinstance(server.get("status"), str)
+            )
         })
         return _sanitize_identifier(",".join(statuses)) if statuses else None
     return None
@@ -1376,33 +1386,62 @@ def _is_benign_post_result_metadata(
     event_type: object,
     ephemeral: object,
     status: object,
+    expected_mcp_server: object,
 ) -> bool:
     if ephemeral is not True or not isinstance(event_type, str):
         return False
     if event_type in BENIGN_EPHEMERAL_POST_RESULT_EVENTS:
         return status is None
     if event_type == "session.mcp_server_status_changed":
-        return status in BENIGN_POST_RESULT_MCP_STATUSES
+        return (
+            isinstance(expected_mcp_server, str)
+            and status
+            in {
+                f"{_sanitize_identifier(expected_mcp_server)}=connected",
+                f"{BUILTIN_MCP_SERVER_NAME}=disabled",
+            }
+        )
     if event_type == "session.mcp_servers_loaded" and isinstance(status, str):
         statuses = status.split(",")
-        return bool(statuses) and all(
-            value in BENIGN_POST_RESULT_MCP_STATUSES
-            for value in statuses
+        selected_status = (
+            f"{_sanitize_identifier(expected_mcp_server)}=connected"
+            if isinstance(expected_mcp_server, str)
+            else None
+        )
+        return (
+            selected_status is not None
+            and selected_status in statuses
+            and all(
+                value
+                in {
+                    selected_status,
+                    f"{BUILTIN_MCP_SERVER_NAME}=disabled",
+                }
+                for value in statuses
+            )
         )
     return False
 
 
-def _is_benign_post_result_event(event: dict, data: dict) -> bool:
+def _is_benign_post_result_event(
+    event: dict,
+    data: dict,
+    expected_mcp_server: str | None,
+) -> bool:
     if event.get("ephemeral") is not True:
         return False
     event_type = event.get("type")
     if event_type in BENIGN_EPHEMERAL_POST_RESULT_EVENTS:
         return True
     if event_type == "session.mcp_server_status_changed":
-        status = str(data.get("status") or data.get("state") or "").casefold()
         return (
             not (data.get("error") or data.get("message"))
-            and _is_benign_post_result_metadata(event_type, True, status)
+            and _is_benign_post_result_metadata(
+                event_type,
+                True,
+                _post_result_status(event_type, data),
+                expected_mcp_server,
+            )
         )
     if event_type == "session.mcp_servers_loaded":
         servers = data.get("servers")
@@ -1421,6 +1460,7 @@ def _is_benign_post_result_event(event: dict, data: dict) -> bool:
             event_type,
             True,
             _post_result_status(event_type, data),
+            expected_mcp_server,
         )
     return False
 
@@ -1581,7 +1621,11 @@ def _parse_json_event(line: str) -> tuple[dict, bool]:
     return _project_large_json_event(line)
 
 
-def parse_event_stream(stdout: str | bytes) -> dict:
+def parse_event_stream(
+    stdout: str | bytes,
+    *,
+    expected_mcp_server: str | None = None,
+) -> dict:
     """Parse `copilot --output-format json` JSONL output into operational metrics.
 
     Extracts the final assistant response text plus turn count, tool-call count,
@@ -1668,7 +1712,11 @@ def parse_event_stream(stdout: str | bytes) -> dict:
                 if not metrics["post_result_events_truncated"]:
                     parse_errors.append("post-result event evidence exceeds retained limit")
                 metrics["post_result_events_truncated"] = True
-            if not isinstance(data, dict) or not _is_benign_post_result_event(event, data):
+            if not isinstance(data, dict) or not _is_benign_post_result_event(
+                event,
+                data,
+                expected_mcp_server,
+            ):
                 parse_errors.append(f"line {line_number}: event occurred after terminal result")
             continue
         if not isinstance(data, dict):
@@ -2009,7 +2057,7 @@ def run_single_eval(
             proc_stderr = proc.stderr
 
         elapsed = time.monotonic() - start_time
-        parsed = parse_event_stream(proc_stdout)
+        parsed = parse_event_stream(proc_stdout, expected_mcp_server=source_name)
         response = parsed["response"]
         evidence_valid, failure_reason, azure_live_query_proven = validate_row_evidence(
             parsed,
@@ -2064,7 +2112,11 @@ def run_single_eval(
         elapsed = time.monotonic() - start_time
         partial_stdout = exc.stdout
         partial_stderr = exc.stderr
-        parsed = parse_event_stream(partial_stdout) if partial_stdout else None
+        parsed = (
+            parse_event_stream(partial_stdout, expected_mcp_server=source_name)
+            if partial_stdout
+            else None
+        )
         azure_live_query_proven = (
             _azure_search_proven(
                 parsed,

--- a/scripts/run_docs_eval.py
+++ b/scripts/run_docs_eval.py
@@ -150,8 +150,9 @@ BENIGN_EPHEMERAL_POST_RESULT_EVENTS = {
     "session.skills_loaded",
     "mcp.tools.list_changed",
 }
-BENIGN_POST_RESULT_MCP_STATUSES = {"connected", "disabled"}
 BUILTIN_MCP_SERVER_NAME = "github-mcp-server"
+SAFE_SELECTED_MCP_STATUSES = {"connected", "ready"}
+POST_RESULT_ERROR_FIELDS = {"error", "failure", "failed"}
 MAX_IDENTIFIER_TEXT = 256
 MAX_USAGE_METRIC = 10**15
 MAX_ENCODED_TOKEN_BYTES = 8_192
@@ -1356,69 +1357,220 @@ def _build_diagnostics(
     return diagnostics
 
 
-def _post_result_status(event_type: object, data: dict) -> str | None:
-    if event_type == "session.mcp_server_status_changed":
-        server = data.get("serverName") or data.get("server") or data.get("name")
-        status = data.get("status") or data.get("state")
-        return (
-            _sanitize_identifier(f"{server}={status.casefold()}")
-            if isinstance(server, str) and isinstance(status, str)
+def _consistent_post_result_alias(
+    value: dict,
+    fields: tuple[str, ...],
+    *,
+    required: bool,
+    casefold: bool = False,
+) -> tuple[str | None, bool]:
+    aliases = [value[field] for field in fields if field in value]
+    if not aliases:
+        return None, not required
+    if not all(isinstance(alias, str) and alias for alias in aliases):
+        return None, False
+    normalized = [
+        alias.casefold() if casefold else alias
+        for alias in aliases
+    ]
+    if len(set(normalized)) != 1:
+        return None, False
+    return normalized[0], True
+
+
+def _post_result_server_state(
+    value: object,
+    *,
+    require_status: bool,
+) -> tuple[dict, bool]:
+    if not isinstance(value, dict):
+        return ({
+            "name": None,
+            "status": None,
+            "identity_aliases": [],
+            "status_aliases": [],
+            "error_fields": ["invalid-shape"],
+            "error_present": True,
+        }, False)
+    name_fields = ("serverName", "server", "name")
+    status_fields = ("status", "state")
+    raw_name, name_valid = _consistent_post_result_alias(
+        value,
+        name_fields,
+        required=True,
+    )
+    raw_status, status_valid = _consistent_post_result_alias(
+        value,
+        status_fields,
+        required=require_status,
+        casefold=True,
+    )
+    identity_aliases = [
+        _sanitize_identifier(value[field])
+        if isinstance(value[field], str)
+        else None
+        for field in name_fields
+        if field in value
+    ]
+    status_aliases = [
+        _sanitize_identifier(value[field].casefold())
+        if isinstance(value[field], str)
+        else None
+        for field in status_fields
+        if field in value
+    ]
+    error_fields = sorted(
+        field for field in POST_RESULT_ERROR_FIELDS if field in value
+    )
+    return ({
+        "name": _sanitize_identifier(raw_name) if raw_name is not None else None,
+        "status": (
+            _sanitize_identifier(raw_status)
+            if raw_status is not None
             else None
+        ),
+        "identity_aliases": identity_aliases,
+        "status_aliases": status_aliases,
+        "error_fields": error_fields,
+        "error_present": bool(error_fields),
+    }, name_valid and status_valid)
+
+
+def _post_result_server_metadata(
+    event_type: object,
+    data: dict,
+) -> tuple[list[dict], int, bool, bool]:
+    if event_type in {
+        "mcp.tools.list_changed",
+        "session.mcp_server_status_changed",
+    }:
+        server, valid = _post_result_server_state(
+            data,
+            require_status=event_type == "session.mcp_server_status_changed",
         )
+        return [server], 1, False, valid
     if event_type == "session.mcp_servers_loaded":
         servers = data.get("servers")
         if not isinstance(servers, list):
-            return None
-        statuses = sorted({
-            f"{server.get('name')}={str(server.get('status')).casefold()}"
-            for server in servers
-            if (
-                isinstance(server, dict)
-                and isinstance(server.get("name"), str)
-                and isinstance(server.get("status"), str)
-            )
-        })
-        return _sanitize_identifier(",".join(statuses)) if statuses else None
-    return None
+            return [], 0, False, False
+        retained = [
+            _post_result_server_state(server, require_status=True)
+            for server in servers[:MAX_DIAGNOSTIC_EVENTS]
+        ]
+        return (
+            [server for server, _valid in retained],
+            len(servers),
+            len(servers) > MAX_DIAGNOSTIC_EVENTS,
+            (
+                all(isinstance(server, dict) for server in servers)
+                and all(valid for _server, valid in retained)
+            ),
+        )
+    return [], 0, False, True
+
+
+def _post_result_server_state_matches(
+    server: object,
+    expected_name: str,
+    allowed_statuses: set[str] | None,
+) -> bool:
+    if not isinstance(server, dict) or set(server) != {
+        "name",
+        "status",
+        "identity_aliases",
+        "status_aliases",
+        "error_fields",
+        "error_present",
+    }:
+        return False
+    aliases = server["identity_aliases"]
+    status_aliases = server["status_aliases"]
+    if (
+        server["name"] != expected_name
+        or not isinstance(aliases, list)
+        or not (1 <= len(aliases) <= 3)
+        or any(alias != expected_name for alias in aliases)
+        or server["error_present"] is not False
+        or server["error_fields"] != []
+        or not isinstance(status_aliases, list)
+    ):
+        return False
+    if allowed_statuses is None:
+        return server["status"] is None and status_aliases == []
+    return (
+        server["status"] in allowed_statuses
+        and 1 <= len(status_aliases) <= 2
+        and all(alias == server["status"] for alias in status_aliases)
+    )
 
 
 def _is_benign_post_result_metadata(
     event_type: object,
     ephemeral: object,
-    status: object,
+    servers: object,
+    server_count: object,
+    servers_truncated: object,
+    server_metadata_valid: object,
     expected_mcp_server: object,
 ) -> bool:
-    if ephemeral is not True or not isinstance(event_type, str):
+    if (
+        ephemeral is not True
+        or not isinstance(event_type, str)
+        or not isinstance(servers, list)
+        or type(server_count) is not int
+        or servers_truncated is not False
+        or server_metadata_valid is not True
+        or server_count != len(servers)
+    ):
         return False
-    if event_type in BENIGN_EPHEMERAL_POST_RESULT_EVENTS:
-        return status is None
-    if event_type == "session.mcp_server_status_changed":
+    if event_type in {
+        "session.tools_updated",
+        "session.skills_loaded",
+    }:
+        return server_count == 0
+    if not isinstance(expected_mcp_server, str):
+        return False
+    selected_name = _sanitize_identifier(expected_mcp_server)
+    if event_type == "mcp.tools.list_changed":
         return (
-            isinstance(expected_mcp_server, str)
-            and status
-            in {
-                f"{_sanitize_identifier(expected_mcp_server)}=connected",
-                f"{BUILTIN_MCP_SERVER_NAME}=disabled",
-            }
-        )
-    if event_type == "session.mcp_servers_loaded" and isinstance(status, str):
-        statuses = status.split(",")
-        selected_status = (
-            f"{_sanitize_identifier(expected_mcp_server)}=connected"
-            if isinstance(expected_mcp_server, str)
-            else None
-        )
-        return (
-            selected_status is not None
-            and selected_status in statuses
-            and all(
-                value
-                in {
-                    selected_status,
-                    f"{BUILTIN_MCP_SERVER_NAME}=disabled",
-                }
-                for value in statuses
+            server_count == 1
+            and _post_result_server_state_matches(
+                servers[0],
+                selected_name,
+                None,
             )
+        )
+    if event_type == "session.mcp_server_status_changed":
+        return server_count == 1 and (
+            _post_result_server_state_matches(
+                servers[0],
+                selected_name,
+                SAFE_SELECTED_MCP_STATUSES,
+            )
+            or _post_result_server_state_matches(
+                servers[0],
+                BUILTIN_MCP_SERVER_NAME,
+                {"disabled"},
+            )
+        )
+    if event_type == "session.mcp_servers_loaded":
+        if server_count == 0:
+            return False
+        names = [server.get("name") for server in servers if isinstance(server, dict)]
+        if len(set(names)) != len(names) or selected_name not in names:
+            return False
+        return all(
+            _post_result_server_state_matches(
+                server,
+                selected_name,
+                SAFE_SELECTED_MCP_STATUSES,
+            )
+            or _post_result_server_state_matches(
+                server,
+                BUILTIN_MCP_SERVER_NAME,
+                {"disabled"},
+            )
+            for server in servers
         )
     return False
 
@@ -1431,38 +1583,16 @@ def _is_benign_post_result_event(
     if event.get("ephemeral") is not True:
         return False
     event_type = event.get("type")
-    if event_type in BENIGN_EPHEMERAL_POST_RESULT_EVENTS:
-        return True
-    if event_type == "session.mcp_server_status_changed":
-        return (
-            not (data.get("error") or data.get("message"))
-            and _is_benign_post_result_metadata(
-                event_type,
-                True,
-                _post_result_status(event_type, data),
-                expected_mcp_server,
-            )
-        )
-    if event_type == "session.mcp_servers_loaded":
-        servers = data.get("servers")
-        benign = (
-            isinstance(servers, list)
-            and bool(servers)
-            and all(
-                isinstance(server, dict)
-                and str(server.get("status") or "").casefold()
-                in BENIGN_POST_RESULT_MCP_STATUSES
-                and not server.get("error")
-                for server in servers
-            )
-        )
-        return benign and _is_benign_post_result_metadata(
-            event_type,
-            True,
-            _post_result_status(event_type, data),
-            expected_mcp_server,
-        )
-    return False
+    servers, count, truncated, valid = _post_result_server_metadata(event_type, data)
+    return _is_benign_post_result_metadata(
+        event_type,
+        True,
+        servers,
+        count,
+        truncated,
+        valid,
+        expected_mcp_server,
+    )
 
 
 def _set_projected_value(target: dict, path: tuple[str, ...], value: object) -> None:
@@ -1701,12 +1831,21 @@ def parse_event_stream(
         data = event.get("data", {})
         if result_seen:
             metrics["post_result_event_count"] += 1
+            server_states, server_count, servers_truncated, server_metadata_valid = (
+                _post_result_server_metadata(
+                    etype,
+                    data if isinstance(data, dict) else {},
+                )
+            )
             if len(metrics["post_result_events"]) < MAX_POST_RESULT_EVENTS:
                 metrics["post_result_events"].append({
                     "line": line_number,
                     "event_type": _sanitize_identifier(etype),
                     "ephemeral": event.get("ephemeral") is True,
-                    "status": _post_result_status(etype, data if isinstance(data, dict) else {}),
+                    "servers": server_states,
+                    "server_count": server_count,
+                    "servers_truncated": servers_truncated,
+                    "server_metadata_valid": server_metadata_valid,
                 })
             else:
                 if not metrics["post_result_events_truncated"]:

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -142,6 +142,42 @@ def _raw_row(
     }
 
 
+def _post_result_event_metadata(
+    event_type: str,
+    *,
+    line: int = 42,
+    ephemeral: bool = True,
+    servers: list[dict] | None = None,
+    server_count: int | None = None,
+    servers_truncated: bool = False,
+    server_metadata_valid: bool = True,
+) -> dict:
+    servers = [] if servers is None else [
+        {
+            **server,
+            "identity_aliases": server.get(
+                "identity_aliases",
+                [server["name"]] if server.get("name") else [],
+            ),
+            "status_aliases": server.get(
+                "status_aliases",
+                [server["status"]] if server.get("status") else [],
+            ),
+            "error_fields": server.get("error_fields", []),
+        }
+        for server in servers
+    ]
+    return {
+        "line": line,
+        "event_type": event_type,
+        "ephemeral": ephemeral,
+        "servers": servers,
+        "server_count": len(servers) if server_count is None else server_count,
+        "servers_truncated": servers_truncated,
+        "server_metadata_valid": server_metadata_valid,
+    }
+
+
 def score_result(result, trusted_scenarios=None):
     if trusted_scenarios is None:
         scenario_id = result.get("scenario_id") if isinstance(result, dict) else SCENARIO["id"]
@@ -355,6 +391,16 @@ def test_known_ephemeral_post_result_events_are_retained_and_ignored():
             "ephemeral": True,
         },
         {
+            "type": "session.mcp_server_status_changed",
+            "data": {"serverName": "foundry_docs", "status": "ready"},
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_server_status_changed",
+            "data": {"serverName": "github-mcp-server", "status": "disabled"},
+            "ephemeral": True,
+        },
+        {
             "type": "session.mcp_servers_loaded",
             "data": {
                 "servers": [
@@ -379,15 +425,23 @@ def test_known_ephemeral_post_result_events_are_retained_and_ignored():
 
     assert valid is True
     assert failure_reason is None
-    assert parsed["post_result_event_count"] == 5
+    assert parsed["post_result_event_count"] == 7
     assert parsed["post_result_events_truncated"] is False
     assert [event["event_type"] for event in parsed["post_result_events"]] == [
         event["type"] for event in post_result_events
     ]
-    assert parsed["post_result_events"][-2]["status"] == "foundry_docs=connected"
-    assert parsed["post_result_events"][-1]["status"] == (
-        "foundry_docs=connected,github-mcp-server=disabled"
-    )
+    connected = parsed["post_result_events"][-4]["servers"][0]
+    assert connected["name"] == "foundry_docs"
+    assert connected["status"] == "connected"
+    assert connected["identity_aliases"] == ["foundry_docs"]
+    assert connected["status_aliases"] == ["connected"]
+    assert connected["error_fields"] == []
+    assert connected["error_present"] is False
+    loaded = parsed["post_result_events"][-1]["servers"]
+    assert [(server["name"], server["status"]) for server in loaded] == [
+        ("foundry_docs", "connected"),
+        ("github-mcp-server", "disabled"),
+    ]
 
 
 @pytest.mark.parametrize(
@@ -414,6 +468,85 @@ def test_known_ephemeral_post_result_events_are_retained_and_ignored():
         {
             "type": "session.mcp_server_status_changed",
             "data": {"serverName": "other_server", "status": "connected"},
+            "ephemeral": True,
+        },
+        {
+            "type": "mcp.tools.list_changed",
+            "data": {"serverName": "other_server"},
+            "ephemeral": True,
+        },
+        {
+            "type": "mcp.tools.list_changed",
+            "data": {},
+            "ephemeral": True,
+        },
+        {
+            "type": "mcp.tools.list_changed",
+            "data": {"serverName": "foundry_docs", "error": "failed"},
+            "ephemeral": True,
+        },
+        {
+            "type": "mcp.tools.list_changed",
+            "data": {"serverName": "foundry_docs", "server": "other_server"},
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_server_status_changed",
+            "data": {
+                "serverName": "foundry_docs",
+                "status": "connected",
+                "state": "failed",
+            },
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_servers_loaded",
+            "data": {
+                "servers": [
+                    {"name": "foundry_docs", "status": "connected"},
+                    {"name": "other_server", "status": "disabled"},
+                ],
+            },
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_servers_loaded",
+            "data": {
+                "servers": [
+                    {"name": "foundry_docs", "status": "connected"},
+                    {"name": "foundry_docs", "status": "ready"},
+                ],
+            },
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_servers_loaded",
+            "data": {
+                "servers": [{
+                    "serverName": "foundry_docs",
+                    "name": "other_server",
+                    "status": "connected",
+                }],
+            },
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_servers_loaded",
+            "data": {
+                "servers": [
+                    {"name": "foundry_docs", "status": "connected", "failure": None},
+                ],
+            },
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_servers_loaded",
+            "data": {
+                "servers": [
+                    {"name": "foundry_docs", "status": "connected"},
+                    {"status": "disabled"},
+                ],
+            },
             "ephemeral": True,
         },
         {"type": "result", "exitCode": 0},
@@ -2270,12 +2403,9 @@ def test_nested_stdout_truncation_flag_is_schema_valid():
 def test_post_result_metadata_is_schema_valid_and_preserved_by_scorer():
     row = _raw_row()
     row["diagnostics"].update({
-        "post_result_events": [{
-            "line": 42,
-            "event_type": "session.tools_updated",
-            "ephemeral": True,
-            "status": None,
-        }],
+        "post_result_events": [
+            _post_result_event_metadata("session.tools_updated")
+        ],
         "post_result_event_count": 1,
         "post_result_events_truncated": False,
     })
@@ -2288,12 +2418,11 @@ def test_post_result_metadata_is_schema_valid_and_preserved_by_scorer():
 def test_post_result_metadata_rejects_invalid_count_and_unsanitized_type():
     row = _raw_row()
     row["diagnostics"].update({
-        "post_result_events": [{
-            "line": 42,
-            "event_type": r"session.tools_updated token=LEAKME C:\Users\Alice\private",
-            "ephemeral": True,
-            "status": None,
-        }],
+        "post_result_events": [
+            _post_result_event_metadata(
+                r"session.tools_updated token=LEAKME C:\Users\Alice\private"
+            )
+        ],
         "post_result_event_count": 0,
         "post_result_events_truncated": False,
     })
@@ -2309,17 +2438,10 @@ def test_post_result_metadata_rejects_invalid_count_and_unsanitized_type():
     [
         "not-an-object",
         {
+            **_post_result_event_metadata("session.tools_updated"),
             "line": -1,
-            "event_type": "session.tools_updated",
-            "ephemeral": True,
-            "status": None,
         },
-        {
-            "line": 42,
-            "event_type": "assistant.message",
-            "ephemeral": True,
-            "status": None,
-        },
+        _post_result_event_metadata("assistant.message"),
     ],
 )
 def test_scorer_rejects_malformed_or_semantic_post_result_metadata(event):
@@ -2340,12 +2462,16 @@ def test_scorer_rejects_malformed_or_semantic_post_result_metadata(event):
 def test_scorer_requires_selected_or_builtin_identity_for_lifecycle_postamble():
     row = _raw_row()
     row["diagnostics"].update({
-        "post_result_events": [{
-            "line": 42,
-            "event_type": "session.mcp_server_status_changed",
-            "ephemeral": True,
-            "status": "other_server=connected",
-        }],
+        "post_result_events": [
+            _post_result_event_metadata(
+                "session.mcp_server_status_changed",
+                servers=[{
+                    "name": "other_server",
+                    "status": "connected",
+                    "error_present": False,
+                }],
+            )
+        ],
         "post_result_event_count": 1,
         "post_result_events_truncated": False,
     })
@@ -2353,6 +2479,92 @@ def test_scorer_requires_selected_or_builtin_identity_for_lifecycle_postamble():
     errors = validate_row_schema(row)
 
     assert "diagnostics.post_result_events[0] is not a benign post-result event" in errors
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        _post_result_event_metadata(
+            "mcp.tools.list_changed",
+            servers=[{
+                "name": "other_server",
+                "status": None,
+                "error_present": False,
+            }],
+        ),
+        _post_result_event_metadata(
+            "mcp.tools.list_changed",
+            servers=[{
+                "name": None,
+                "status": None,
+                "error_present": False,
+            }],
+            server_metadata_valid=False,
+        ),
+        _post_result_event_metadata(
+            "session.mcp_servers_loaded",
+            servers=[
+                {
+                    "name": "foundry_docs",
+                    "status": "connected",
+                    "error_present": False,
+                },
+                {
+                    "name": None,
+                    "status": "disabled",
+                    "error_present": False,
+                },
+            ],
+            server_metadata_valid=False,
+        ),
+        _post_result_event_metadata(
+            "mcp.tools.list_changed",
+            servers=[{
+                "name": "foundry_docs",
+                "status": None,
+                "identity_aliases": ["foundry_docs", "other_server"],
+                "status_aliases": [],
+                "error_fields": [],
+                "error_present": False,
+            }],
+        ),
+        _post_result_event_metadata(
+            "session.mcp_server_status_changed",
+            servers=[{
+                "name": "foundry_docs",
+                "status": "connected",
+                "identity_aliases": ["foundry_docs"],
+                "status_aliases": ["connected", "failed"],
+                "error_fields": [],
+                "error_present": False,
+            }],
+        ),
+        _post_result_event_metadata(
+            "session.mcp_server_status_changed",
+            servers=[{
+                "name": "foundry_docs",
+                "status": "connected",
+                "identity_aliases": ["foundry_docs"] * 20,
+                "status_aliases": ["connected"] * 20,
+                "error_fields": [],
+                "error_present": False,
+            }],
+        ),
+    ],
+)
+def test_scorer_rejects_foreign_or_unnamed_lifecycle_metadata(metadata):
+    row = _raw_row()
+    row["diagnostics"].update({
+        "post_result_events": [metadata],
+        "post_result_event_count": 1,
+        "post_result_events_truncated": False,
+    })
+
+    errors = validate_row_schema(row)
+    scored = score_result(row)
+
+    assert "diagnostics.post_result_events[0] is not a benign post-result event" in errors
+    assert scored["row_valid"] is False
 
 
 @pytest.mark.parametrize(
@@ -2365,12 +2577,9 @@ def test_scorer_requires_selected_or_builtin_identity_for_lifecycle_postamble():
 def test_scorer_rejects_inconsistent_post_result_count_and_truncation(count, truncated):
     row = _raw_row()
     row["diagnostics"].update({
-        "post_result_events": [{
-            "line": 42,
-            "event_type": "session.tools_updated",
-            "ephemeral": True,
-            "status": None,
-        }],
+        "post_result_events": [
+            _post_result_event_metadata("session.tools_updated")
+        ],
         "post_result_event_count": count,
         "post_result_events_truncated": truncated,
     })
@@ -2382,12 +2591,10 @@ def test_scorer_rejects_truncated_post_result_tail_even_with_benign_prefix():
     row = _raw_row()
     row["diagnostics"].update({
         "post_result_events": [
-            {
-                "line": index + 1,
-                "event_type": "session.tools_updated",
-                "ephemeral": True,
-                "status": None,
-            }
+            _post_result_event_metadata(
+                "session.tools_updated",
+                line=index + 1,
+            )
             for index in range(run_docs_eval.MAX_POST_RESULT_EVENTS)
         ],
         "post_result_event_count": run_docs_eval.MAX_POST_RESULT_EVENTS + 1,

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -2518,6 +2518,30 @@ def test_scorer_requires_selected_or_builtin_identity_for_lifecycle_postamble():
             server_metadata_valid=False,
         ),
         _post_result_event_metadata(
+            "session.mcp_servers_loaded",
+            servers=[
+                {
+                    "name": "foundry_docs",
+                    "status": "connected",
+                    "error_present": False,
+                },
+                {
+                    "name": "other_server",
+                    "status": "disabled",
+                    "error_present": False,
+                },
+            ],
+        ),
+        _post_result_event_metadata(
+            "session.mcp_servers_loaded",
+            servers=[{
+                "name": "foundry_docs",
+                "status": "connected",
+                "error_fields": ["error"],
+                "error_present": True,
+            }],
+        ),
+        _post_result_event_metadata(
             "mcp.tools.list_changed",
             servers=[{
                 "name": "foundry_docs",

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -326,7 +326,7 @@ def test_unknown_tool_allowlist_warning_is_retained_and_fails_closed():
         json.dumps({"type": "result", "exitCode": 0}),
     ])
 
-    parsed = parse_event_stream(stdout)
+    parsed = parse_event_stream(stdout, expected_mcp_server="foundry_docs")
     valid, failure_reason, _azure_proven = run_docs_eval.validate_row_evidence(
         parsed,
         "foundry_docs_vnext",
@@ -370,7 +370,7 @@ def test_known_ephemeral_post_result_events_are_retained_and_ignored():
         *(json.dumps(event) for event in post_result_events),
     ])
 
-    parsed = parse_event_stream(stdout)
+    parsed = parse_event_stream(stdout, expected_mcp_server="foundry_docs")
     valid, failure_reason, _azure_proven = run_docs_eval.validate_row_evidence(
         parsed,
         "foundry_docs",
@@ -384,8 +384,10 @@ def test_known_ephemeral_post_result_events_are_retained_and_ignored():
     assert [event["event_type"] for event in parsed["post_result_events"]] == [
         event["type"] for event in post_result_events
     ]
-    assert parsed["post_result_events"][-2]["status"] == "connected"
-    assert parsed["post_result_events"][-1]["status"] == "connected,disabled"
+    assert parsed["post_result_events"][-2]["status"] == "foundry_docs=connected"
+    assert parsed["post_result_events"][-1]["status"] == (
+        "foundry_docs=connected,github-mcp-server=disabled"
+    )
 
 
 @pytest.mark.parametrize(
@@ -407,6 +409,11 @@ def test_known_ephemeral_post_result_events_are_retained_and_ignored():
         {
             "type": "session.mcp_server_status_changed",
             "data": {"serverName": "foundry_docs", "status": "failed"},
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_server_status_changed",
+            "data": {"serverName": "other_server", "status": "connected"},
             "ephemeral": True,
         },
         {"type": "result", "exitCode": 0},
@@ -2328,6 +2335,24 @@ def test_scorer_rejects_malformed_or_semantic_post_result_metadata(event):
 
     assert errors
     assert scored["row_valid"] is False
+
+
+def test_scorer_requires_selected_or_builtin_identity_for_lifecycle_postamble():
+    row = _raw_row()
+    row["diagnostics"].update({
+        "post_result_events": [{
+            "line": 42,
+            "event_type": "session.mcp_server_status_changed",
+            "ephemeral": True,
+            "status": "other_server=connected",
+        }],
+        "post_result_event_count": 1,
+        "post_result_events_truncated": False,
+    })
+
+    errors = validate_row_schema(row)
+
+    assert "diagnostics.post_result_events[0] is not a benign post-result event" in errors
 
 
 @pytest.mark.parametrize(

--- a/tests/test_docs_eval_evidence.py
+++ b/tests/test_docs_eval_evidence.py
@@ -124,6 +124,9 @@ def _raw_row(
         "diagnostics": {
             "events": [],
             "events_truncated": False,
+            "post_result_events": [],
+            "post_result_event_count": 0,
+            "post_result_events_truncated": False,
             "stdout_excerpt": "",
             "stdout_truncated": False,
             "stderr_excerpt": "",
@@ -240,7 +243,14 @@ def test_run_single_eval_passes_only_selected_config_across_process_boundary(mon
 
     assert list(captured["config"]["mcpServers"]) == ["foundry_docs"]
     assert "--disable-builtin-mcps" in captured["cmd"]
-    assert not any(arg.startswith("--available-tools") for arg in captured["cmd"])
+    assert {
+        arg
+        for arg in captured["cmd"]
+        if arg.startswith("--available-tools=")
+    } == {
+        f"--available-tools={tool}"
+        for tool in MCP_SERVERS["foundry-docs"]["config"]["available_tools"]
+    }
     assert "--allow-tool=foundry_docs" in captured["cmd"]
     assert captured["cwd"] == captured["copilot_home"]
     assert result["selected_source"] == "foundry-docs"
@@ -271,7 +281,14 @@ def test_copilot_command_isolates_all_selected_mcp_servers_without_broken_availa
     config, descriptor = build_mcp_config(MCP_SERVERS[server_name])
     config_path.write_text(json.dumps(config), encoding="utf-8")
 
-    cmd = build_copilot_command("model-1", "prompt", config_path, source_name)
+    available_tools = tuple(MCP_SERVERS[server_name]["config"]["available_tools"])
+    cmd = build_copilot_command(
+        "model-1",
+        "prompt",
+        config_path,
+        source_name,
+        available_tools,
+    )
 
     assert list(config["mcpServers"]) == [source_name]
     assert config["mcpServers"][source_name]["deferTools"] == "never"
@@ -279,7 +296,18 @@ def test_copilot_command_isolates_all_selected_mcp_servers_without_broken_availa
     assert "--disable-builtin-mcps" in cmd
     assert cmd[cmd.index("--additional-mcp-config") + 1] == f"@{config_path}"
     assert f"--allow-tool={source_name}" in cmd
-    assert not any(arg.startswith("--available-tools") for arg in cmd)
+    assert {
+        arg
+        for arg in cmd
+        if arg.startswith("--available-tools=")
+    } == {f"--available-tools={tool}" for tool in available_tools}
+    assert not {
+        "bash",
+        "grep",
+        "rg",
+        "view",
+        "web_fetch",
+    } & set(available_tools)
     for other_server in MCP_SERVERS.values():
         other_name = other_server["config"]["name"]
         if other_name != source_name:
@@ -314,6 +342,120 @@ def test_unknown_tool_allowlist_warning_is_retained_and_fails_closed():
             "message": 'Unknown tool name in the tool allowlist: "foundry_docs_vnext"',
         },
     }]
+
+
+def test_known_ephemeral_post_result_events_are_retained_and_ignored():
+    post_result_events = [
+        {"type": "session.tools_updated", "data": {}, "ephemeral": True},
+        {"type": "session.skills_loaded", "data": {"skills": []}, "ephemeral": True},
+        {"type": "mcp.tools.list_changed", "data": {"serverName": "foundry_docs"}, "ephemeral": True},
+        {
+            "type": "session.mcp_server_status_changed",
+            "data": {"serverName": "foundry_docs", "status": "connected"},
+            "ephemeral": True,
+        },
+        {
+            "type": "session.mcp_servers_loaded",
+            "data": {
+                "servers": [
+                    {"name": "foundry_docs", "status": "connected"},
+                    {"name": "github-mcp-server", "status": "disabled"},
+                ],
+            },
+            "ephemeral": True,
+        },
+    ]
+    stdout = "\n".join([
+        _event_stream(),
+        *(json.dumps(event) for event in post_result_events),
+    ])
+
+    parsed = parse_event_stream(stdout)
+    valid, failure_reason, _azure_proven = run_docs_eval.validate_row_evidence(
+        parsed,
+        "foundry_docs",
+        False,
+    )
+
+    assert valid is True
+    assert failure_reason is None
+    assert parsed["post_result_event_count"] == 5
+    assert parsed["post_result_events_truncated"] is False
+    assert [event["event_type"] for event in parsed["post_result_events"]] == [
+        event["type"] for event in post_result_events
+    ]
+    assert parsed["post_result_events"][-2]["status"] == "connected"
+    assert parsed["post_result_events"][-1]["status"] == "connected,disabled"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "assistant.message", "data": {"content": "late"}, "ephemeral": True},
+        {
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "late", "toolName": "foundry_docs-search_docs"},
+            "ephemeral": True,
+        },
+        {
+            "type": "session.error",
+            "data": {"errorType": "late", "message": "failure"},
+            "ephemeral": True,
+        },
+        {"type": "unknown.postamble", "data": {}, "ephemeral": True},
+        {"type": "session.tools_updated", "data": {}, "ephemeral": False},
+        {
+            "type": "session.mcp_server_status_changed",
+            "data": {"serverName": "foundry_docs", "status": "failed"},
+            "ephemeral": True,
+        },
+        {"type": "result", "exitCode": 0},
+    ],
+)
+def test_semantic_unknown_or_non_ephemeral_post_result_events_fail_closed(event):
+    parsed = parse_event_stream("\n".join([_event_stream(), json.dumps(event)]))
+
+    assert "event occurred after terminal result" in parsed["parse_error"]
+    assert parsed["post_result_event_count"] == 1
+    assert parsed["post_result_events"][0]["event_type"] == event["type"]
+
+
+def test_post_result_event_metadata_is_bounded_and_counts_truncation():
+    benign = json.dumps({
+        "type": "session.tools_updated",
+        "data": {},
+        "ephemeral": True,
+    })
+    parsed = parse_event_stream("\n".join([
+        _event_stream(),
+        *([benign] * 25),
+    ]))
+
+    assert "post-result event evidence exceeds retained limit" in parsed["parse_error"]
+    assert parsed["post_result_event_count"] == 25
+    assert len(parsed["post_result_events"]) == run_docs_eval.MAX_POST_RESULT_EVENTS
+    assert parsed["post_result_events_truncated"] is True
+
+
+def test_azure_proof_survives_an_independent_row_failure():
+    parsed = parse_event_stream("\n".join([
+        _event_stream(),
+        json.dumps({
+            "type": "assistant.message",
+            "data": {"content": "late"},
+            "ephemeral": True,
+        }),
+    ]))
+
+    valid, failure_reason, azure_proven = run_docs_eval.validate_row_evidence(
+        parsed,
+        "foundry_docs",
+        True,
+    )
+
+    assert valid is False
+    assert failure_reason.startswith("event_parse_failure:")
+    assert azure_proven is True
 
 
 def test_live_selected_mcp_fixture_loads_and_calls_search_without_allowlist_warning():
@@ -1063,6 +1205,43 @@ def test_timeout_projects_partial_stream_output(monkeypatch):
     assert result["status"] == "timeout"
     assert result["diagnostics"]["events"][0]["event_type"] == "session.mcp_server_status_changed"
     assert result["diagnostics"]["stderr_excerpt"] == "streamed timeout diagnostic"
+
+
+def test_timeout_retains_completed_azure_search_proof(monkeypatch):
+    monkeypatch.setenv("AZURE_SEARCH_ENDPOINT", "https://search.example")
+    monkeypatch.setenv("AZURE_AI_PROJECT_ENDPOINT", "https://project.example")
+    partial_events = "\n".join([
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {"toolCallId": "call-1", "toolName": "foundry_docs-search_docs"},
+        }),
+        json.dumps({
+            "type": "tool.execution_complete",
+            "data": {"toolCallId": "call-1", "success": True},
+        }),
+    ])
+
+    def time_out(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=cmd,
+            timeout=kwargs["timeout"],
+            output=partial_events.encode(),
+        )
+
+    monkeypatch.setattr(run_docs_eval, "_run_process_bounded", time_out)
+
+    result = run_single_eval(
+        SCENARIO,
+        "foundry-docs",
+        MCP_SERVERS["foundry-docs"],
+        "model-1",
+        timeout=3,
+        require_azure=True,
+    )
+
+    assert result["status"] == "timeout"
+    assert result["source_validated"] is False
+    assert result["azure_live_query_proven"] is True
 
 
 def test_bounded_process_timeout_does_not_wait_for_inheriting_descendant(tmp_path):
@@ -2081,6 +2260,159 @@ def test_nested_stdout_truncation_flag_is_schema_valid():
     assert validate_row_schema(row) == []
 
 
+def test_post_result_metadata_is_schema_valid_and_preserved_by_scorer():
+    row = _raw_row()
+    row["diagnostics"].update({
+        "post_result_events": [{
+            "line": 42,
+            "event_type": "session.tools_updated",
+            "ephemeral": True,
+            "status": None,
+        }],
+        "post_result_event_count": 1,
+        "post_result_events_truncated": False,
+    })
+
+    assert validate_row_schema(row) == []
+    scored = score_result(row)
+    assert scored["diagnostics"]["post_result_events"] == row["diagnostics"]["post_result_events"]
+
+
+def test_post_result_metadata_rejects_invalid_count_and_unsanitized_type():
+    row = _raw_row()
+    row["diagnostics"].update({
+        "post_result_events": [{
+            "line": 42,
+            "event_type": r"session.tools_updated token=LEAKME C:\Users\Alice\private",
+            "ephemeral": True,
+            "status": None,
+        }],
+        "post_result_event_count": 0,
+        "post_result_events_truncated": False,
+    })
+
+    errors = validate_row_schema(row)
+
+    assert "diagnostics.post_result_events must equal its sanitized canonical form" in errors
+    assert "diagnostics.post_result_event_count must cover retained post-result events" in errors
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        "not-an-object",
+        {
+            "line": -1,
+            "event_type": "session.tools_updated",
+            "ephemeral": True,
+            "status": None,
+        },
+        {
+            "line": 42,
+            "event_type": "assistant.message",
+            "ephemeral": True,
+            "status": None,
+        },
+    ],
+)
+def test_scorer_rejects_malformed_or_semantic_post_result_metadata(event):
+    row = _raw_row()
+    row["diagnostics"].update({
+        "post_result_events": [event],
+        "post_result_event_count": 1,
+        "post_result_events_truncated": False,
+    })
+
+    errors = validate_row_schema(row)
+    scored = score_result(row)
+
+    assert errors
+    assert scored["row_valid"] is False
+
+
+@pytest.mark.parametrize(
+    ("count", "truncated"),
+    [
+        (2, False),
+        (1, True),
+    ],
+)
+def test_scorer_rejects_inconsistent_post_result_count_and_truncation(count, truncated):
+    row = _raw_row()
+    row["diagnostics"].update({
+        "post_result_events": [{
+            "line": 42,
+            "event_type": "session.tools_updated",
+            "ephemeral": True,
+            "status": None,
+        }],
+        "post_result_event_count": count,
+        "post_result_events_truncated": truncated,
+    })
+
+    assert validate_row_schema(row)
+
+
+def test_scorer_rejects_truncated_post_result_tail_even_with_benign_prefix():
+    row = _raw_row()
+    row["diagnostics"].update({
+        "post_result_events": [
+            {
+                "line": index + 1,
+                "event_type": "session.tools_updated",
+                "ephemeral": True,
+                "status": None,
+            }
+            for index in range(run_docs_eval.MAX_POST_RESULT_EVENTS)
+        ],
+        "post_result_event_count": run_docs_eval.MAX_POST_RESULT_EVENTS + 1,
+        "post_result_events_truncated": True,
+    })
+
+    errors = validate_row_schema(row)
+    scored = score_result(row)
+
+    assert "diagnostics.post_result_events must not be truncated" in errors
+    assert scored["row_valid"] is False
+
+
+def test_undeclared_same_prefix_tool_cannot_validate_source_or_azure_proof():
+    parsed = parse_event_stream("\n".join([
+        json.dumps({
+            "type": "tool.execution_start",
+            "data": {
+                "toolCallId": "call-1",
+                "toolName": "foundry_docs-undeclared_search_docs",
+            },
+        }),
+        json.dumps({
+            "type": "tool.execution_complete",
+            "data": {"toolCallId": "call-1", "success": True},
+        }),
+        json.dumps({"type": "assistant.message", "data": {"content": "answer"}}),
+        json.dumps({"type": "result", "exitCode": 0}),
+    ]))
+
+    valid, failure_reason, azure_proven = run_docs_eval.validate_row_evidence(
+        parsed,
+        "foundry_docs",
+        True,
+    )
+
+    assert valid is False
+    assert failure_reason == "cross_source_tool_call: foundry_docs-undeclared_search_docs"
+    assert azure_proven is False
+
+    row = _raw_row()
+    row["observed_tools"] = ["foundry_docs-undeclared_search_docs"]
+    row["successful_tools"] = ["foundry_docs-undeclared_search_docs"]
+    row["azure_required"] = True
+    row["azure_live_query_proven"] = True
+    row["selected_source_config"]["azure_required"] = True
+    scored = score_result(row)
+    assert scored["row_valid"] is False
+
+
 def test_large_event_is_stopped_before_json_parse_and_remains_bounded():
     huge_event = b'{"type":"session.error","data":{"message":"' + (b"x" * 5_000_000) + b'"}}'
 
@@ -2775,7 +3107,7 @@ def test_diagnostic_path_keys_are_sanitized(monkeypatch):
     assert "<PATH>" in serialized
 
 
-def test_tool_name_is_validated_raw_but_persisted_sanitized(monkeypatch):
+def test_forged_same_prefix_tool_name_is_rejected_and_persisted_sanitized(monkeypatch):
     tool_name = r"foundry_docs-search_docs token=LEAKME C:\Users\Alice\private"
     stdout = _event_stream(tool_name=tool_name, response="trusted answer")
     monkeypatch.setattr(
@@ -2792,8 +3124,9 @@ def test_tool_name_is_validated_raw_but_persisted_sanitized(monkeypatch):
     )
     scored_row = score_result(raw_row)
 
-    assert raw_row["source_validated"] is True
-    assert scored_row["row_valid"] is True
+    assert raw_row["source_validated"] is False
+    assert raw_row["failure_reason"].startswith("cross_source_tool_call:")
+    assert scored_row["row_valid"] is False
     assert raw_row["observed_tools"] == ["foundry_docs-search_docs token=[REDACTED] <PATH>"]
     for row in (raw_row, scored_row):
         persisted = json.dumps(row)


### PR DESCRIPTION
## Summary

- expose only each selected MCP server's exact fully qualified documentation tools; retain `deferTools: "never"`, one config, built-in MCP disablement, and server permission
- enforce exact configured tool membership in runner, scorer, and Azure proof
- retain bounded post-result metadata: line/type/ephemeral plus structured server states containing canonical name/status, every supplied identity/status alias, exact error-field names/presence, total counts, truncation, and shape validity
- `mcp.tools.list_changed` requires exactly the selected server identity, no status, no error/failure fields, and ephemeral=true
- status changes allow only selected connected/ready or builtin `github-mcp-server` disabled, with consistent aliases and no error fields
- loaded summaries require every entry named and typed, selected server present, no foreign/duplicate/error entries, and each entry exactly selected connected/ready or builtin disabled
- reject conflicting identity/status aliases and alias arrays beyond runner-representable cardinality; scorer independently enforces all lifecycle rules
- fail closed on semantic, unknown, non-ephemeral, failing lifecycle, duplicate-result, or truncated post-result evidence
- compute Azure selected-search proof before other validity short circuits and retain it on invalid/timeout rows without changing row validity

Artifact `8755138625` cannot reveal prior exact post-result types because all affected excerpts truncate before the result; this PR closes that gap conservatively.

## Validation

- `python -m pytest tests\test_docs_eval_evidence.py -q` — 322 passed, 2 POSIX-specific tests skipped on Windows
- `python -m ruff check scripts\run_docs_eval.py scripts\eval_scorer.py tests\test_docs_eval_evidence.py` — passed
- runner/scorer tests cover allowed selected/builtin cases and foreign, unnamed, duplicate, error-bearing, shape-invalid, alias-conflicting, and oversized-alias cases
- exact selected-tool isolation and Azure invalid/timeout proof tests retained

Do not merge or rerun the full matrix until reviewed.